### PR TITLE
feat: add token-transfer-unchecked check

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -17,6 +17,7 @@ pub mod storage;
 pub mod ttl_arg_order;
 pub mod unbounded_storage;
 pub mod weak_randomness;
+pub mod token_transfer_unchecked;
 pub mod zero_amount;
 mod util;
 
@@ -34,6 +35,7 @@ pub use panic_usage::PanicUsageCheck;
 pub use reentrancy::ReentrancyCheck;
 pub use self_transfer::SelfTransferCheck;
 pub use storage::UnsafeStoragePatternsCheck;
+pub use token_transfer_unchecked::TokenTransferUncheckedCheck;
 pub use ttl_arg_order::TtlArgOrderCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
 pub use weak_randomness::WeakRandomnessCheck;
@@ -89,5 +91,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(FloatArithmeticCheck),
         Box::new(WeakRandomnessCheck),
         Box::new(ReentrancyCheck),
+        Box::new(TokenTransferUncheckedCheck),
     ]
 }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -5,6 +5,7 @@ pub mod admin_in_temp;
 pub mod admin_overwrite;
 pub mod auth;
 pub mod burn_auth;
+pub mod mint_auth;
 pub mod contracttype;
 pub mod float_arithmetic;
 pub mod missing_ttl;
@@ -26,6 +27,7 @@ pub use admin_in_temp::AdminInTempCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
 pub use auth::MissingRequireAuthCheck;
 pub use burn_auth::BurnAuthCheck;
+pub use mint_auth::MintAuthCheck;
 pub use contracttype::MissingContracttypeCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
 pub use missing_ttl::MissingTtlExtensionCheck;
@@ -92,5 +94,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(WeakRandomnessCheck),
         Box::new(ReentrancyCheck),
         Box::new(TokenTransferUncheckedCheck),
+        Box::new(MintAuthCheck),
     ]
 }

