### PR TITLE
feat(checks): add self-transfer, no-std, float-arithmetic, weak-rando…

### DIFF
--- a/crates/checks/src/float_arithmetic.rs
+++ b/crates/checks/src/float_arithmetic.rs
@@ -1,0 +1,152 @@
+//! Floating-point arithmetic (`f32`/`f64`) in contract methods.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprCast, File, Lit, Type, TypePath};
+
+const CHECK_NAME: &str = "float-arithmetic";
+
+pub struct FloatArithmeticCheck;
+
+impl Check for FloatArithmeticCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = FloatVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn is_arithmetic(op: &BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Add(_) | BinOp::Sub(_) | BinOp::Mul(_) | BinOp::Div(_)
+            | BinOp::AddAssign(_) | BinOp::SubAssign(_) | BinOp::MulAssign(_) | BinOp::DivAssign(_)
+    )
+}
+
+fn is_float_lit(expr: &Expr) -> bool {
+    matches!(expr, Expr::Lit(el) if matches!(el.lit, Lit::Float(_)))
+}
+
+fn is_float_cast(expr: &Expr) -> bool {
+    if let Expr::Cast(ExprCast { ty, .. }) = expr {
+        if let Type::Path(TypePath { path, .. }) = ty.as_ref() {
+            return path
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "f32" || s.ident == "f64");
+        }
+    }
+    false
+}
+
+fn operand_is_float(expr: &Expr) -> bool {
+    is_float_lit(expr) || is_float_cast(expr)
+}
+
+struct FloatVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for FloatVisitor<'_> {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if is_arithmetic(&i.op) && (operand_is_float(&i.left) || operand_is_float(&i.right)) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Floating-point arithmetic detected in `{}`. \
+                     f32/f64 results can differ across host environments; \
+                     use integer math for all financial calculations.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_float_literal_arithmetic() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn fee(env: Env, amount: i128) -> f64 {
+        let _ = env;
+        amount as f64 * 0.01_f64
+    }
+}
+"#,
+        )?;
+        let hits = FloatArithmeticCheck.run(&file, "");
+        assert!(!hits.is_empty());
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_float_cast_arithmetic() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn ratio(env: Env, a: i128, b: i128) -> f32 {
+        let _ = env;
+        (a as f32) / (b as f32)
+    }
+}
+"#,
+        )?;
+        let hits = FloatArithmeticCheck.run(&file, "");
+        assert!(!hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_integer_only_arithmetic() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn fee(env: Env, amount: i128) -> i128 {
+        let _ = env;
+        amount * 100 / 10000
+    }
+}
+"#,
+        )?;
+        let hits = FloatArithmeticCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -3,20 +3,28 @@
 pub mod admin;
 pub mod auth;
 pub mod contracttype;
+pub mod float_arithmetic;
+pub mod no_std;
 pub mod overflow;
 pub mod panic_usage;
+pub mod self_transfer;
 pub mod storage;
 pub mod unbounded_storage;
+pub mod weak_randomness;
 pub mod zero_amount;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
 pub use auth::MissingRequireAuthCheck;
 pub use contracttype::MissingContracttypeCheck;
+pub use float_arithmetic::FloatArithmeticCheck;
+pub use no_std::NoStdCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use panic_usage::PanicUsageCheck;
+pub use self_transfer::SelfTransferCheck;
 pub use storage::UnsafeStoragePatternsCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
+pub use weak_randomness::WeakRandomnessCheck;
 pub use zero_amount::ZeroAmountCheck;
 
 use serde::Serialize;
@@ -63,5 +71,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
         Box::new(ZeroAmountCheck),
+        Box::new(SelfTransferCheck),
+        Box::new(NoStdCheck),
+        Box::new(FloatArithmeticCheck),
+        Box::new(WeakRandomnessCheck),
     ]
 }

