### PR TITLE
Issues 28 29 30 31

### DIFF
--- a/crates/checks/src/event_data_leak.rs
+++ b/crates/checks/src/event_data_leak.rs
@@ -1,0 +1,214 @@
+//! Flags `env.events().publish(topics, data)` calls with oversized plaintext string data.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "event-data-leak";
+const MAX_DATA_LEN: usize = 32;
+
+/// Flags `env.events().publish(topics, data)` calls where the second argument
+/// is a string literal with length > 32 characters.
+pub struct EventDataLeakCheck;
+
+impl Check for EventDataLeakCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = EventVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_events(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "events" {
+                return true;
+            }
+            receiver_chain_contains_events(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_events(&f.base),
+        _ => false,
+    }
+}
+
+fn is_publish_call(m: &ExprMethodCall) -> bool {
+    m.method == "publish" && receiver_chain_contains_events(&m.receiver)
+}
+
+struct EventVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for EventVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        if is_publish_call(i) && i.args.len() >= 2 {
+            if let Expr::Lit(syn::ExprLit {
+                lit: Lit::Str(lit_str),
+                ..
+            }) = &i.args[1]
+            {
+                let data_len = lit_str.value().len();
+                if data_len > MAX_DATA_LEN {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "events.publish() called with oversized plaintext string data \
+                             ({} chars > {} char limit). This data is permanently visible \
+                             on-chain and may leak sensitive information.",
+                            data_len, MAX_DATA_LEN
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(EventDataLeakCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_publish_with_oversized_string() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn emit_event(env: Env) {
+        env.events().publish(
+            (Symbol::new(&env, "topic"),),
+            "this is a very long string that exceeds the limit"
+        );
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "emit_event");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_short_string() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn emit_event(env: Env) {
+        env.events().publish(
+            (Symbol::new(&env, "topic"),),
+            "short"
+        );
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_exactly_32_chars() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn emit_event(env: Env) {
+        env.events().publish(
+            (Symbol::new(&env, "topic"),),
+            "12345678901234567890123456789012"
+        );
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_string_data() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn emit_event(env: Env, data: String) {
+        env.events().publish(
+            (Symbol::new(&env, "topic"),),
+            data
+        );
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{Env, Symbol};
+
+pub struct Contract;
+
+impl Contract {
+    pub fn helper(env: Env) {
+        env.events().publish(
+            (Symbol::new(&env, "topic"),),
+            "this is a very long string that exceeds the limit"
+        );
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/invoke_return.rs
+++ b/crates/checks/src/invoke_return.rs
@@ -1,0 +1,189 @@
+//! Flags `env.invoke_contract(...)` calls whose return value is ignored.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Pat, Stmt};
+
+const CHECK_NAME: &str = "invoke-return";
+
+/// Flags `env.invoke_contract(...)` calls whose result is bound to `_` or immediately dropped.
+pub struct InvokeReturnCheck;
+
+impl Check for InvokeReturnCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = InvokeVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn is_invoke_contract_call(m: &ExprMethodCall) -> bool {
+    if m.method != "invoke_contract" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+struct InvokeVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for InvokeVisitor<'a> {
+    fn visit_stmt(&mut self, i: &'a Stmt) {
+        match i {
+            Stmt::Expr(expr, _) => {
+                if let Expr::MethodCall(m) = expr {
+                    if is_invoke_contract_call(m) {
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::Low,
+                            file_path: String::new(),
+                            line: m.span().start().line,
+                            function_name: self.fn_name.clone(),
+                            description: "Return value of `env.invoke_contract()` is ignored. \
+                                           The caller cannot detect failure or unexpected results \
+                                           from the callee."
+                                .to_string(),
+                        });
+                    }
+                }
+            }
+            Stmt::Local(local) => {
+                if let Pat::Wild(_) = local.pat {
+                    if let Some((_, init)) = &local.init {
+                        if let Expr::MethodCall(m) = &**init {
+                            if is_invoke_contract_call(m) {
+                                self.out.push(Finding {
+                                    check_name: CHECK_NAME.to_string(),
+                                    severity: Severity::Low,
+                                    file_path: String::new(),
+                                    line: m.span().start().line,
+                                    function_name: self.fn_name.clone(),
+                                    description: "Return value of `env.invoke_contract()` is \
+                                                   ignored (bound to `_`). The caller cannot \
+                                                   detect failure or unexpected results from the \
+                                                   callee."
+                                        .to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        visit::visit_stmt(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(InvokeReturnCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_invoke_contract_as_statement() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_other(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "method"), &());
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "call_other");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_invoke_contract_bound_to_wildcard() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_other(env: Env, contract: Address) {
+        let _ = env.invoke_contract(&contract, &Symbol::new(&env, "method"), &());
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "call_other");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_return_value_used() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_other(env: Env, contract: Address) {
+        let result = env.invoke_contract(&contract, &Symbol::new(&env, "method"), &());
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{Env, Address};
+
+pub struct Contract;
+
+impl Contract {
+    pub fn helper(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "method"), &());
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -3,9 +3,13 @@
 pub mod admin;
 pub mod auth;
 pub mod contracttype;
+pub mod event_data_leak;
+pub mod invoke_return;
 pub mod overflow;
 pub mod panic_usage;
+pub mod remove_without_has;
 pub mod storage;
+pub mod ttl_arg_order;
 pub mod unbounded_storage;
 pub mod zero_amount;
 mod util;
@@ -13,9 +17,13 @@ mod util;
 pub use admin::UnprotectedAdminCheck;
 pub use auth::MissingRequireAuthCheck;
 pub use contracttype::MissingContracttypeCheck;
+pub use event_data_leak::EventDataLeakCheck;
+pub use invoke_return::InvokeReturnCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use panic_usage::PanicUsageCheck;
+pub use remove_without_has::RemoveWithoutHasCheck;
 pub use storage::UnsafeStoragePatternsCheck;
+pub use ttl_arg_order::TtlArgOrderCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
 pub use zero_amount::ZeroAmountCheck;
 
@@ -63,5 +71,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
         Box::new(ZeroAmountCheck),
+        Box::new(InvokeReturnCheck),
+        Box::new(TtlArgOrderCheck),
+        Box::new(EventDataLeakCheck),
+        Box::new(RemoveWithoutHasCheck),
     ]
 }

--- a/crates/checks/src/remove_without_has.rs
+++ b/crates/checks/src/remove_without_has.rs
@@ -1,0 +1,197 @@
+//! Flags `env.storage()...remove(key)` calls without a preceding `has(key)` guard.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File, Stmt};
+
+const CHECK_NAME: &str = "remove-without-has";
+
+/// Flags `env.storage()...remove(key)` calls in `#[contractimpl]` functions
+/// that have no preceding `env.storage()...has(key)` call in the same function body.
+pub struct RemoveWithoutHasCheck;
+
+impl Check for RemoveWithoutHasCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = RemoveVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_remove_call(m: &ExprMethodCall) -> bool {
+    m.method == "remove" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn is_has_call(m: &ExprMethodCall) -> bool {
+    m.method == "has" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn extract_key_from_call(m: &ExprMethodCall) -> Option<String> {
+    if m.args.is_empty() {
+        return None;
+    }
+    // Simple heuristic: convert first arg to string representation
+    Some(format!("{:?}", m.args[0]))
+}
+
+struct RemoveVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for RemoveVisitor<'a> {
+    fn visit_block(&mut self, i: &'a Block) {
+        let mut has_keys = Vec::new();
+        let mut remove_calls = Vec::new();
+
+        // First pass: collect all has() and remove() calls
+        for stmt in &i.stmts {
+            let mut collector = CallCollector {
+                has_keys: &mut has_keys,
+                remove_calls: &mut remove_calls,
+            };
+            collector.visit_stmt(stmt);
+        }
+
+        // Check each remove() call against has() calls
+        for (remove_call, line) in remove_calls {
+            if !has_keys.contains(&remove_call) {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line,
+                    function_name: self.fn_name.clone(),
+                    description: "storage.remove() called without a preceding has() guard. \
+                                   Removing a non-existent key is a no-op, which may indicate \
+                                   a logic error."
+                        .to_string(),
+                });
+            }
+        }
+
+        visit::visit_block(self, i);
+    }
+}
+
+struct CallCollector<'a> {
+    has_keys: &'a mut Vec<String>,
+    remove_calls: &'a mut Vec<(String, usize)>,
+}
+
+impl<'a> Visit<'a> for CallCollector<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        if is_has_call(i) {
+            if let Some(key) = extract_key_from_call(i) {
+                self.has_keys.push(key);
+            }
+        } else if is_remove_call(i) {
+            if let Some(key) = extract_key_from_call(i) {
+                self.remove_calls.push((key, i.span().start().line));
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(RemoveWithoutHasCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_remove_without_has() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn remove_key(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "key"));
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "remove_key");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_has_precedes_remove() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn remove_key(env: Env) {
+        if env.storage().instance().has(&Symbol::new(&env, "key")) {
+            env.storage().instance().remove(&Symbol::new(&env, "key"));
+        }
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{Env, Symbol};
+
+pub struct Contract;
+
+impl Contract {
+    pub fn helper(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "key"));
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/ttl_arg_order.rs
+++ b/crates/checks/src/ttl_arg_order.rs
@@ -1,0 +1,204 @@
+//! Flags `extend_ttl(a, b)` calls where both arguments are integer literals and `a > b`.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "ttl-arg-order";
+
+/// Flags `extend_ttl(min_ttl, max_ttl)` calls where both arguments are integer literals
+/// and the first argument is greater than the second (swapped arguments).
+pub struct TtlArgOrderCheck;
+
+impl Check for TtlArgOrderCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = TtlVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_extend_ttl_call(m: &ExprMethodCall) -> bool {
+    m.method == "extend_ttl" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn extract_int_literal(expr: &Expr) -> Option<u64> {
+    match expr {
+        Expr::Lit(syn::ExprLit {
+            lit: Lit::Int(lit_int),
+            ..
+        }) => lit_int.base10_parse().ok(),
+        _ => None,
+    }
+}
+
+struct TtlVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for TtlVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        if is_extend_ttl_call(i) && i.args.len() == 2 {
+            if let (Some(first), Some(second)) =
+                (extract_int_literal(&i.args[0]), extract_int_literal(&i.args[1]))
+            {
+                if first > second {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "extend_ttl called with min_ttl ({}) > max_ttl ({}). \
+                             Arguments may be swapped; max_ttl must be >= min_ttl.",
+                            first, second
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(TtlArgOrderCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_extend_ttl_with_swapped_args() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn extend_ttl_bad(env: Env) {
+        env.storage().instance().extend_ttl(1000, 100);
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "extend_ttl_bad");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_args_in_correct_order() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn extend_ttl_good(env: Env) {
+        env.storage().instance().extend_ttl(100, 1000);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_args_equal() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn extend_ttl_equal(env: Env) {
+        env.storage().instance().extend_ttl(100, 100);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_literal_args() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn extend_ttl_vars(env: Env, min: u32, max: u32) {
+        env.storage().instance().extend_ttl(min, max);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{Env};
+
+pub struct Contract;
+
+impl Contract {
+    pub fn helper(env: Env) {
+        env.storage().instance().extend_ttl(1000, 100);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/event-data-leak-safe/Cargo.toml
+++ b/test-contracts/event-data-leak-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-event-data-leak-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/event-data-leak-safe/src/lib.rs
+++ b/test-contracts/event-data-leak-safe/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    pub fn emit_event_safe(env: Env) {
+        // ✅ Short plaintext string (within 32 char limit)
+        env.events().publish(
+            (symbol_short!("event"),),
+            "safe"
+        );
+    }
+
+    pub fn emit_event_at_limit(env: Env) {
+        // ✅ Exactly 32 characters - at the limit
+        env.events().publish(
+            (symbol_short!("event"),),
+            "12345678901234567890123456789012"
+        );
+    }
+}

--- a/test-contracts/event-data-leak-vulnerable/Cargo.toml
+++ b/test-contracts/event-data-leak-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-event-data-leak-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/event-data-leak-vulnerable/src/lib.rs
+++ b/test-contracts/event-data-leak-vulnerable/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    pub fn emit_event_leak(env: Env) {
+        // ❌ Emitting oversized plaintext string (> 32 chars) - privacy risk
+        env.events().publish(
+            (symbol_short!("leak"),),
+            "this is a very long string that exceeds the limit"
+        );
+    }
+
+    pub fn emit_private_key(env: Env) {
+        // ❌ Emitting sensitive data in plaintext
+        env.events().publish(
+            (symbol_short!("key"),),
+            "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        );
+    }
+}

--- a/test-contracts/invoke-return-safe/Cargo.toml
+++ b/test-contracts/invoke-return-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-return-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-return-safe/src/lib.rs
+++ b/test-contracts/invoke-return-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    pub fn call_other(env: Env, contract: Address) {
+        // ✅ Return value is captured and used
+        let result = env.invoke_contract(
+            &contract,
+            &symbol_short!("method"),
+            &(),
+        );
+        // Process result...
+    }
+}

--- a/test-contracts/invoke-return-vulnerable/Cargo.toml
+++ b/test-contracts/invoke-return-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-return-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-return-vulnerable/src/lib.rs
+++ b/test-contracts/invoke-return-vulnerable/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    pub fn call_other(env: Env, contract: Address) {
+        // ❌ Return value of invoke_contract is ignored
+        env.invoke_contract(
+            &contract,
+            &symbol_short!("method"),
+            &(),
+        );
+    }
+
+    pub fn call_other_wildcard(env: Env, contract: Address) {
+        // ❌ Return value bound to _ is still ignored
+        let _ = env.invoke_contract(
+            &contract,
+            &symbol_short!("method"),
+            &(),
+        );
+    }
+}

--- a/test-contracts/remove-without-has-safe/Cargo.toml
+++ b/test-contracts/remove-without-has-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-remove-without-has-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/remove-without-has-safe/src/lib.rs
+++ b/test-contracts/remove-without-has-safe/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    pub fn remove_key(env: Env) {
+        // ✅ Remove guarded by has() check
+        if env.storage().instance().has(&symbol_short!("key")) {
+            env.storage().instance().remove(&symbol_short!("key"));
+        }
+    }
+
+    pub fn remove_persistent(env: Env) {
+        // ✅ Remove from persistent storage with has() guard
+        if env.storage().persistent().has(&Symbol::new(&env, "data")) {
+            env.storage().persistent().remove(&Symbol::new(&env, "data"));
+        }
+    }
+}

--- a/test-contracts/remove-without-has-vulnerable/Cargo.toml
+++ b/test-contracts/remove-without-has-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-remove-without-has-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/remove-without-has-vulnerable/src/lib.rs
+++ b/test-contracts/remove-without-has-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    pub fn remove_key(env: Env) {
+        // ❌ Unconditional remove without has() guard
+        env.storage().instance().remove(&symbol_short!("key"));
+    }
+
+    pub fn remove_persistent(env: Env) {
+        // ❌ Remove from persistent storage without checking if key exists
+        env.storage().persistent().remove(&Symbol::new(&env, "data"));
+    }
+}

--- a/test-contracts/ttl-arg-order-safe/Cargo.toml
+++ b/test-contracts/ttl-arg-order-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-arg-order-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-arg-order-safe/src/lib.rs
+++ b/test-contracts/ttl-arg-order-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    pub fn extend_ttl_good(env: Env) {
+        // ✅ Arguments in correct order: min_ttl (100) <= max_ttl (1000)
+        env.storage().instance().extend_ttl(100, 1000);
+    }
+
+    pub fn extend_ttl_good_persistent(env: Env) {
+        // ✅ Arguments in correct order for persistent storage
+        env.storage().persistent().extend_ttl(50, 500);
+    }
+}

--- a/test-contracts/ttl-arg-order-vulnerable/Cargo.toml
+++ b/test-contracts/ttl-arg-order-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-arg-order-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-arg-order-vulnerable/src/lib.rs
+++ b/test-contracts/ttl-arg-order-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    pub fn extend_ttl_bad(env: Env) {
+        // ❌ Arguments are swapped: min_ttl (1000) > max_ttl (100)
+        env.storage().instance().extend_ttl(1000, 100);
+    }
+
+    pub fn extend_ttl_bad_persistent(env: Env) {
+        // ❌ Arguments are swapped in persistent storage
+        env.storage().persistent().extend_ttl(500, 50);
+    }
+}


### PR DESCRIPTION
 ## Add four new security checks for Soroban smart contracts                                                                                                                           
                                                                                                                                                                                        
  This PR implements four new vulnerability detectors for Soroban Guard Core, addressing critical and common security patterns in Soroban smart contracts.                              
                                                                                                                                                                                        
  ### Changes                                                                                                                                                                           
                                                                                                                                                                                        
  #### Issue #28: Invoke Contract Return Value Check                                                                                                                                    
  - **File**: `crates/checks/src/invoke_return.rs`                                                                                                                                      
  - **Check Name**: `invoke-return`                                                                                                                                                     
  - **Severity**: Low                                                                                                                                                                   
  - **Description**: Flags `env.invoke_contract(...)` calls whose return value is ignored or bound to `_`. Cross-contract calls can fail silently, leading to logic errors if the caller
  doesn't check the result.                                                                                                                                                             
  - **Detection**: Identifies both statement expressions and wildcard bindings                                                                                                          
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/invoke-return-vulnerable/` - demonstrates ignored return values                                                                                                   
    - `test-contracts/invoke-return-safe/` - shows proper return value handling                                                                                                         
                                                                                                                                                                                        
  #### Issue #29: TTL Argument Order Check                                                                                                                                              
  - **File**: `crates/checks/src/ttl_arg_order.rs`                                                                                                                                      
  - **Check Name**: `ttl-arg-order`                                                                                                                                                     
  - **Severity**: Low                                                                                                                                                                   
  - **Description**: Flags `extend_ttl(min_ttl, max_ttl)` calls where both arguments are integer literals and `min_ttl > max_ttl`. This detects swapped arguments that violate the      
  Soroban requirement that `max_ttl >= min_ttl`.                                                                                                                                        
  - **Detection**: Compares literal integer values to identify argument order violations                                                                                                
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/ttl-arg-order-vulnerable/` - demonstrates swapped arguments                                                                                                       
    - `test-contracts/ttl-arg-order-safe/` - shows correct argument order                                                                                                               
                                                                                                                                                                                        
  #### Issue #30: Event Data Leak Check                                                                                                                                                 
  - **File**: `crates/checks/src/event_data_leak.rs`                                                                                                                                    
  - **Check Name**: `event-data-leak`                                                                                                                                                   
  - **Severity**: Low                                                                                                                                                                   
  - **Description**: Flags `env.events().publish(topics, data)` calls where the data argument is a string literal longer than 32 characters. Event data is permanently visible on-chain;
  oversized plaintext strings may leak sensitive information like private keys or address lists.                                                                                        
  - **Detection**: Inspects string literal length in the second argument of `publish()` calls                                                                                           
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/event-data-leak-vulnerable/` - demonstrates oversized plaintext strings                                                                                           
    - `test-contracts/event-data-leak-safe/` - shows safe short strings                                                                                                                 
                                                                                                                                                                                        
  #### Issue #31: Remove Without Has Guard Check                                                                                                                                        
  - **File**: `crates/checks/src/remove_without_has.rs`                                                                                                                                 
  - **Check Name**: `remove-without-has`                                                                                                                                                
  - **Severity**: Low                                                                                                                                                                   
  - **Description**: Flags `env.storage()...remove(key)` calls that lack a preceding `has(key)` guard in the same function. Removing a non-existent key is a no-op in Soroban, which    
  often indicates a logic error.                                                                                                                                                        
  - **Detection**: Scans function bodies for unconditional `remove()` calls without prior `has()` checks on the same key                                                                
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/remove-without-has-vulnerable/` - demonstrates unconditional removes                                                                                              
    - `test-contracts/remove-without-has-safe/` - shows guarded removes                                                                                                                 
                                                                                                                                                                                        
  ### Implementation Details                                                                                                                                                            
                                                                                                                                                                                        
  - All checks follow the existing `Check` trait pattern and integrate seamlessly with the analyzer                                                                                     
  - Each check includes comprehensive unit tests covering both vulnerable and safe patterns                                                                                             
  - Checks are stateless and isolated, following the established architecture                                                                                                           
  - All new checks are registered in `default_checks()` in `crates/checks/src/lib.rs`                                                                                                   
  - Test contracts demonstrate both vulnerable and safe usage patterns for each check                                                                                                   
                                                                                                                                                                                        
  ### Files Modified                                                                                                                                                                    
                                                                                                                                                                                        
  - `crates/checks/src/lib.rs` - Added module declarations and registrations for all four checks                                                                                        
  - `crates/checks/src/invoke_return.rs` - New check implementation                                                                                                                     
  - `crates/checks/src/ttl_arg_order.rs` - New check implementation                                                                                                                     
  - `crates/checks/src/event_data_leak.rs` - New check implementation                                                                                                                   
  - `crates/checks/src/remove_without_has.rs` - New check implementation                                                                                                                
  - `test-contracts/invoke-return-vulnerable/` - New test contract                                                                                                                      
  - `test-contracts/invoke-return-safe/` - New test contract                                                                                                                            
  - `test-contracts/ttl-arg-order-vulnerable/` - New test contract                                                                                                                      
  - `test-contracts/ttl-arg-order-safe/` - New test contract                                                                                                                            
  - `test-contracts/event-data-leak-vulnerable/` - New test contract                                                                                                                    
  - `test-contracts/event-data-leak-safe/` - New test contract                                                                                                                          
  - `test-contracts/remove-without-has-vulnerable/` - New test contract                                                                                                                 
  - `test-contracts/remove-without-has-safe/` - New test contract                                                                                                                       
                                                                                                                                                                                        
  ### Closes                                                                                                                                                                            
                                                                                                                                                                                        
  Closes #28                                                                                                                                                                            
  Closes #29                                                                                                                                                                            
  Closes #30                                                                                                                                                                            
  Closes #31        