### PR TITLE
Issues 36 37 38 39

### DIFF
--- a/crates/checks/src/auth_after_write.rs
+++ b/crates/checks/src/auth_after_write.rs
@@ -1,0 +1,249 @@
+//! require_auth() called after state mutation (TOCTOU).
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "auth-after-write";
+
+/// Flags `#[contractimpl]` functions where `env.require_auth()` appears
+/// *after* the first `env.storage()...set(...)` call in statement order.
+pub struct AuthAfterWriteCheck;
+
+impl Check for AuthAfterWriteCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = AuthWriteVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_set_call(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn is_env_require_auth(m: &ExprMethodCall) -> bool {
+    if m.method != "require_auth" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+struct AuthWriteVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for AuthWriteVisitor<'ast> {
+    fn visit_block(&mut self, i: &'ast Block) {
+        let mut first_set_idx: Option<usize> = None;
+        let mut first_auth_idx: Option<usize> = None;
+
+        for (idx, stmt) in i.stmts.iter().enumerate() {
+            let mut set_finder = SetFinder { found: false };
+            set_finder.visit_stmt(stmt);
+            if set_finder.found && first_set_idx.is_none() {
+                first_set_idx = Some(idx);
+            }
+
+            let mut auth_finder = AuthFinder { found: false };
+            auth_finder.visit_stmt(stmt);
+            if auth_finder.found && first_auth_idx.is_none() {
+                first_auth_idx = Some(idx);
+            }
+        }
+
+        // If set comes before auth, flag it
+        if let (Some(set_idx), Some(auth_idx)) = (first_set_idx, first_auth_idx) {
+            if set_idx < auth_idx {
+                // Find the line of the first set call
+                for stmt in &i.stmts {
+                    let mut line_finder = FirstSetLineFinder { line: None };
+                    line_finder.visit_stmt(stmt);
+                    if let Some(line) = line_finder.line {
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Method `{}` calls `env.require_auth()` *after* a storage write. \
+                                 Authorization must be checked *before* any state mutation to \
+                                 prevent TOCTOU (time-of-check/time-of-use) vulnerabilities.",
+                                self.fn_name
+                            ),
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        visit::visit_block(self, i);
+    }
+}
+
+struct SetFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for SetFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_storage_set_call(i) {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct AuthFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for AuthFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_env_require_auth(i) {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct FirstSetLineFinder {
+    line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for FirstSetLineFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line.is_none() && is_storage_set_call(i) {
+            self.line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_require_auth_after_storage_write() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn bad_order(env: Env, user: Address, amount: i128) {
+        env.storage().instance().set(&Symbol::new(&env, "bal"), &amount);
+        env.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AuthAfterWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "bad_order");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_auth_before_write() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn good_order(env: Env, user: Address, amount: i128) {
+        env.require_auth();
+        env.storage().instance().set(&Symbol::new(&env, "bal"), &amount);
+    }
+}
+"#,
+        )?;
+        let hits = AuthAfterWriteCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_no_storage_write() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn read_only(env: Env, user: Address) {
+        env.require_auth();
+        let _ = (env, user);
+    }
+}
+"#,
+        )?;
+        let hits = AuthAfterWriteCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_no_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn no_auth(env: Env, amount: i128) {
+        env.storage().instance().set(&Symbol::new(&env, "bal"), &amount);
+    }
+}
+"#,
+        )?;
+        let hits = AuthAfterWriteCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/contracttype.rs
+++ b/crates/checks/src/contracttype.rs
@@ -89,7 +89,7 @@ fn has_contracttype_attr<T: HasAttrs>(item: &T) -> bool {
         // #[derive(...contracttype...)]
         if attr.path().is_ident("derive") {
             if let syn::Meta::List(meta_list) = &attr.meta {
-                if meta_list.input.to_string().contains("contracttype") {
+                if meta_list.tokens.to_string().contains("contracttype") {
                     return true;
                 }
             }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -2,21 +2,29 @@
 
 pub mod admin;
 pub mod auth;
+pub mod auth_after_write;
 pub mod contracttype;
+pub mod negative_balance;
 pub mod overflow;
 pub mod panic_usage;
+pub mod persistent_set_in_loop;
 pub mod storage;
 pub mod unbounded_storage;
+pub mod upload_wasm_auth;
 pub mod zero_amount;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
 pub use auth::MissingRequireAuthCheck;
+pub use auth_after_write::AuthAfterWriteCheck;
 pub use contracttype::MissingContracttypeCheck;
+pub use negative_balance::NegativeBalanceCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use panic_usage::PanicUsageCheck;
+pub use persistent_set_in_loop::PersistentSetInLoopCheck;
 pub use storage::UnsafeStoragePatternsCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
+pub use upload_wasm_auth::UploadWasmAuthCheck;
 pub use zero_amount::ZeroAmountCheck;
 
 use serde::Serialize;
@@ -63,5 +71,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
         Box::new(ZeroAmountCheck),
+        Box::new(PersistentSetInLoopCheck),
+        Box::new(AuthAfterWriteCheck),
+        Box::new(UploadWasmAuthCheck),
+        Box::new(NegativeBalanceCheck),
     ]
 }

--- a/crates/checks/src/negative_balance.rs
+++ b/crates/checks/src/negative_balance.rs
@@ -1,0 +1,276 @@
+//! i128 subtraction result stored without underflow guard.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Block, Expr, ExprBinary, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "negative-balance";
+
+/// Flags `BinOp::Sub` expressions in `#[contractimpl]` functions where the result
+/// is passed directly to `env.storage()...set(...)` without a preceding `>=` or `>`
+/// comparison involving the same operands.
+pub struct NegativeBalanceCheck;
+
+impl Check for NegativeBalanceCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = SubtractionVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_set_call(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p.path.segments.iter().map(|s| s.ident.to_string()).collect::<Vec<_>>().join("::"),
+        Expr::Field(f) => {
+            let member_str = match &f.member {
+                syn::Member::Named(ident) => ident.to_string(),
+                syn::Member::Unnamed(idx) => idx.index.to_string(),
+            };
+            format!("{}.{}", expr_to_string(&f.base), member_str)
+        }
+        _ => String::new(),
+    }
+}
+
+
+
+struct SubtractionVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for SubtractionVisitor<'ast> {
+    fn visit_block(&mut self, i: &'ast Block) {
+        // Only process the top-level block, not nested blocks
+        // Collect all comparisons in this block and nested blocks
+        let mut comp_finder = AllComparisonsFinder {
+            comparisons: Vec::new(),
+        };
+        comp_finder.visit_block(i);
+
+        // Check each statement for storage set calls with subtraction
+        for stmt in &i.stmts {
+            let mut set_finder = SetWithSubFinder {
+                subs: Vec::new(),
+            };
+            set_finder.visit_stmt(stmt);
+
+            for (sub_expr, line) in set_finder.subs {
+                let left_str = expr_to_string(&sub_expr.left);
+                let right_str = expr_to_string(&sub_expr.right);
+                
+                // Check if there's a matching comparison anywhere in the function
+                let has_guard = !left_str.is_empty() && !right_str.is_empty() && 
+                    comp_finder.comparisons.iter().any(|(l, r)| {
+                        (l == &left_str && r == &right_str) || (l == &right_str && r == &left_str)
+                    });
+
+                if !has_guard {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` stores the result of a subtraction directly to \
+                             storage without checking that the minuend is >= the subtrahend. \
+                             This can produce negative balances, allowing overdrafts.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Don't call visit_block recursively - we've already processed all statements
+    }
+}
+
+struct AllComparisonsFinder {
+    comparisons: Vec<(String, String)>,
+}
+
+impl<'ast> Visit<'ast> for AllComparisonsFinder {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if matches!(i.op, BinOp::Ge(_) | BinOp::Gt(_)) {
+            let left_str = expr_to_string(&i.left);
+            let right_str = expr_to_string(&i.right);
+            if !left_str.is_empty() && !right_str.is_empty() {
+                self.comparisons.push((left_str, right_str));
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+struct SetWithSubFinder {
+    subs: Vec<(&'static ExprBinary, usize)>,
+}
+
+impl<'ast> Visit<'ast> for SetWithSubFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_storage_set_call(i) {
+            // Check if any argument is a subtraction
+            for arg in &i.args {
+                let mut sub_finder = SubFinder {
+                    subs: Vec::new(),
+                };
+                sub_finder.visit_expr(arg);
+                for (sub_expr, line) in sub_finder.subs {
+                    // SAFETY: We're storing a reference to an expression from the AST.
+                    // This is safe because the AST is owned by the File and lives for the
+                    // duration of the check.
+                    self.subs.push((unsafe { std::mem::transmute(sub_expr) }, line));
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct SubFinder {
+    subs: Vec<(&'static ExprBinary, usize)>,
+}
+
+impl<'ast> Visit<'ast> for SubFinder {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if matches!(i.op, BinOp::Sub(_)) {
+            let line = i.span().start().line;
+            // SAFETY: Same as above
+            self.subs.push((unsafe { std::mem::transmute(i) }, line));
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_subtraction_stored_without_guard() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        env.storage().instance().set(&Symbol::new(&env, "bal"), &(balance - amount));
+    }
+}
+"#,
+        )?;
+        let hits = NegativeBalanceCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "withdraw");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_ge_guard() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        if balance >= amount {
+            env.storage().instance().set(&Symbol::new(&env, "bal"), &(balance - amount));
+        }
+    }
+}
+"#,
+        )?;
+        let hits = NegativeBalanceCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_gt_guard() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        if balance > amount {
+            env.storage().instance().set(&Symbol::new(&env, "bal"), &(balance - amount));
+        }
+    }
+}
+"#,
+        )?;
+        let hits = NegativeBalanceCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::Env;
+
+pub struct C;
+
+impl C {
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        env.storage().instance().set(&Symbol::new(&env, "bal"), &(balance - amount));
+    }
+}
+"#,
+        )?;
+        let hits = NegativeBalanceCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/persistent_set_in_loop.rs
+++ b/crates/checks/src/persistent_set_in_loop.rs
@@ -1,0 +1,260 @@
+//! Persistent storage set() inside loops without extend_ttl.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File, Stmt};
+
+const CHECK_NAME: &str = "persistent-set-in-loop";
+
+/// Flags `env.storage().persistent().set(...)` calls inside loop bodies
+/// that are not accompanied by an `extend_ttl` call in the same loop body.
+pub struct PersistentSetInLoopCheck;
+
+impl Check for PersistentSetInLoopCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = LoopVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+                in_loop: false,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_persistent(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "persistent" {
+                return true;
+            }
+            receiver_chain_contains_persistent(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_persistent(&f.base),
+        _ => false,
+    }
+}
+
+fn is_persistent_set_call(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_persistent(&m.receiver)
+}
+
+fn is_persistent_extend_ttl_call(m: &ExprMethodCall) -> bool {
+    m.method == "extend_ttl" && receiver_chain_contains_persistent(&m.receiver)
+}
+
+struct LoopVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    in_loop: bool,
+}
+
+impl<'ast> Visit<'ast> for LoopVisitor<'ast> {
+    fn visit_block(&mut self, i: &'ast Block) {
+        if self.in_loop {
+            // We're already in a loop; check for set/extend_ttl in this block
+            let mut has_set = false;
+            let mut has_extend_ttl = false;
+
+            for stmt in &i.stmts {
+                let mut stmt_visitor = StmtVisitor {
+                    has_set: &mut has_set,
+                    has_extend_ttl: &mut has_extend_ttl,
+                };
+                stmt_visitor.visit_stmt(stmt);
+            }
+
+            if has_set && !has_extend_ttl {
+                // Find the line of the first set call
+                for stmt in &i.stmts {
+                    let mut line_finder = FirstSetLineFinder { line: None };
+                    line_finder.visit_stmt(stmt);
+                    if let Some(line) = line_finder.line {
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::Medium,
+                            file_path: String::new(),
+                            line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Method `{}` calls `env.storage().persistent().set()` inside a \
+                                 loop without calling `extend_ttl()` in the same loop body. \
+                                 Each persistent write should be paired with `extend_ttl()` to \
+                                 ensure consistent TTL across entries.",
+                                self.fn_name
+                            ),
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Visit loop bodies with in_loop = true
+        let was_in_loop = self.in_loop;
+        for stmt in &i.stmts {
+            match stmt {
+                Stmt::Expr(Expr::ForLoop(fl), _) => {
+                    self.in_loop = true;
+                    self.visit_block(&fl.body);
+                    self.in_loop = was_in_loop;
+                }
+                Stmt::Expr(Expr::While(wl), _) => {
+                    self.in_loop = true;
+                    self.visit_block(&wl.body);
+                    self.in_loop = was_in_loop;
+                }
+                Stmt::Expr(Expr::Loop(l), _) => {
+                    self.in_loop = true;
+                    self.visit_block(&l.body);
+                    self.in_loop = was_in_loop;
+                }
+                _ => {
+                    self.visit_stmt(stmt);
+                }
+            }
+        }
+    }
+}
+
+struct StmtVisitor<'a> {
+    has_set: &'a mut bool,
+    has_extend_ttl: &'a mut bool,
+}
+
+impl<'ast> Visit<'ast> for StmtVisitor<'ast> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_persistent_set_call(i) {
+            *self.has_set = true;
+        }
+        if is_persistent_extend_ttl_call(i) {
+            *self.has_extend_ttl = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct FirstSetLineFinder {
+    line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for FirstSetLineFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line.is_none() && is_persistent_set_call(i) {
+            self.line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_persistent_set_in_for_loop_without_extend_ttl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn batch_set(env: Env, keys: Vec<Symbol>, values: Vec<u32>) {
+        for i in 0..keys.len() {
+            env.storage().persistent().set(&keys[i], &values[i]);
+        }
+    }
+}
+"#,
+        )?;
+        let hits = PersistentSetInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].function_name, "batch_set");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_extend_ttl_present_in_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn batch_set(env: Env, keys: Vec<Symbol>, values: Vec<u32>) {
+        for i in 0..keys.len() {
+            env.storage().persistent().set(&keys[i], &values[i]);
+            env.storage().persistent().extend_ttl(&keys[i], 100, 200);
+        }
+    }
+}
+"#,
+        )?;
+        let hits = PersistentSetInLoopCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_persistent_set_in_while_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn loop_set(env: Env, key: Symbol, value: u32) {
+        let mut i = 0;
+        while i < 10 {
+            env.storage().persistent().set(&key, &value);
+            i += 1;
+        }
+    }
+}
+"#,
+        )?;
+        let hits = PersistentSetInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_persistent_set_outside_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn set_once(env: Env, key: Symbol, value: u32) {
+        env.storage().persistent().set(&key, &value);
+    }
+}
+"#,
+        )?;
+        let hits = PersistentSetInLoopCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/upload_wasm_auth.rs
+++ b/crates/checks/src/upload_wasm_auth.rs
@@ -1,0 +1,214 @@
+//! env.deployer().upload_contract_wasm() called without authorization.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "upload-wasm-auth";
+
+/// Flags `#[contractimpl]` functions that call `env.deployer().upload_contract_wasm(...)`
+/// without a preceding `require_auth` or `require_auth_for_args` call.
+pub struct UploadWasmAuthCheck;
+
+impl Check for UploadWasmAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let mut scan = FuncBodyScan::default();
+            scan.visit_block(&method.block);
+            if !scan.upload_wasm || scan.env_require_auth {
+                continue;
+            }
+            let line = first_upload_wasm_line(&method.block)
+                .unwrap_or_else(|| method.sig.ident.span().start().line);
+            let fn_name = method.sig.ident.to_string();
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: fn_name.clone(),
+                description: format!(
+                    "Method `{fn_name}` calls `env.deployer().upload_contract_wasm()` but does \
+                     not call `env.require_auth()` or `env.require_auth_for_args()`. Any caller \
+                     can upload arbitrary WASM under the contract's deployer identity."
+                ),
+            });
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_deployer(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "deployer" {
+                return true;
+            }
+            receiver_chain_contains_deployer(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_deployer(&f.base),
+        _ => false,
+    }
+}
+
+fn is_upload_contract_wasm_call(m: &ExprMethodCall) -> bool {
+    m.method == "upload_contract_wasm" && receiver_chain_contains_deployer(&m.receiver)
+}
+
+fn is_env_require_auth(m: &ExprMethodCall) -> bool {
+    if m.method != "require_auth" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+fn is_env_require_auth_for_args(m: &ExprMethodCall) -> bool {
+    if m.method != "require_auth_for_args" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct FuncBodyScan {
+    upload_wasm: bool,
+    env_require_auth: bool,
+}
+
+impl<'ast> Visit<'ast> for FuncBodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_upload_contract_wasm_call(i) {
+            self.upload_wasm = true;
+        }
+        if is_env_require_auth(i) || is_env_require_auth_for_args(i) {
+            self.env_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct FirstUploadWasmLine {
+    line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for FirstUploadWasmLine {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line.is_none() && is_upload_contract_wasm_call(i) {
+            self.line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn first_upload_wasm_line(block: &Block) -> Option<usize> {
+    let mut v = FirstUploadWasmLine { line: None };
+    v.visit_block(block);
+    v.line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_upload_wasm_without_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UploadWasmAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "upload");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_env_require_auth_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.require_auth();
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UploadWasmAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_env_require_auth_for_args_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.require_auth_for_args((wasm.clone(),));
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UploadWasmAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::Env;
+
+pub struct C;
+
+impl C {
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}
+"#,
+        )?;
+        let hits = UploadWasmAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/auth-after-write-safe/Cargo.toml
+++ b/test-contracts/auth-after-write-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-auth-after-write-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/auth-after-write-safe/src/lib.rs
+++ b/test-contracts/auth-after-write-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct AuthAfterWriteSafe;
+
+const KEY: Symbol = symbol_short!("owner");
+
+#[contractimpl]
+impl AuthAfterWriteSafe {
+    /// Calls require_auth before storage write — should pass.
+    pub fn set_owner(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage().instance().set(&KEY, &new_owner);
+    }
+}

--- a/test-contracts/auth-after-write-vulnerable/Cargo.toml
+++ b/test-contracts/auth-after-write-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-auth-after-write-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/auth-after-write-vulnerable/src/lib.rs
+++ b/test-contracts/auth-after-write-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct AuthAfterWriteVulnerable;
+
+const KEY: Symbol = symbol_short!("owner");
+
+#[contractimpl]
+impl AuthAfterWriteVulnerable {
+    /// Calls require_auth after storage write — should trigger check.
+    pub fn set_owner(env: Env, new_owner: Address) {
+        env.storage().instance().set(&KEY, &new_owner);
+        env.require_auth();
+    }
+}

--- a/test-contracts/negative-balance-safe/Cargo.toml
+++ b/test-contracts/negative-balance-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-negative-balance-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/negative-balance-safe/src/lib.rs
+++ b/test-contracts/negative-balance-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct NegativeBalanceSafe;
+
+const BALANCE_KEY: Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl NegativeBalanceSafe {
+    /// Checks for underflow before subtracting — should pass.
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        if balance >= amount {
+            env.storage().instance().set(&BALANCE_KEY, &(balance - amount));
+        }
+    }
+}

--- a/test-contracts/negative-balance-vulnerable/Cargo.toml
+++ b/test-contracts/negative-balance-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-negative-balance-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/negative-balance-vulnerable/src/lib.rs
+++ b/test-contracts/negative-balance-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct NegativeBalanceVulnerable;
+
+const BALANCE_KEY: Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl NegativeBalanceVulnerable {
+    /// Subtracts without checking for underflow — should trigger check.
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = 100;
+        env.storage().instance().set(&BALANCE_KEY, &(balance - amount));
+    }
+}

--- a/test-contracts/persistent-set-in-loop-safe/Cargo.toml
+++ b/test-contracts/persistent-set-in-loop-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-persistent-set-in-loop-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/persistent-set-in-loop-safe/src/lib.rs
+++ b/test-contracts/persistent-set-in-loop-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct PersistentSetInLoopSafe;
+
+const KEY: Symbol = symbol_short!("key");
+
+#[contractimpl]
+impl PersistentSetInLoopSafe {
+    /// Writes to persistent storage inside a loop with extend_ttl — should pass.
+    pub fn batch_set(env: Env, count: u32) {
+        for i in 0..count {
+            let key = Symbol::new(&env, &format!("key_{}", i));
+            env.storage().persistent().set(&key, &i);
+            env.storage().persistent().extend_ttl(&key, 100, 200);
+        }
+    }
+}

--- a/test-contracts/persistent-set-in-loop-vulnerable/Cargo.toml
+++ b/test-contracts/persistent-set-in-loop-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-persistent-set-in-loop-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/persistent-set-in-loop-vulnerable/src/lib.rs
+++ b/test-contracts/persistent-set-in-loop-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct PersistentSetInLoopVulnerable;
+
+const KEY: Symbol = symbol_short!("key");
+
+#[contractimpl]
+impl PersistentSetInLoopVulnerable {
+    /// Writes to persistent storage inside a loop without extend_ttl — should trigger check.
+    pub fn batch_set(env: Env, count: u32) {
+        for i in 0..count {
+            let key = Symbol::new(&env, &format!("key_{}", i));
+            env.storage().persistent().set(&key, &i);
+        }
+    }
+}

--- a/test-contracts/upload-wasm-auth-safe/Cargo.toml
+++ b/test-contracts/upload-wasm-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-upload-wasm-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/upload-wasm-auth-safe/src/lib.rs
+++ b/test-contracts/upload-wasm-auth-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct UploadWasmAuthSafe;
+
+#[contractimpl]
+impl UploadWasmAuthSafe {
+    /// Calls upload_contract_wasm with require_auth — should pass.
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.require_auth();
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}

--- a/test-contracts/upload-wasm-auth-vulnerable/Cargo.toml
+++ b/test-contracts/upload-wasm-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-upload-wasm-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/upload-wasm-auth-vulnerable/src/lib.rs
+++ b/test-contracts/upload-wasm-auth-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct UploadWasmAuthVulnerable;
+
+#[contractimpl]
+impl UploadWasmAuthVulnerable {
+    /// Calls upload_contract_wasm without require_auth — should trigger check.
+    pub fn upload(env: Env, wasm: soroban_sdk::Bytes) {
+        env.deployer().upload_contract_wasm(wasm);
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                            
                                                                                                                                                                                        
  Implement four critical security checks for Soroban smart contracts to detect common vulnerability patterns before deployment to the Stellar network.                                 
                                                                                                                                                                                        
  ## Changes                                                                                                                                                                            
                                                                                                                                                                                        
  ### Issue #36: Persistent Storage Set in Loop Without TTL Extension                                                                                                                   
  - **File**: `crates/checks/src/persistent_set_in_loop.rs`                                                                                                                             
  - **Severity**: Medium                                                                                                                                                                
  - **Detection**: Flags `env.storage().persistent().set()` calls inside loop bodies (`for`, `while`, `loop`) that are not accompanied by an `extend_ttl()` call in the same loop body  
  - **Rationale**: Writing to persistent storage in a loop without extending TTL on each entry means entries written in later iterations may have shorter effective TTLs than earlier   
  ones, or the TTL extension may be missed entirely                                                                                                                                     
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/persistent-set-in-loop-vulnerable/` - Demonstrates the vulnerability                                                                                              
    - `test-contracts/persistent-set-in-loop-safe/` - Shows correct pattern with `extend_ttl()`                                                                                         
  - **Tests**: 4 unit tests covering for loops, while loops, and safe patterns                                                                                                          
                                                                                                                                                                                        
  ### Issue #37: Authorization Check After State Mutation (TOCTOU)                                                                                                                      
  - **File**: `crates/checks/src/auth_after_write.rs`                                                                                                                                   
  - **Severity**: High                                                                                                                                                                  
  - **Detection**: Flags `#[contractimpl]` functions where `env.require_auth()` appears *after* the first `env.storage()...set()` call in statement order                               
  - **Rationale**: Authorization must be checked *before* any state mutation. If called after a storage write, the contract has already modified state before verifying the caller — a  
  classic TOCTOU (time-of-check/time-of-use) pattern                                                                                                                                    
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/auth-after-write-vulnerable/` - Demonstrates the vulnerability                                                                                                    
    - `test-contracts/auth-after-write-safe/` - Shows correct pattern with auth before write                                                                                            
  - **Tests**: 4 unit tests covering various scenarios                                                                                                                                  
                                                                                                                                                                                        
  ### Issue #38: Unprotected WASM Upload                                                                                                                                                
  - **File**: `crates/checks/src/upload_wasm_auth.rs`                                                                                                                                   
  - **Severity**: High                                                                                                                                                                  
  - **Detection**: Flags `#[contractimpl]` functions that call `env.deployer().upload_contract_wasm(wasm_bytes)` without a preceding `require_auth()` or `require_auth_for_args()` call 
  - **Rationale**: `env.deployer().upload_contract_wasm()` uploads new WASM to the network. If called inside a contract entrypoint without authorization, any caller can upload         
  arbitrary WASM under the contract's deployer identity                                                                                                                                 
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/upload-wasm-auth-vulnerable/` - Demonstrates the vulnerability                                                                                                    
    - `test-contracts/upload-wasm-auth-safe/` - Shows correct pattern with authorization                                                                                                
  - **Tests**: 4 unit tests covering authorization patterns                                                                                                                             
                                                                                                                                                                                        
  ### Issue #39: Negative Balance Vulnerability (Underflow)                                                                                                                             
  - **File**: `crates/checks/src/negative_balance.rs`                                                                                                                                   
  - **Severity**: High                                                                                                                                                                  
  - **Detection**: Flags `BinOp::Sub` expressions in `#[contractimpl]` functions where the result is passed directly to `env.storage()...set()` without a preceding `>=` or `>`         
  comparison involving the same operands                                                                                                                                                
  - **Rationale**: Subtracting two `i128` values and storing the result directly (e.g., `balance - amount`) without checking that `balance >= amount` first can produce a negative      
  balance in token contracts, allowing users to overdraw                                                                                                                                
  - **Implementation Details**:                                                                                                                                                         
    - Collects all comparison expressions (`>=`, `>`) in the function block                                                                                                             
    - Detects subtraction expressions passed to storage `set()` calls                                                                                                                   
    - Verifies a matching comparison guard exists for the operands                                                                                                                      
    - Properly handles nested blocks (e.g., comparisons inside if statements)                                                                                                           
  - **Test Contracts**:                                                                                                                                                                 
    - `test-contracts/negative-balance-vulnerable/` - Demonstrates the vulnerability                                                                                                    
    - `test-contracts/negative-balance-safe/` - Shows correct pattern with underflow guard                                                                                              
  - **Tests**: 4 unit tests covering guard detection                                                                                                                                    
                                                                                                                                                                                        
  ## Integration                                                                                                                                                                        
                                                                                                                                                                                        
  - All four checks are registered in `default_checks()` in `crates/checks/src/lib.rs`                                                                                                  
  - Each check implements the `Check` trait with AST-based detection using `syn` visitors                                                                                               
  - All checks follow the existing pattern and conventions in the codebase                                                                                                              
                                                                                                                                                                                        
  ## Testing                                                                                                                                                                            
                                                                                                                                                                                        
  - **Total Tests**: 16 unit tests (all passing)                                                                                                                                        
  - **Test Coverage**: Each check has 4 unit tests covering:                                                                                                                            
    - Vulnerable patterns (should flag)                                                                                                                                                 
    - Safe patterns (should pass)                                                                                                                                                       
    - Edge cases and non-contractimpl code (should ignore)                                                                                                                              
  - **Integration Tests**: 8 test contracts (4 vulnerable, 4 safe) verified with CLI scanner                                                                                            
  - **Build**: Project builds successfully with `cargo build --release`                                                                                                                 
                                                                                                                                                                                        
  ## Bug Fixes                                                                                                                                                                          
                                                                                                                                                                                        
  - Fixed `crates/checks/src/contracttype.rs` to use `meta_list.tokens` instead of deprecated `meta_list.input` field for compatibility with current `syn` version                      
                                                                                                                                                                                        
  ## Closes                                                                                                                                                                             
                                                                                                                                                                                        
  Closes #36                                                                                                                                                                            
  Closes #37                                                                                                                                                                            
  Closes #38                                                                                                                                                                            
  Closes #39        