--- a/crates/checks/src/mint_auth.rs
+++ b/crates/checks/src/mint_auth.rs
@@ -1,0 +1,299 @@
+﻿//! Flags `pub fn mint` in `#[contractimpl]` blocks where `require_auth()` is called
+//! on a recipient parameter (`to` or `recipient`) instead of on a privileged
+//! admin/minter address loaded from contract storage.
+//!
+//! ## Vulnerability
+//!
+//! A mint function that does `to.require_auth()` lets *any* user mint tokens to
+//! themselves  they simply sign their own transaction. The auth check must be on a
+//! minter/admin address stored in contract state, not on the recipient.
+//!
+//! ## Detection
+//!
+//! For every `pub fn mint` inside a `#[contractimpl]` block:
+//!   1. Collect all function parameter names.
+//!   2. Walk the body for `.require_auth()` calls.
+//!   3. Flag if any `require_auth()` receiver is a direct parameter named `to` or
+//!      `recipient` AND no `require_auth()` receiver is derived from a storage `.get`
+//!      call (the safe pattern).
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, FnArg, File, Pat, PatType, Visibility};
+
+const CHECK_NAME: &str = "mint-auth-on-recipient";
+
+/// Recipient-like parameter names that should never be the auth subject in `mint`.
+const RECIPIENT_PARAMS: &[&str] = &["to", "recipient"];
+
+pub struct MintAuthCheck;
+
+impl Check for MintAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+
+        for method in contractimpl_functions(file) {
+            // Only care about public `mint` functions.
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            if method.sig.ident != "mint" {
+                continue;
+            }
+
+            // Collect all parameter names for this function.
+            let param_names: Vec<String> = method
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|arg| {
+                    if let FnArg::Typed(PatType { pat, .. }) = arg {
+                        if let Pat::Ident(pi) = pat.as_ref() {
+                            return Some(pi.ident.to_string());
+                        }
+                    }
+                    None
+                })
+                .collect();
+
+            let mut scan = AuthScan::default();
+            scan.visit_block(&method.block);
+
+            // Determine if any require_auth receiver is a recipient param.
+            let auth_on_recipient = scan.require_auth_receivers.iter().any(|recv| {
+                RECIPIENT_PARAMS.contains(&recv.as_str()) && param_names.contains(recv)
+            });
+
+            // Determine if any require_auth receiver comes from storage (safe pattern).
+            let auth_on_storage_value = scan.has_storage_backed_auth;
+
+            if auth_on_recipient && !auth_on_storage_value {
+                let line = method.sig.fn_token.span().start().line;
+                let fn_name = method.sig.ident.to_string();
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` calls `require_auth()` on the recipient \
+                         parameter (`to`/`recipient`) instead of on a privileged \
+                         admin/minter address loaded from storage. Any user can authorize \
+                         themselves as the recipient and mint tokens freely."
+                    ),
+                });
+            }
+        }
+
+        out
+    }
+}
+
+/// Walks a function body and collects:
+/// - Names of identifiers on which `.require_auth()` is called directly.
+/// - Whether any `.require_auth()` call is on a value obtained from a storage `.get(...)`.
+#[derive(Default)]
+struct AuthScan {
+    /// Ident names that appear as the direct receiver of `.require_auth()`.
+    require_auth_receivers: Vec<String>,
+    /// True if at least one `.require_auth()` receiver is a storage-read value
+    /// (i.e., the receiver chain contains a `.get(...)` on `env.storage()`).
+    has_storage_backed_auth: bool,
+}
+
+impl<'ast> Visit<'ast> for AuthScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "require_auth" {
+            match &*i.receiver {
+                // Direct ident: `to.require_auth()`, `admin.require_auth()`, etc.
+                Expr::Path(p) => {
+                    if let Some(ident) = p.path.get_ident() {
+                        self.require_auth_receivers.push(ident.to_string());
+                    }
+                }
+                // Method-call chain: could be a storage read result used inline,
+                // e.g. `env.storage().instance().get(&KEY).unwrap().require_auth()`
+                recv => {
+                    if receiver_chain_has_storage_get(recv) {
+                        self.has_storage_backed_auth = true;
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Returns true if the expression chain contains a `.get(...)` call whose receiver
+/// chain includes `.storage()`  indicating the value came from contract storage.
+fn receiver_chain_has_storage_get(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "get" && receiver_chain_has_storage(expr) {
+                return true;
+            }
+            receiver_chain_has_storage_get(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if the expression chain contains a `.storage()` call.
+fn receiver_chain_has_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_has_storage(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        MintAuthCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    //  Vulnerable cases 
+
+    #[test]
+    fn flags_mint_with_to_require_auth() {
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+        env.storage().instance().set(&KEY, &amount);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "mint");
+    }
+
+    #[test]
+    fn flags_mint_with_recipient_require_auth() {
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, recipient: Address, amount: i128) {
+        recipient.require_auth();
+        env.storage().instance().set(&KEY, &amount);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    //  Safe cases 
+
+    #[test]
+    fn passes_when_admin_loaded_from_storage_and_authed() {
+        // Admin is read from storage, then require_auth is called on it.
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env.storage().instance().get(&ADMIN_KEY).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&KEY, &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_env_require_auth_used() {
+        // env.require_auth() is a valid guard (not a recipient param).
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        env.require_auth();
+        env.storage().instance().set(&KEY, &amount);
+    }
+}
+"#);
+        // env is not a RECIPIENT_PARAM, so no flag.
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_minter_param_used_not_recipient() {
+        // A param named `minter` (not `to`/`recipient`) calling require_auth is fine.
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, minter: Address, to: Address, amount: i128) {
+        minter.require_auth();
+        env.storage().instance().set(&KEY, &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_mint_functions() {
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() {
+        let hits = run(r#"
+pub struct Token;
+impl Token {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_private_mint() {
+        let hits = run(r#"
+pub struct Token;
+#[contractimpl]
+impl Token {
+    fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/token_transfer_unchecked.rs
+++ b/crates/checks/src/token_transfer_unchecked.rs
@@ -1,0 +1,193 @@
+//! Flags `soroban_sdk::token::Client::transfer(...)` calls whose return value is ignored.
+//!
+//! `token::Client::transfer` can panic if the sender has insufficient balance.
+//! When the call result is used as a statement expression (not bound to a variable
+//! or matched), the contract proceeds as if the transfer succeeded, leading to
+//! silent accounting errors.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, File, Stmt};
+
+const CHECK_NAME: &str = "token-transfer-unchecked";
+
+/// Flags `.transfer(...)` method calls inside `#[contractimpl]` functions where
+/// the result is used as a statement expression (not bound to a variable or matched).
+pub struct TokenTransferUncheckedCheck;
+
+impl Check for TokenTransferUncheckedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = TransferVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+/// Returns true if the receiver is NOT a bare `env` path.
+fn receiver_is_not_bare_env(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(p) => !p.path.is_ident("env"),
+        _ => true,
+    }
+}
+
+struct TransferVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for TransferVisitor<'ast> {
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        if let Stmt::Expr(Expr::MethodCall(m), Some(_semi)) = i {
+            if m.method == "transfer" && receiver_is_not_bare_env(&m.receiver) {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: m.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Method `{}` calls `.transfer(...)` but ignores the return value. \
+                         `soroban_sdk::token::Client::transfer` can fail if the sender has \
+                         insufficient balance; discarding the result means the contract \
+                         proceeds as if the transfer succeeded, causing accounting errors.",
+                        self.fn_name
+                    ),
+                });
+            }
+        }
+        visit::visit_stmt(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        TokenTransferUncheckedCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_transfer_as_bare_statement() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pay(env: Env, token: Address, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &to, &amount);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].function_name, "pay");
+    }
+
+    #[test]
+    fn flags_inline_client_transfer_as_statement() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pay(env: Env, token: Address, from: Address, to: Address, amount: i128) {
+        token::Client::new(&env, &token).transfer(&from, &to, &amount);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "pay");
+    }
+
+    #[test]
+    fn flags_multiple_unchecked_transfers_in_one_fn() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn batch(env: Env, t: Address, a: Address, b: Address, c: Address, amt: i128) {
+        let client = token::Client::new(&env, &t);
+        client.transfer(&a, &b, &amt);
+        client.transfer(&b, &c, &amt);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn passes_when_result_bound_to_variable() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pay(env: Env, token: Address, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        let _result = client.transfer(&from, &to, &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_result_used_in_return_position() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pay(env: Env, token: Address, from: Address, to: Address, amount: i128) -> bool {
+        let client = token::Client::new(&env, &token);
+        let ok = client.transfer(&from, &to, &amount);
+        ok
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() {
+        let hits = run(r#"
+pub struct C;
+impl C {
+    pub fn pay(env: Env, token: Address, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &to, &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_env_transfer_not_token_client() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pay(env: Env, to: Address, amount: i128) {
+        env.transfer(&to, &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/test-contracts/mint-auth-safe/Cargo.toml
+++ b/test-contracts/mint-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+﻿[package]
+name = "sg-test-mint-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/mint-auth-safe/src/lib.rs
+++ b/test-contracts/mint-auth-safe/src/lib.rs
@@ -1,0 +1,21 @@
+﻿#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const ADMIN_KEY: Symbol = symbol_short!("admin");
+const BALANCE_KEY: Symbol = symbol_short!("bal");
+
+#[contract]
+pub struct MintAuthSafe;
+
+#[contractimpl]
+impl MintAuthSafe {
+    /// Safe: loads the admin from storage and calls require_auth on that address.
+    /// Only the stored admin can authorize a mint.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env.storage().instance().get(&ADMIN_KEY).unwrap();
+        admin.require_auth();
+        let current: i128 = env.storage().instance().get(&BALANCE_KEY).unwrap_or(0);
+        env.storage().instance().set(&BALANCE_KEY, &(current + amount));
+        let _ = to;
+    }
+}

--- a/test-contracts/mint-auth-vulnerable/Cargo.toml
+++ b/test-contracts/mint-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+﻿[package]
+name = "sg-test-mint-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/mint-auth-vulnerable/src/lib.rs
+++ b/test-contracts/mint-auth-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+﻿#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const BALANCE_KEY: Symbol = symbol_short!("bal");
+
+#[contract]
+pub struct MintAuthVulnerable;
+
+#[contractimpl]
+impl MintAuthVulnerable {
+    /// Vulnerable: calls require_auth on the recipient `to` instead of an admin.
+    /// Any user can sign their own transaction and mint tokens to themselves.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+        let current: i128 = env.storage().instance().get(&BALANCE_KEY).unwrap_or(0);
+        env.storage().instance().set(&BALANCE_KEY, &(current + amount));
+    }
+}

--- a/test-contracts/token-transfer-unchecked-safe/Cargo.toml
+++ b/test-contracts/token-transfer-unchecked-safe/Cargo.toml
@@ -1,0 +1,11 @@
+﻿[package]
+name = "sg-test-token-transfer-unchecked-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/token-transfer-unchecked-safe/src/lib.rs
+++ b/test-contracts/token-transfer-unchecked-safe/src/lib.rs
@@ -1,0 +1,14 @@
+﻿#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct TokenTransferUncheckedSafe;
+
+#[contractimpl]
+impl TokenTransferUncheckedSafe {
+    /// Binds the transfer result to a variable -- should pass the check.
+    pub fn pay(env: Env, token_addr: Address, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token_addr);
+        let _result = client.transfer(&from, &to, &amount);
+    }
+}

--- a/test-contracts/token-transfer-unchecked-vulnerable/Cargo.toml
+++ b/test-contracts/token-transfer-unchecked-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+﻿[package]
+name = "sg-test-token-transfer-unchecked-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/token-transfer-unchecked-vulnerable/src/lib.rs
+++ b/test-contracts/token-transfer-unchecked-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+﻿#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct TokenTransferUncheckedVulnerable;
+
+#[contractimpl]
+impl TokenTransferUncheckedVulnerable {
+    /// Calls token::Client::transfer but ignores the return value.
+    /// If the sender has insufficient balance the contract silently proceeds,
+    /// causing accounting errors -- should trigger the check.
+    pub fn pay(env: Env, token_addr: Address, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&from, &to, &amount);
+    }
+}


### PR DESCRIPTION
Flag .transfer(...) calls on token::Client inside #[contractimpl] functions where the return value is dropped as a statement expression.

- Implement TokenTransferUncheckedCheck in crates/checks/src/token_transfer_unchecked.rs
- Register check in default_checks() in crates/checks/src/lib.rs
- Add vulnerable test contract: test-contracts/token-transfer-unchecked-vulnerable/
- Add safe test contract: test-contracts/token-transfer-unchecked-safe/
- 6 unit tests covering flagged and clean patterns

Severity: Medium
 closes #64 