--- a/crates/checks/src/no_std.rs
+++ b/crates/checks/src/no_std.rs
@@ -1,0 +1,118 @@
+//! Detects `std::` / `::std::` path usage in Soroban contracts.
+
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{File, UseTree};
+
+const CHECK_NAME: &str = "no-std-violation";
+
+pub struct NoStdCheck;
+
+impl Check for NoStdCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut v = StdVisitor { out: Vec::new() };
+        v.visit_file(file);
+        v.out
+    }
+}
+
+struct StdVisitor {
+    out: Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for StdVisitor {
+    fn visit_use_tree(&mut self, i: &'ast UseTree) {
+        if let UseTree::Path(p) = i {
+            if p.ident == "std" {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: p.ident.span().start().line,
+                    function_name: String::new(),
+                    description: format!(
+                        "`use std::` detected. Soroban contracts must be compiled with \
+                         `#![no_std]`; `std` paths are unavailable in WASM targets."
+                    ),
+                });
+            }
+        }
+        visit::visit_use_tree(self, i);
+    }
+
+    fn visit_expr_path(&mut self, i: &'ast syn::ExprPath) {
+        let segs = &i.path.segments;
+        if segs.first().is_some_and(|s| s.ident == "std") && segs.len() > 1 {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: String::new(),
+                description: format!(
+                    "`std::` path expression detected. Soroban contracts must be compiled \
+                     with `#![no_std]`; `std` paths are unavailable in WASM targets."
+                ),
+            });
+        }
+        visit::visit_expr_path(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_use_std() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use std::collections::HashMap;
+pub struct C;
+"#,
+        )?;
+        let hits = NoStdCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_std_path_expr() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub fn f() {
+    let _m = std::collections::HashMap::<u32, u32>::new();
+}
+"#,
+        )?;
+        let hits = NoStdCheck.run(&file, "");
+        assert!(!hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_no_std_contract() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn hello(_env: Env) {}
+}
+"#,
+        )?;
+        let hits = NoStdCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/self_transfer.rs
+++ b/crates/checks/src/self_transfer.rs
@@ -1,0 +1,195 @@
+//! Transfer functions that do not assert `from != to`.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, ExprBinary, File, FnArg, Pat, PatType, Type, TypePath};
+
+const CHECK_NAME: &str = "self-transfer";
+
+pub struct SelfTransferCheck;
+
+impl Check for SelfTransferCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let name = method.sig.ident.to_string();
+            if name != "transfer" {
+                continue;
+            }
+            let address_params = address_param_names(&method.sig.inputs);
+            if address_params.len() < 2 {
+                continue;
+            }
+            let mut v = NeScan {
+                names: &address_params,
+                found: false,
+            };
+            v.visit_block(&method.block);
+            if !v.found {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line,
+                    function_name: name.clone(),
+                    description: format!(
+                        "`transfer` accepts `from` and `to` Address parameters but never \
+                         asserts `from != to`. Self-transfers produce confusing accounting \
+                         and event logs."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+/// Returns the names of parameters whose type is `Address` (or ends in `Address`).
+fn address_param_names(inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>) -> Vec<String> {
+    inputs
+        .iter()
+        .filter_map(|arg| {
+            let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+                return None;
+            };
+            if !is_address_type(ty) {
+                return None;
+            }
+            if let Pat::Ident(pi) = pat.as_ref() {
+                Some(pi.ident.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn is_address_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        path.segments
+            .last()
+            .is_some_and(|s| s.ident == "Address")
+    } else {
+        false
+    }
+}
+
+struct NeScan<'a> {
+    names: &'a [String],
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for NeScan<'_> {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if matches!(i.op, BinOp::Ne(_)) {
+            let left = expr_ident_name(&i.left);
+            let right = expr_ident_name(&i.right);
+            if let (Some(l), Some(r)) = (left, right) {
+                if self.names.contains(&l) && self.names.contains(&r) {
+                    self.found = true;
+                }
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+fn expr_ident_name(expr: &syn::Expr) -> Option<String> {
+    if let syn::Expr::Path(p) = expr {
+        p.path.get_ident().map(|i| i.to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_transfer_without_ne_check() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let _ = (env, from, to, amount);
+    }
+}
+"#,
+        )?;
+        let hits = SelfTransferCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_ne_assert_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        assert!(from != to);
+        let _ = (env, amount);
+    }
+}
+"#,
+        )?;
+        let hits = SelfTransferCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_transfer_fn() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn send(env: Env, from: Address, to: Address, amount: i128) {
+        let _ = (env, from, to, amount);
+    }
+}
+"#,
+        )?;
+        let hits = SelfTransferCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_transfer_with_single_address() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, to: Address, amount: i128) {
+        let _ = (env, to, amount);
+    }
+}
+"#,
+        )?;
+        let hits = SelfTransferCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/weak_randomness.rs
+++ b/crates/checks/src/weak_randomness.rs
@@ -1,0 +1,160 @@
+//! Detects `env.ledger().timestamp()` / `env.ledger().sequence()` used as randomness.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "weak-randomness";
+
+pub struct WeakRandomnessCheck;
+
+impl Check for WeakRandomnessCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = LedgerRandVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+/// Returns true if `expr` is `*.ledger().timestamp()` or `*.ledger().sequence()`.
+fn is_ledger_rand(expr: &Expr) -> bool {
+    let Expr::MethodCall(outer) = expr else {
+        return false;
+    };
+    if !matches!(outer.method.to_string().as_str(), "timestamp" | "sequence") {
+        return false;
+    }
+    let Expr::MethodCall(inner) = outer.receiver.as_ref() else {
+        return false;
+    };
+    inner.method == "ledger"
+}
+
+fn is_arithmetic_op(op: &BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Add(_) | BinOp::Sub(_) | BinOp::Mul(_) | BinOp::Div(_) | BinOp::Rem(_)
+    )
+}
+
+struct LedgerRandVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for LedgerRandVisitor<'_> {
+    /// Flag arithmetic that directly involves a ledger timestamp/sequence operand.
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if is_arithmetic_op(&i.op) && (is_ledger_rand(&i.left) || is_ledger_rand(&i.right)) {
+            self.out.push(finding(i.span().start().line, &self.fn_name));
+        }
+        visit::visit_expr_binary(self, i);
+    }
+
+    /// Flag storage writes where the argument is a ledger timestamp/sequence call.
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+        if method == "set" {
+            if let Some(val_arg) = i.args.last() {
+                if is_ledger_rand(val_arg) {
+                    self.out.push(finding(i.span().start().line, &self.fn_name));
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn finding(line: usize, fn_name: &str) -> Finding {
+    Finding {
+        check_name: CHECK_NAME.to_string(),
+        severity: Severity::Medium,
+        file_path: String::new(),
+        line,
+        function_name: fn_name.to_string(),
+        description: format!(
+            "`env.ledger().timestamp()` or `env.ledger().sequence()` used as a randomness \
+             source in `{fn_name}`. Validators can influence these values; use a VRF or \
+             commit-reveal scheme instead."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_timestamp_in_arithmetic() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn roll(env: Env) -> u64 {
+        env.ledger().timestamp() % 6
+    }
+}
+"#,
+        )?;
+        let hits = WeakRandomnessCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_sequence_stored_as_seed() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn init(env: Env) {
+        env.storage().instance().set(&Symbol::short("seed"), &env.ledger().sequence());
+    }
+}
+"#,
+        )?;
+        let hits = WeakRandomnessCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_safe_contract() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn is_expired(env: Env, deadline: u64) -> bool {
+        env.ledger().timestamp() > deadline
+    }
+}
+"#,
+        )?;
+        // Comparison (>) is not arithmetic — should not flag.
+        let hits = WeakRandomnessCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/float-arithmetic-safe/Cargo.toml
+++ b/test-contracts/float-arithmetic-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-float-arithmetic-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/float-arithmetic-safe/src/lib.rs
+++ b/test-contracts/float-arithmetic-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct FeeContract;
+
+const FEE_BPS: i128 = 250; // 2.5% in basis points
+
+#[contractimpl]
+impl FeeContract {
+    // ✅ Integer-only arithmetic — deterministic on all WASM hosts.
+    pub fn calculate_fee(_env: Env, amount: i128) -> i128 {
+        amount * FEE_BPS / 10_000
+    }
+}

