### PR TITLE
feat(checks): add admin-in-temp, burn-auth, upgrade-auth, missing-con…

### DIFF
--- a/crates/checks/src/admin_in_temp.rs
+++ b/crates/checks/src/admin_in_temp.rs
@@ -1,0 +1,197 @@
+//! Admin/owner data stored in temporary storage — expires with TTL, leaving contract without admin.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "admin-in-temp";
+
+pub struct AdminInTempCheck;
+
+impl Check for AdminInTempCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let mut v = AdminInTempVisitor {
+                fn_name: method.sig.ident.to_string(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_temporary(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            m.method == "temporary" || receiver_chain_contains_temporary(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_temporary(&f.base),
+        _ => false,
+    }
+}
+
+/// Returns the string representation of the first argument to `.set(key, val)`.
+fn first_arg_str(m: &ExprMethodCall) -> Option<String> {
+    let arg = m.args.first()?;
+    Some(match arg {
+        Expr::Reference(r) => expr_to_string(&r.expr),
+        other => expr_to_string(other),
+    })
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+fn key_looks_like_admin(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    lower.contains("admin") || lower.contains("owner") || lower.contains("role")
+}
+
+struct AdminInTempVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for AdminInTempVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_temporary(&i.receiver) {
+            if let Some(key) = first_arg_str(i) {
+                if key_looks_like_admin(&key) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` stores an admin/owner/role key (`{}`) in \
+                             `env.storage().temporary()`. Temporary storage expires with TTL, \
+                             potentially leaving the contract without an admin. Use \
+                             `persistent()` or `instance()` instead.",
+                            self.fn_name, key
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_admin_key_in_temporary() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+const ADMIN: soroban_sdk::Symbol = symbol_short!("admin");
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.storage().temporary().set(&ADMIN, &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminInTempCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("ADMIN"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_owner_string_key_in_temporary() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn init(env: Env, owner: Address) {
+        let key = Symbol::new(&env, "owner");
+        env.storage().temporary().set(&key, &owner);
+    }
+}
+"#,
+        )?;
+        let hits = AdminInTempCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_persistent_admin() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+const ADMIN: soroban_sdk::Symbol = symbol_short!("admin");
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&ADMIN, &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminInTempCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_admin_temp_key() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const COUNTER: soroban_sdk::Symbol = symbol_short!("cnt");
+#[contractimpl]
+impl C {
+    pub fn tick(env: Env) {
+        env.storage().temporary().set(&COUNTER, &1u32);
+    }
+}
+"#,
+        )?;
+        let hits = AdminInTempCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/burn_auth.rs
+++ b/crates/checks/src/burn_auth.rs
@@ -1,0 +1,155 @@
+//! `burn` / `burn_from` in `#[contractimpl]` blocks without any `require_auth` call.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "burn-missing-auth";
+
+pub struct BurnAuthCheck;
+
+impl Check for BurnAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if name != "burn" && name != "burn_from" {
+                continue;
+            }
+            if body_has_auth_gate(&method.block) {
+                continue;
+            }
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: method.sig.fn_token.span().start().line,
+                function_name: name.clone(),
+                description: format!(
+                    "Token function `{name}` has no `require_auth()` or \
+                     `require_auth_for_args()` call. Any caller can destroy tokens \
+                     belonging to any address."
+                ),
+            });
+        }
+        out
+    }
+}
+
+fn body_has_auth_gate(block: &Block) -> bool {
+    let mut v = AuthScan { found: false };
+    v.visit_block(block);
+    v.found
+}
+
+#[derive(Default)]
+struct AuthScan {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for AuthScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let m = i.method.to_string();
+        if matches!(m.as_str(), "require_auth" | "require_auth_for_args") {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_burn_without_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        // no auth
+        let _ = (env, from, amount);
+    }
+}
+"#,
+        )?;
+        let hits = BurnAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "burn");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_burn_from_without_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
+        let _ = (env, spender, from, amount);
+    }
+}
+"#,
+        )?;
+        let hits = BurnAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "burn_from");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_burn_with_require_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        let _ = (env, amount);
+    }
+}
+"#,
+        )?;
+        let hits = BurnAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_burn_functions() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, amount: i128) {
+        let _ = (env, amount);
+    }
+}
+"#,
+        )?;
+        let hits = BurnAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -1,22 +1,30 @@
 //! Vulnerability detectors for Soroban smart contracts.
 
 pub mod admin;
+pub mod admin_in_temp;
 pub mod auth;
+pub mod burn_auth;
 pub mod contracttype;
+pub mod missing_contractimpl;
 pub mod overflow;
 pub mod panic_usage;
 pub mod storage;
 pub mod unbounded_storage;
