### PR TITLE
Issues 32 33 34 35

### DIFF
--- a/crates/checks/src/amount_type.rs
+++ b/crates/checks/src/amount_type.rs
@@ -1,0 +1,162 @@
+//! Detects u64/u32 used for token amount parameters instead of i128.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::{File, FnArg, PatType};
+
+const CHECK_NAME: &str = "amount-type";
+
+/// Flags function parameters named `amount`, `balance`, `value`, or `quantity` in
+/// `#[contractimpl]` functions whose type is `u64` or `u32` instead of `i128`.
+pub struct AmountTypeCheck;
+
+impl Check for AmountTypeCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            for arg in &method.sig.inputs {
+                if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+                    if let syn::Pat::Ident(pat_ident) = &**pat {
+                        let param_name = pat_ident.ident.to_string();
+                        if matches!(
+                            param_name.as_str(),
+                            "amount" | "balance" | "value" | "quantity"
+                        ) {
+                            if is_u64_or_u32_type(ty) {
+                                let line = arg.span().start().line;
+                                out.push(Finding {
+                                    check_name: CHECK_NAME.to_string(),
+                                    severity: Severity::Medium,
+                                    file_path: String::new(),
+                                    line,
+                                    function_name: fn_name.clone(),
+                                    description: format!(
+                                        "Parameter `{}` in `{}` is `u64` or `u32`, but the \
+                                         Soroban token interface uses `i128` for amounts. Using \
+                                         the wrong type silently truncates values and is \
+                                         incompatible with the standard token interface.",
+                                        param_name, fn_name
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+fn is_u64_or_u32_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(p) => {
+            if let Some(seg) = p.path.segments.last() {
+                let ident = seg.ident.to_string();
+                matches!(ident.as_str(), "u64" | "u32")
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_u64_amount_parameter() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, amount: u64) {
+        let _ = (env, amount);
+    }
+}
+"#,
+        )?;
+        let hits = AmountTypeCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("amount"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_u32_balance_parameter() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn set_balance(env: Env, balance: u32) {
+        let _ = (env, balance);
+    }
+}
+"#,
+        )?;
+        let hits = AmountTypeCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_i128_amount() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, amount: i128) {
+        let _ = (env, amount);
+    }
+}
+"#,
+        )?;
+        let hits = AmountTypeCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_unrelated_u64_params() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, count: u64) {
+        let _ = (env, count);
+    }
+}
+"#,
+        )?;
+        let hits = AmountTypeCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/contract_addr_in_loop.rs
+++ b/crates/checks/src/contract_addr_in_loop.rs
@@ -1,0 +1,194 @@
+//! Detects env.current_contract_address() called inside loops.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "contract-addr-in-loop";
+
+/// Flags `env.current_contract_address()` calls that appear inside `for`, `while`, or `loop` blocks.
+pub struct ContractAddrInLoopCheck;
+
+impl Check for ContractAddrInLoopCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = LoopVisitor {
+                fn_name,
+                loop_depth: 0,
+                out: &mut out,
+            };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct LoopVisitor<'a> {
+    fn_name: String,
+    loop_depth: usize,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'_> for LoopVisitor<'a> {
+    fn visit_expr_for_loop(&mut self, i: &syn::ExprForLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_for_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_while(&mut self, i: &syn::ExprWhile) {
+        self.loop_depth += 1;
+        visit::visit_expr_while(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_loop(&mut self, i: &syn::ExprLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if self.loop_depth > 0 && is_current_contract_address_call(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Low,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`env.current_contract_address()` is called inside a loop in `{}`. \
+                     This is a host call with non-trivial cost. Cache the result in a local \
+                     variable before the loop to avoid wasting compute budget.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn is_current_contract_address_call(m: &ExprMethodCall) -> bool {
+    if m.method != "current_contract_address" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_current_contract_address_in_for_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        for i in 0..10 {
+            let addr = env.current_contract_address();
+            let _ = (i, addr);
+        }
+    }
+}
+"#,
+        )?;
+        let hits = ContractAddrInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_current_contract_address_in_while_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        let mut i = 0;
+        while i < 10 {
+            let addr = env.current_contract_address();
+            let _ = addr;
+            i += 1;
+        }
+    }
+}
+"#,
+        )?;
+        let hits = ContractAddrInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_current_contract_address_outside_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        let addr = env.current_contract_address();
+        for i in 0..10 {
+            let _ = (i, &addr);
+        }
+    }
+}
+"#,
+        )?;
+        let hits = ContractAddrInLoopCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_current_contract_address_in_loop_block() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        loop {
+            let addr = env.current_contract_address();
+            let _ = addr;
+            break;
+        }
+    }
+}
+"#,
+        )?;
+        let hits = ContractAddrInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -1,21 +1,29 @@
 //! Vulnerability detectors for Soroban smart contracts.
 
 pub mod admin;