--- a/test-contracts/float-arithmetic-vulnerable/Cargo.toml
+++ b/test-contracts/float-arithmetic-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-float-arithmetic-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/float-arithmetic-vulnerable/src/lib.rs
+++ b/test-contracts/float-arithmetic-vulnerable/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct FeeContract;
+
+#[contractimpl]
+impl FeeContract {
+    // ❌ Uses f64 arithmetic — non-deterministic across WASM host environments.
+    pub fn calculate_fee(_env: Env, amount: i128) -> i128 {
+        let fee = amount as f64 * 0.025_f64;
+        fee as i128
+    }
+}

--- a/test-contracts/no-std-safe/Cargo.toml
+++ b/test-contracts/no-std-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-no-std-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/no-std-safe/src/lib.rs
+++ b/test-contracts/no-std-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+// ✅ Uses only soroban_sdk types — no std:: paths.
+use soroban_sdk::{contract, contractimpl, Env, Symbol, Vec};
+
+#[contract]
+pub struct GoodContract;
+
+#[contractimpl]
+impl GoodContract {
+    pub fn hello(env: Env) -> Symbol {
+        let _ = Vec::<Symbol>::new(&env);
+        Symbol::new(&env, "hello")
+    }
+}

--- a/test-contracts/no-std-vulnerable/Cargo.toml
+++ b/test-contracts/no-std-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-no-std-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/no-std-vulnerable/src/lib.rs
+++ b/test-contracts/no-std-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+// ❌ Missing #![no_std] and uses std:: paths — will fail on WASM targets.
+use std::collections::HashMap;
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct BadContract;
+
+#[contractimpl]
+impl BadContract {
+    pub fn store(_env: Env) {
+        let _map: HashMap<u32, u32> = HashMap::new();
+    }
+}