+pub mod upgrade_auth;
 pub mod zero_amount;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
+pub use admin_in_temp::AdminInTempCheck;
 pub use auth::MissingRequireAuthCheck;
+pub use burn_auth::BurnAuthCheck;
 pub use contracttype::MissingContracttypeCheck;
+pub use missing_contractimpl::MissingContractimplCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use panic_usage::PanicUsageCheck;
 pub use storage::UnsafeStoragePatternsCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
+pub use upgrade_auth::UpgradeAuthCheck;
 pub use zero_amount::ZeroAmountCheck;
 
 use serde::Serialize;
@@ -63,5 +71,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
         Box::new(ZeroAmountCheck),
+        Box::new(AdminInTempCheck),
+        Box::new(BurnAuthCheck),
+        Box::new(UpgradeAuthCheck),
+        Box::new(MissingContractimplCheck),
     ]
 }

--- a/crates/checks/src/missing_contractimpl.rs
+++ b/crates/checks/src/missing_contractimpl.rs
@@ -1,0 +1,170 @@
+//! `impl` blocks for `#[contract]` structs that are missing `#[contractimpl]`.
+
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::{File, ImplItem, Item, Type, Visibility};
+
+const CHECK_NAME: &str = "missing-contractimpl";
+
+pub struct MissingContractimplCheck;
+
+impl Check for MissingContractimplCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        // Pass 1: collect struct names annotated with #[contract].
+        let contract_structs: Vec<String> = file
+            .items
+            .iter()
+            .filter_map(|item| {
+                let Item::Struct(s) = item else { return None };
+                let has_contract = s.attrs.iter().any(|a| {
+                    a.path()
+                        .segments
+                        .last()
+                        .is_some_and(|seg| seg.ident == "contract")
+                });
+                has_contract.then(|| s.ident.to_string())
+            })
+            .collect();
+
+        if contract_structs.is_empty() {
+            return vec![];
+        }
+
+        // Pass 2: find impl blocks for those structs that lack #[contractimpl] and have pub fns.
+        let mut out = Vec::new();
+        for item in &file.items {
+            let Item::Impl(item_impl) = item else {
+                continue;
+            };
+            // Skip trait impls.
+            if item_impl.trait_.is_some() {
+                continue;
+            }
+            // Already has contractimpl — fine.
+            if crate::util::is_contractimpl(item_impl) {
+                continue;
+            }
+            // Check self type matches a #[contract] struct.
+            let self_name = impl_self_type_name(&item_impl.self_ty);
+            if !contract_structs.iter().any(|n| *n == self_name) {
+                continue;
+            }
+            // Has at least one pub fn?
+            let has_pub_fn = item_impl.items.iter().any(|i| {
+                if let ImplItem::Fn(f) = i {
+                    matches!(f.vis, Visibility::Public(_))
+                } else {
+                    false
+                }
+            });
+            if !has_pub_fn {
+                continue;
+            }
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Low,
+                file_path: String::new(),
+                line: item_impl.impl_token.span().start().line,
+                function_name: String::new(),
+                description: format!(
+                    "`impl {self_name}` has public methods but is missing `#[contractimpl]`. \
+                     These methods will not be exposed as contract entrypoints."
+                ),
+            });
+        }
+        out
+    }
+}
+
+fn impl_self_type_name(ty: &Type) -> String {
+    match ty {
+        Type::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_impl_without_contractimpl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contract, Env};
+#[contract]
+pub struct MyContract;
+impl MyContract {
+    pub fn hello(env: Env) { let _ = env; }
+}
+"#,
+        )?;
+        let hits = MissingContractimplCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert!(hits[0].description.contains("MyContract"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_contractimpl_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contract, contractimpl, Env};
+#[contract]
+pub struct MyContract;
+#[contractimpl]
+impl MyContract {
+    pub fn hello(env: Env) { let _ = env; }
+}
+"#,
+        )?;
+        let hits = MissingContractimplCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_contract_struct() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::Env;
+pub struct Helper;
+impl Helper {
+    pub fn do_thing(env: Env) { let _ = env; }
+}
+"#,
+        )?;
+        let hits = MissingContractimplCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_only_private_fns() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contract, Env};
+#[contract]
+pub struct MyContract;
+impl MyContract {
+    fn internal(env: Env) { let _ = env; }
+}
+"#,
+        )?;
+        let hits = MissingContractimplCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/upgrade_auth.rs
+++ b/crates/checks/src/upgrade_auth.rs
@@ -1,0 +1,145 @@
+//! `upgrade` entrypoints that call `update_current_contract_wasm` without prior auth.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprMethodCall, File, Stmt, Visibility};
+
+const CHECK_NAME: &str = "upgrade-missing-auth";
+
+pub struct UpgradeAuthCheck;
+
+impl Check for UpgradeAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            if method.sig.ident != "upgrade" {
+                continue;
+            }
+            // Walk statements in order; track whether auth appeared before wasm update.
+            let mut auth_seen = false;
+            let mut wasm_update_line: Option<usize> = None;
+            for stmt in &method.block.stmts {
+                let mut sv = StmtVisitor::default();
+                sv.visit_stmt(stmt);
+                if sv.has_auth {
+                    auth_seen = true;
+                }
+                if sv.has_wasm_update && !auth_seen && wasm_update_line.is_none() {
+                    wasm_update_line = sv.wasm_update_line;
+                }
+            }
+            if let Some(line) = wasm_update_line {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: "upgrade".to_string(),
+                    description:
+                        "Function `upgrade` calls `update_current_contract_wasm` without a \
+                         preceding `require_auth()` or `require_auth_for_args()`. Any account \
+                         on Stellar can replace the contract WASM."
+                            .to_string(),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct StmtVisitor {
+    has_auth: bool,
+    has_wasm_update: bool,
+    wasm_update_line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for StmtVisitor {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let m = i.method.to_string();
+        if matches!(m.as_str(), "require_auth" | "require_auth_for_args") {
+            self.has_auth = true;
+        }
+        if m == "update_current_contract_wasm" {
+            self.has_wasm_update = true;
+            self.wasm_update_line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_upgrade_without_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, BytesN, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, new_wasm: BytesN<32>) {
+        env.deployer().update_current_contract_wasm(new_wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UpgradeAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "upgrade");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_upgrade_with_require_auth_before() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, BytesN, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, new_wasm: BytesN<32>) {
+        env.require_auth();
+        env.deployer().update_current_contract_wasm(new_wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UpgradeAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_upgrade_without_wasm_call() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env) {
+        let _ = env;
+    }
+}
+"#,
+        )?;
+        let hits = UpgradeAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/admin-in-temp-safe/Cargo.toml
+++ b/test-contracts/admin-in-temp-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-in-temp-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-in-temp-safe/src/lib.rs
+++ b/test-contracts/admin-in-temp-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct AdminInTempSafe;
+
+const ADMIN: Symbol = symbol_short!("admin");
+
+#[contractimpl]
+impl AdminInTempSafe {
+    /// ✅ Admin stored in persistent storage — survives TTL expiry.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&ADMIN, &new_admin);
+    }
+}

--- a/test-contracts/admin-in-temp-vulnerable/Cargo.toml
+++ b/test-contracts/admin-in-temp-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-in-temp-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-in-temp-vulnerable/src/lib.rs
+++ b/test-contracts/admin-in-temp-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct AdminInTempVulnerable;
+
+const ADMIN: Symbol = symbol_short!("admin");
+
+#[contractimpl]
+impl AdminInTempVulnerable {
+    /// ❌ Stores admin in temporary storage — expires with TTL, leaving contract without admin.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.storage().temporary().set(&ADMIN, &new_admin);
+    }
+}