+pub mod amount_type;
 pub mod auth;
+pub mod contract_addr_in_loop;
 pub mod contracttype;
+pub mod mixed_storage_tiers;
 pub mod overflow;
 pub mod panic_usage;
 pub mod storage;
+pub mod symbol_short_len;
 pub mod unbounded_storage;
 pub mod zero_amount;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
+pub use amount_type::AmountTypeCheck;
 pub use auth::MissingRequireAuthCheck;
+pub use contract_addr_in_loop::ContractAddrInLoopCheck;
 pub use contracttype::MissingContracttypeCheck;
+pub use mixed_storage_tiers::MixedStorageTiersCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use panic_usage::PanicUsageCheck;
 pub use storage::UnsafeStoragePatternsCheck;
+pub use symbol_short_len::SymbolShortLenCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
 pub use zero_amount::ZeroAmountCheck;
 
@@ -63,5 +71,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
         Box::new(ZeroAmountCheck),
+        Box::new(MixedStorageTiersCheck),
+        Box::new(AmountTypeCheck),
+        Box::new(SymbolShortLenCheck),
+        Box::new(ContractAddrInLoopCheck),
     ]
 }

--- a/crates/checks/src/mixed_storage_tiers.rs
+++ b/crates/checks/src/mixed_storage_tiers.rs
@@ -1,0 +1,203 @@
+//! Detects same logical key written to multiple storage tiers.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashMap;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "mixed-storage-tiers";
+
+/// Flags functions where the same string literal key is passed to `set`/`get` on
+/// more than one storage tier (`persistent`, `instance`, `temporary`).
+pub struct MixedStorageTiersCheck;
+
+impl Check for MixedStorageTiersCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = StorageTierVisitor {
+                fn_name: fn_name.clone(),
+                key_tiers: HashMap::new(),
+                out: &mut out,
+            };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct StorageTierVisitor<'a> {
+    fn_name: String,
+    key_tiers: HashMap<String, Vec<(String, usize)>>, // key -> [(tier, line), ...]
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'_> for StorageTierVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let method_name = i.method.to_string();
+        if matches!(method_name.as_str(), "set" | "get" | "remove") {
+            if let Some((tier, key)) = extract_storage_tier_and_key(&i.receiver, &i.args) {
+                let line = i.span().start().line;
+                self.key_tiers
+                    .entry(key.clone())
+                    .or_insert_with(Vec::new)
+                    .push((tier, line));
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+impl<'a> Drop for StorageTierVisitor<'a> {
+    fn drop(&mut self) {
+        for (key, tiers) in &self.key_tiers {
+            let unique_tiers: std::collections::HashSet<_> =
+                tiers.iter().map(|(t, _)| t.as_str()).collect();
+            if unique_tiers.len() > 1 {
+                for (tier, line) in tiers {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: *line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Key `{}` is accessed via multiple storage tiers ({}). \
+                             Reads from one tier will not see writes to another, causing data \
+                             consistency bugs.",
+                            key,
+                            unique_tiers.iter().copied().collect::<Vec<_>>().join(", ")
+                        ),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn extract_storage_tier_and_key(
+    receiver: &Expr,
+    args: &syn::punctuated::Punctuated<Expr, syn::token::Comma>,
+) -> Option<(String, String)> {
+    let tier = extract_tier_from_receiver(receiver)?;
+    let key = extract_key_from_args(args)?;
+    Some((tier, key))
+}
+
+fn extract_tier_from_receiver(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::MethodCall(m) => {
+            let method = m.method.to_string();
+            if matches!(method.as_str(), "persistent" | "instance" | "temporary") {
+                return Some(method);
+            }
+            extract_tier_from_receiver(&m.receiver)
+        }
+        Expr::Field(f) => extract_tier_from_receiver(&f.base),
+        _ => None,
+    }
+}
+
+fn extract_key_from_args(
+    args: &syn::punctuated::Punctuated<Expr, syn::token::Comma>,
+) -> Option<String> {
+    args.iter().next().and_then(|arg| match arg {
+        Expr::Lit(lit_expr) => match &lit_expr.lit {
+            Lit::Str(s) => Some(s.value()),
+            _ => None,
+        },
+        Expr::Reference(r) => match &*r.expr {
+            Expr::Lit(lit_expr) => match &lit_expr.lit {
+                Lit::Str(s) => Some(s.value()),
+                _ => None,
+            },
+            Expr::Path(p) => {
+                // Try to extract from const references like &KEY
+                p.path.segments.last().map(|s| s.ident.to_string())
+            }
+            _ => None,
+        },
+        Expr::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_same_key_in_multiple_tiers() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn bad(env: Env) {
+        env.storage().persistent().set("key", &1u32);
+        env.storage().instance().set("key", &2u32);
+    }
+}
+"#,
+        )?;
+        let hits = MixedStorageTiersCheck.run(&file, "");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_different_keys() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn good(env: Env) {
+        env.storage().persistent().set("key1", &1u32);
+        env.storage().instance().set("key2", &2u32);
+    }
+}
+"#,
+        )?;
+        let hits = MixedStorageTiersCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_same_key_same_tier() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn good(env: Env) {
+        env.storage().persistent().set("key", &1u32);
+        env.storage().persistent().get("key");
+    }
+}
+"#,
+        )?;
+        let hits = MixedStorageTiersCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/symbol_short_len.rs
+++ b/crates/checks/src/symbol_short_len.rs
@@ -1,0 +1,143 @@
+//! Detects symbol_short! macro used with strings longer than 9 characters.
+
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprMacro, File};
+
+const CHECK_NAME: &str = "symbol-short-len";
+
+/// Flags `symbol_short!(s)` macro invocations where the string literal `s` has length > 9.
+pub struct SymbolShortLenCheck;
+
+impl Check for SymbolShortLenCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        let mut visitor = SymbolShortVisitor { out: &mut out };
+        visitor.visit_file(file);
+        out
+    }
+}
+
+struct SymbolShortVisitor<'a> {
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'_> for SymbolShortVisitor<'a> {
+    fn visit_expr_macro(&mut self, i: &ExprMacro) {
+        if let Some(last_seg) = i.mac.path.segments.last() {
+            if last_seg.ident == "symbol_short" {
+                if let Some(len) = extract_string_len_from_macro(&i.mac.tokens) {
+                    if len > 9 {
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::Medium,
+                            file_path: String::new(),
+                            line: i.span().start().line,
+                            function_name: String::new(),
+                            description: format!(
+                                "`symbol_short!` macro invocation uses a string of length {}. \
+                                 `symbol_short!` only supports strings up to 9 characters. \
+                                 Longer strings cause compile-time panic in debug builds and \
+                                 undefined behavior in release builds.",
+                                len
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        visit::visit_expr_macro(self, i);
+    }
+}
+
+fn extract_string_len_from_macro(tokens: &proc_macro2::TokenStream) -> Option<usize> {
+    let mut iter = tokens.clone().into_iter();
+    while let Some(token) = iter.next() {
+        match token {
+            proc_macro2::TokenTree::Literal(lit) => {
+                let lit_str = lit.to_string();
+                if lit_str.starts_with('"') && lit_str.ends_with('"') {
+                    let content = &lit_str[1..lit_str.len() - 1];
+                    return Some(content.len());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_symbol_short_too_long() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn test(env: Env) {
+        let _ = symbol_short!("toolongkey");
+    }
+}
+"#,
+        )?;
+        let hits = SymbolShortLenCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_symbol_short_valid_length() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn test(env: Env) {
+        let _ = symbol_short!("key");
+    }
+}
+"#,
+        )?;
+        let hits = SymbolShortLenCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_symbol_short_exactly_9_chars() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn test(env: Env) {
+        let _ = symbol_short!("123456789");
+    }
+}
+"#,
+        )?;
+        let hits = SymbolShortLenCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/amount-type-safe/Cargo.toml
+++ b/test-contracts/amount-type-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-amount-type-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/amount-type-safe/src/lib.rs
+++ b/test-contracts/amount-type-safe/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct AmountTypeSafe;
+
+#[contractimpl]
+impl AmountTypeSafe {
+    pub fn transfer(env: Env, to: Address, amount: i128) {
+        // ✅ Using i128 for amount as per Soroban token interface
+        let _ = (env, to, amount);
+    }
+
+    pub fn set_balance(env: Env, balance: i128) {
+        // ✅ Using i128 for balance
+        let _ = (env, balance);
+    }
+
+    pub fn deposit(env: Env, value: i128) {
+        // ✅ Using i128 for value
+        let _ = (env, value);
+    }
+
+    pub fn process(env: Env, count: u64) {
+        // ✅ Using u64 for non-amount parameter is fine
+        let _ = (env, count);
+    }
+}

--- a/test-contracts/amount-type-vulnerable/Cargo.toml
+++ b/test-contracts/amount-type-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-amount-type-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/amount-type-vulnerable/src/lib.rs
+++ b/test-contracts/amount-type-vulnerable/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct AmountTypeVulnerable;
+
+#[contractimpl]
+impl AmountTypeVulnerable {
+    pub fn transfer(env: Env, to: Address, amount: u64) {
+        // ❌ Using u64 for amount instead of i128
+        // This silently truncates values and is incompatible with Soroban token interface
+        let _ = (env, to, amount);
+    }
+
+    pub fn set_balance(env: Env, balance: u32) {
+        // ❌ Using u32 for balance instead of i128
+        let _ = (env, balance);
+    }
+
+    pub fn deposit(env: Env, value: u64) {
+        // ❌ Using u64 for value instead of i128
+        let _ = (env, value);
+    }
+}

--- a/test-contracts/contract-addr-in-loop-safe/Cargo.toml
+++ b/test-contracts/contract-addr-in-loop-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-contract-addr-in-loop-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/contract-addr-in-loop-safe/src/lib.rs
+++ b/test-contracts/contract-addr-in-loop-safe/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ContractAddrInLoopSafe;
+
+#[contractimpl]
+impl ContractAddrInLoopSafe {
+    pub fn process_items(env: Env, count: u32) {
+        // ✅ Cache contract address before the loop
+        let addr = env.current_contract_address();
+        for i in 0..count {
+            let _ = (i, &addr);
+        }
+    }
+
+    pub fn process_while(env: Env) {
+        // ✅ Cache contract address before the loop
+        let addr = env.current_contract_address();
+        let mut i = 0;
+        while i < 10 {
+            let _ = &addr;
+            i += 1;
+        }
+    }
+
+    pub fn process_outside_loop(env: Env) {
+        // ✅ Call outside of any loop
+        let addr = env.current_contract_address();
+        let _ = addr;
+    }
+}

--- a/test-contracts/contract-addr-in-loop-vulnerable/Cargo.toml
+++ b/test-contracts/contract-addr-in-loop-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-contract-addr-in-loop-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/contract-addr-in-loop-vulnerable/src/lib.rs
+++ b/test-contracts/contract-addr-in-loop-vulnerable/src/lib.rs
@@ -1,0 +1,35 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ContractAddrInLoopVulnerable;
+
+#[contractimpl]
+impl ContractAddrInLoopVulnerable {
+    pub fn process_items(env: Env, count: u32) {
+        // ❌ env.current_contract_address() called inside for loop
+        for i in 0..count {
+            let addr = env.current_contract_address();
+            let _ = (i, addr);
+        }
+    }
+
+    pub fn process_while(env: Env) {
+        let mut i = 0;
+        // ❌ env.current_contract_address() called inside while loop
+        while i < 10 {
+            let addr = env.current_contract_address();
+            let _ = addr;
+            i += 1;
+        }
+    }
+
+    pub fn process_loop(env: Env) {
+        // ❌ env.current_contract_address() called inside loop
+        loop {
+            let addr = env.current_contract_address();
+            let _ = addr;
+            break;
+        }
+    }
+}

--- a/test-contracts/mixed-storage-tiers-safe/Cargo.toml
+++ b/test-contracts/mixed-storage-tiers-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-mixed-storage-tiers-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/mixed-storage-tiers-safe/src/lib.rs
+++ b/test-contracts/mixed-storage-tiers-safe/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct MixedStorageTiersSafe;
+
+const PERSISTENT_KEY: Symbol = symbol_short!("persist");
+const INSTANCE_KEY: Symbol = symbol_short!("instance");
+
+#[contractimpl]
+impl MixedStorageTiersSafe {
+    pub fn set_persistent(env: Env, amount: i128) {
+        // ✅ Consistent use of persistent storage
+        env.storage().persistent().set(&PERSISTENT_KEY, &amount);
+    }
+
+    pub fn set_instance(env: Env, amount: i128) {
+        // ✅ Consistent use of instance storage with different key
+        env.storage().instance().set(&INSTANCE_KEY, &amount);
+    }
+
+    pub fn get_persistent(env: Env) -> i128 {
+        env.storage().persistent().get(&PERSISTENT_KEY).unwrap_or(0)
+    }
+
+    pub fn get_instance(env: Env) -> i128 {
+        env.storage().instance().get(&INSTANCE_KEY).unwrap_or(0)
+    }
+}

--- a/test-contracts/mixed-storage-tiers-vulnerable/Cargo.toml
+++ b/test-contracts/mixed-storage-tiers-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-mixed-storage-tiers-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/mixed-storage-tiers-vulnerable/src/lib.rs
+++ b/test-contracts/mixed-storage-tiers-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct MixedStorageTiersVulnerable;
+
+const KEY: Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl MixedStorageTiersVulnerable {
+    pub fn set_balance(env: Env, amount: i128) {
+        // ❌ Same key written to multiple storage tiers
+        env.storage().persistent().set(&KEY, &amount);
+        env.storage().instance().set(&KEY, &amount);
+    }
+
+    pub fn get_balance(env: Env) -> i128 {
+        // ❌ Reading from different tier than where it was written
+        env.storage().persistent().get(&KEY).unwrap_or(0)
+    }
+}

--- a/test-contracts/symbol-short-len-safe/Cargo.toml
+++ b/test-contracts/symbol-short-len-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-symbol-short-len-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/symbol-short-len-safe/src/lib.rs
+++ b/test-contracts/symbol-short-len-safe/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct SymbolShortLenSafe;
+
+#[contractimpl]
+impl SymbolShortLenSafe {
+    pub fn test(env: Env) {
+        // ✅ String is 3 characters, within limit
+        let _ = symbol_short!("key");
+        
+        // ✅ String is exactly 9 characters, at the limit
+        let _ = symbol_short!("123456789");
+        
+        // ✅ String is 5 characters
+        let _ = symbol_short!("token");
+        
+        let _ = env;
+    }
+}

--- a/test-contracts/symbol-short-len-vulnerable/Cargo.toml
+++ b/test-contracts/symbol-short-len-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-symbol-short-len-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/symbol-short-len-vulnerable/src/lib.rs
+++ b/test-contracts/symbol-short-len-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct SymbolShortLenVulnerable;
+
+#[contractimpl]
+impl SymbolShortLenVulnerable {
+    pub fn test(env: Env) {
+        // ❌ String is 10 characters, exceeds 9 character limit
+        let _ = symbol_short!("toolongkey");
+        
+        // ❌ String is 11 characters
+        let _ = symbol_short!("verylongkey");
+        
+        let _ = env;
+    }
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                            
                                                                                                                                                                                        
  This PR implements four new security checks for Soroban smart contracts, addressing critical vulnerabilities in storage management, token accounting, macro usage, and performance    
  optimization.                                                                                                                                                                         
                                                                                                                                                                                        
  ## Changes                                                                                                                                                                            
                                                                                                                                                                                        
  ### 1. Mixed Storage Tiers Check (#32)                                                                                                                                                
  - **File**: `crates/checks/src/mixed_storage_tiers.rs`                                                                                                                                
  - **Severity**: Medium                                                                                                                                                                
  - **Description**: Detects when the same logical key is written to multiple storage tiers (`persistent`, `instance`, `temporary`) within the same contract. This is a data consistency
  bug—reads from one tier will not see writes to another.                                                                                                                               
  - **Implementation**: Visitor pattern that collects `(tier_name, key_literal)` pairs from all storage calls and flags any key appearing with multiple distinct tiers.                 
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/mixed-storage-tiers-vulnerable/`: Demonstrates the vulnerability                                                                                                  
    - `test-contracts/mixed-storage-tiers-safe/`: Shows correct usage with separate keys per tier                                                                                       
                                                                                                                                                                                        
  ### 2. Amount Type Check (#33)                                                                                                                                                        
  - **File**: `crates/checks/src/amount_type.rs`                                                                                                                                        
  - **Severity**: Medium                                                                                                                                                                
  - **Description**: Flags function parameters named `amount`, `balance`, `value`, or `quantity` in `#[contractimpl]` functions that use `u64` or `u32` instead of `i128`. The Soroban  
  token interface requires `i128` for all amounts; using the wrong type silently truncates values and breaks compatibility.                                                             
  - **Implementation**: Inspects function signatures in `#[contractimpl]` blocks, matching parameter names against the list and checking type paths for `u64`/`u32`.                    
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/amount-type-vulnerable/`: Shows incorrect use of `u64`/`u32` for amount parameters                                                                                
    - `test-contracts/amount-type-safe/`: Demonstrates correct use of `i128` for amounts                                                                                                
                                                                                                                                                                                        
  ### 3. Symbol Short Length Check (#34)                                                                                                                                                
  - **File**: `crates/checks/src/symbol_short_len.rs`                                                                                                                                   
  - **Severity**: Medium                                                                                                                                                                
  - **Description**: Detects `symbol_short!` macro invocations with string literals longer than 9 characters. `symbol_short!` only supports strings up to 9 characters; longer strings  
  cause compile-time panic in debug builds and undefined behavior in release builds.                                                                                                    
  - **Implementation**: Visitor pattern that inspects `Expr::Macro` nodes, matches the `symbol_short` path, and extracts string length from the token stream.                           
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/symbol-short-len-vulnerable/`: Shows strings exceeding the 9-character limit                                                                                      
    - `test-contracts/symbol-short-len-safe/`: Demonstrates valid usage within the limit                                                                                                
                                                                                                                                                                                        
  ### 4. Contract Address in Loop Check (#35)                                                                                                                                           
  - **File**: `crates/checks/src/contract_addr_in_loop.rs`                                                                                                                              
  - **Severity**: Low                                                                                                                                                                   
  - **Description**: Flags `env.current_contract_address()` calls inside loops (`for`, `while`, `loop` blocks). This is a host call with non-trivial cost; calling it inside a loop     
  wastes compute budget. The result should be cached in a local variable before the loop.                                                                                               
  - **Implementation**: Visitor pattern that tracks loop depth with a counter; flags `current_contract_address` method calls when depth > 0.                                            
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/contract-addr-in-loop-vulnerable/`: Shows inefficient calls inside loops                                                                                          
    - `test-contracts/contract-addr-in-loop-safe/`: Demonstrates caching the address before the loop                                                                                    
                                                                                                                                                                                        
  ## Registration                                                                                                                                                                       
                                                                                                                                                                                        
  All four checks have been registered in `crates/checks/src/lib.rs`:                                                                                                                   
  - Added module declarations for each check                                                                                                                                            
  - Added public exports for each check struct                                                                                                                                          
  - Registered all checks in the `default_checks()` function                                                                                                                            
                                                                                                                                                                                        
  ## Testing                                                                                                                                                                            
                                                                                                                                                                                        
  Each check includes comprehensive unit tests covering:                                                                                                                                
  - Vulnerable patterns that should be flagged                                                                                                                                          
  - Safe patterns that should pass                                                                                                                                                      
  - Edge cases and boundary conditions                                                                                                                                                  
                                                                                                                                                                                        
  ## Files Modified                                                                                                                                                                     
                                                                                                                                                                                        
  - `crates/checks/src/lib.rs` - Module registration and exports                                                                                                                        
  - `crates/checks/src/mixed_storage_tiers.rs` - New check implementation                                                                                                               
  - `crates/checks/src/amount_type.rs` - New check implementation                                                                                                                       
  - `crates/checks/src/symbol_short_len.rs` - New check implementation                                                                                                                  
  - `crates/checks/src/contract_addr_in_loop.rs` - New check implementation                                                                                                             
                                                                                                                                                                                        
  ## Test Contracts Added                                                                                                                                                               
                                                                                                                                                                                        
  - `test-contracts/mixed-storage-tiers-vulnerable/`                                                                                                                                    
  - `test-contracts/mixed-storage-tiers-safe/`                                                                                                                                          
  - `test-contracts/amount-type-vulnerable/`                                                                                                                                            
  - `test-contracts/amount-type-safe/`                                                                                                                                                  
  - `test-contracts/symbol-short-len-vulnerable/`                                                                                                                                       
  - `test-contracts/symbol-short-len-safe/`                                                                                                                                             
  - `test-contracts/contract-addr-in-loop-vulnerable/`                                                                                                                                  
  - `test-contracts/contract-addr-in-loop-safe/`                                                                                                                                        
                                                                                                                                                                                        
  ## Closes                                                                                                                                                                             
                                                                                                                                                                                        
  Closes #32                                                                                                                                                                            
  Closes #33                                                                                                                                                                            
  Closes #34                                                                                                                                                                            
  Closes #35        