--- a/test-contracts/self-transfer-safe/Cargo.toml
+++ b/test-contracts/self-transfer-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-self-transfer-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/self-transfer-safe/src/lib.rs
+++ b/test-contracts/self-transfer-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    // ✅ Asserts from != to before proceeding.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        assert!(from != to, "self-transfer not allowed");
+        from.require_auth();
+        let _ = (env, amount);
+    }
+}

--- a/test-contracts/self-transfer-vulnerable/Cargo.toml
+++ b/test-contracts/self-transfer-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-self-transfer-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/self-transfer-vulnerable/src/lib.rs
+++ b/test-contracts/self-transfer-vulnerable/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    // ❌ No `from != to` assertion — self-transfers are silently allowed.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let _ = (env, to, amount);
+    }
+}

--- a/test-contracts/weak-randomness-safe/Cargo.toml
+++ b/test-contracts/weak-randomness-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-weak-randomness-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/weak-randomness-safe/src/lib.rs
+++ b/test-contracts/weak-randomness-safe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct LotteryContract;
+
+#[contractimpl]
+impl LotteryContract {
+    // ✅ Uses a commit-reveal seed supplied by the caller — not ledger metadata.
+    pub fn roll(_env: Env, seed: Bytes) -> u64 {
+        // In production: verify the seed against a prior commitment.
+        let first_byte = seed.get(0).unwrap_or(0) as u64;
+        first_byte % 6 + 1
+    }
+
+    // ✅ Ledger timestamp used only for comparison (deadline check), not as randomness.
+    pub fn is_expired(env: Env, deadline: u64) -> bool {
+        env.ledger().timestamp() > deadline
+    }
+}

--- a/test-contracts/weak-randomness-vulnerable/Cargo.toml
+++ b/test-contracts/weak-randomness-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-weak-randomness-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/weak-randomness-vulnerable/src/lib.rs
+++ b/test-contracts/weak-randomness-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct LotteryContract;
+
+#[contractimpl]
+impl LotteryContract {
+    // ❌ Uses ledger timestamp as randomness — validators can manipulate this.
+    pub fn roll(env: Env) -> u64 {
+        env.ledger().timestamp() % 6 + 1
+    }
+}


### PR DESCRIPTION
closes #21 
closes #19 
closes #16 
closes #15


…mness detectors

## New checks

### self-transfer (Low)
- File: crates/checks/src/self_transfer.rs
- Flags `pub fn transfer` in `#[contractimpl]` blocks that accept two `Address` parameters (from + to) but contain no `!=` assertion between them.
- Self-transfers produce confusing accounting and misleading event logs on-chain.

### no-std-violation (Medium)
- File: crates/checks/src/no_std.rs
- Flags `use std::` imports and `std::path` expressions anywhere in the file.
- Soroban contracts must be compiled with `#![no_std]`; std paths are unavailable in WASM targets and will cause compilation failures.

### float-arithmetic (Medium)
- File: crates/checks/src/float_arithmetic.rs
- Flags binary arithmetic (+, -, *, /) where either operand is an f32/f64 literal or a cast to f32/f64 inside `#[contractimpl]` functions.
- Floating-point results are non-deterministic across WASM host environments; all financial math must use integer types.

### weak-randomness (Medium)
- File: crates/checks/src/weak_randomness.rs
- Flags `env.ledger().timestamp()` and `env.ledger().sequence()` when used in arithmetic expressions or stored directly as a seed via `storage.set()`.
- Validators can influence ledger metadata; contracts requiring randomness must use a VRF or commit-reveal scheme. Comparison-only uses (e.g. deadline checks) are intentionally not flagged.

## Registration
- All four checks added to `default_checks()` in crates/checks/src/lib.rs.

## Test contracts (8 new crates)
- test-contracts/self-transfer-vulnerable/
- test-contracts/self-transfer-safe/
- test-contracts/no-std-vulnerable/
- test-contracts/no-std-safe/
- test-contracts/float-arithmetic-vulnerable/
- test-contracts/float-arithmetic-safe/
- test-contracts/weak-randomness-vulnerable/
- test-contracts/weak-randomness-safe/

Each check also includes inline unit tests covering the flag and pass cases.