--- a/test-contracts/burn-auth-safe/Cargo.toml
+++ b/test-contracts/burn-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-burn-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/burn-auth-safe/src/lib.rs
+++ b/test-contracts/burn-auth-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct BurnAuthSafe;
+
+#[contractimpl]
+impl BurnAuthSafe {
+    /// ✅ Token owner must authorize the burn.
+    pub fn burn(_env: Env, from: Address, _amount: i128) {
+        from.require_auth();
+    }
+
+    /// ✅ Spender must be authorized to burn on behalf of `from`.
+    pub fn burn_from(_env: Env, spender: Address, _from: Address, _amount: i128) {
+        spender.require_auth();
+    }
+}

--- a/test-contracts/burn-auth-vulnerable/Cargo.toml
+++ b/test-contracts/burn-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-burn-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/burn-auth-vulnerable/src/lib.rs
+++ b/test-contracts/burn-auth-vulnerable/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct BurnAuthVulnerable;
+
+#[contractimpl]
+impl BurnAuthVulnerable {
+    /// ❌ No require_auth — any caller can destroy tokens belonging to any address.
+    pub fn burn(_env: Env, _from: Address, _amount: i128) {}
+
+    /// ❌ No require_auth — any caller can burn on behalf of any spender.
+    pub fn burn_from(_env: Env, _spender: Address, _from: Address, _amount: i128) {}
+}

--- a/test-contracts/missing-contractimpl-safe/Cargo.toml
+++ b/test-contracts/missing-contractimpl-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-missing-contractimpl-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/missing-contractimpl-safe/src/lib.rs
+++ b/test-contracts/missing-contractimpl-safe/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct MissingContractimplSafe;
+
+/// ✅ #[contractimpl] present — methods are properly exposed as contract entrypoints.
+#[contractimpl]
+impl MissingContractimplSafe {
+    pub fn hello(_env: Env) -> u32 {
+        42
+    }
+}

--- a/test-contracts/missing-contractimpl-vulnerable/Cargo.toml
+++ b/test-contracts/missing-contractimpl-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-missing-contractimpl-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/missing-contractimpl-vulnerable/src/lib.rs
+++ b/test-contracts/missing-contractimpl-vulnerable/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, Env};
+
+#[contract]
+pub struct MissingContractimplVulnerable;
+
+/// ❌ Missing #[contractimpl] — these pub methods are NOT exposed as contract entrypoints.
+impl MissingContractimplVulnerable {
+    pub fn hello(_env: Env) -> u32 {
+        42
+    }
+}

--- a/test-contracts/upgrade-auth-safe/Cargo.toml
+++ b/test-contracts/upgrade-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-upgrade-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/upgrade-auth-safe/src/lib.rs
+++ b/test-contracts/upgrade-auth-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, BytesN, Env};
+
+#[contract]
+pub struct UpgradeAuthSafe;
+
+#[contractimpl]
+impl UpgradeAuthSafe {
+    /// ✅ Only the authorized caller can upgrade the contract WASM.
+    pub fn upgrade(env: Env, new_wasm: BytesN<32>) {
+        env.require_auth();
+        env.deployer().update_current_contract_wasm(new_wasm);
+    }
+}

--- a/test-contracts/upgrade-auth-vulnerable/Cargo.toml
+++ b/test-contracts/upgrade-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-upgrade-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/upgrade-auth-vulnerable/src/lib.rs
+++ b/test-contracts/upgrade-auth-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, BytesN, Env};
+
+#[contract]
+pub struct UpgradeAuthVulnerable;
+
+#[contractimpl]
+impl UpgradeAuthVulnerable {
+    /// ❌ No require_auth — any account on Stellar can replace the contract WASM.
+    pub fn upgrade(env: Env, new_wasm: BytesN<32>) {
+        env.deployer().update_current_contract_wasm(new_wasm);
+    }
+}


### PR DESCRIPTION
closes #22 
closes #20 
closes #18 
closes #17 

…tractimpl detectors

Four new static analysis checks covering critical and low-severity vulnerability classes in Soroban smart contracts.

## admin-in-temp (High)
Flags env.storage().temporary().set(...) calls where the key variable or string contains 'admin', 'owner', or 'role' (case-insensitive). Storing admin/owner addresses in temporary storage is dangerous because the entry expires with its TTL, potentially leaving the contract permanently without an admin.
- crates/checks/src/admin_in_temp.rs
- test-contracts/admin-in-temp-vulnerable/  (triggers the check)
- test-contracts/admin-in-temp-safe/        (uses persistent storage)

## burn-auth (High)
Flags pub fn burn and pub fn burn_from inside #[contractimpl] blocks that contain no require_auth() or require_auth_for_args() call. Without authorization, any caller on Stellar can destroy tokens belonging to any address — a critical gap specific to token contracts.
- crates/checks/src/burn_auth.rs
- test-contracts/burn-auth-vulnerable/  (no auth on burn/burn_from)
- test-contracts/burn-auth-safe/        (from.require_auth() / spender.require_auth())

## upgrade-auth (High)
Flags pub fn upgrade that calls env.deployer().update_current_contract_wasm(...) without a preceding require_auth() or require_auth_for_args(). Statements are walked in order so auth appearing *after* the wasm update is still flagged. Without this guard any account on Stellar can replace the contract logic.
- crates/checks/src/upgrade_auth.rs
- test-contracts/upgrade-auth-vulnerable/  (no auth before wasm update)
- test-contracts/upgrade-auth-safe/        (env.require_auth() before update)

## missing-contractimpl (Low)
Two-pass check: first collects all struct names annotated with #[contract], then finds impl blocks for those structs that (a) lack #[contractimpl] and (b) contain at least one pub fn. Such methods are silently ignored by the Soroban runtime and will never be reachable as contract entrypoints — a common refactoring mistake.
- crates/checks/src/missing_contractimpl.rs
- test-contracts/missing-contractimpl-vulnerable/  (impl without #[contractimpl])
- test-contracts/missing-contractimpl-safe/        (#[contractimpl] present)

## Registration
All four checks are wired into default_checks() in crates/checks/src/lib.rs and exported via pub use so they are available to the analyzer and any downstream consumers.

Each check file includes inline unit tests covering the flag path, the safe path, and relevant edge cases (private functions, non-matching keys, auth after wasm update, etc.).