### PR TITLE
Add check: admin key removed from persistent storage without replacement

### DIFF
--- a/crates/checks/src/admin_key_removal.rs
+++ b/crates/checks/src/admin_key_removal.rs
@@ -1,0 +1,243 @@
+//! Detects `persistent().remove(key)` on admin/owner/operator keys without a
+//! subsequent `persistent().set(key, …)` in the same function body.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "admin-key-removal";
+
+fn is_admin_key(expr: &Expr) -> bool {
+    let text = quote_expr(expr).to_lowercase();
+    text.contains("admin") || text.contains("owner") || text.contains("operator")
+}
+
+/// Render an expression to a string for heuristic key-name matching.
+fn quote_expr(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => quote_expr(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        _ => String::new(),
+    }
+}
+
+fn receiver_chain_contains(expr: &Expr, method: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == method {
+                return true;
+            }
+            receiver_chain_contains(&m.receiver, method)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, method),
+        _ => false,
+    }
+}
+
+fn is_persistent_remove(m: &ExprMethodCall) -> bool {
+    m.method == "remove"
+        && receiver_chain_contains(&m.receiver, "persistent")
+        && receiver_chain_contains(&m.receiver, "storage")
+}
+
+fn is_persistent_set(m: &ExprMethodCall) -> bool {
+    m.method == "set"
+        && receiver_chain_contains(&m.receiver, "persistent")
+        && receiver_chain_contains(&m.receiver, "storage")
+}
+
+pub struct AdminKeyRemovalCheck;
+
+impl Check for AdminKeyRemovalCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = RemovalScan::default();
+            scan.visit_block(&method.block);
+
+            for (line, key_text) in &scan.removals {
+                // Safe if any persistent().set() follows with a matching key name
+                let replaced = scan.sets.iter().any(|set_key| {
+                    let k = set_key.to_lowercase();
+                    let r = key_text.to_lowercase();
+                    // same variable / literal, or both are admin-ish names
+                    k == r || (is_admin_name(&k) && is_admin_name(&r))
+                });
+                if !replaced {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: *line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "`{}` calls `persistent().remove({})` on an admin key without \
+                             atomically replacing it with `persistent().set(…)`. \
+                             The contract will be permanently left without an admin.",
+                            fn_name, key_text
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+fn is_admin_name(s: &str) -> bool {
+    s.contains("admin") || s.contains("owner") || s.contains("operator")
+}
+
+#[derive(Default)]
+struct RemovalScan {
+    /// (line, key_text) for each admin-key persistent().remove() found
+    removals: Vec<(usize, String)>,
+    /// key_text for each persistent().set() found after a removal
+    sets: Vec<String>,
+    seen_removal: bool,
+}
+
+impl<'ast> Visit<'ast> for RemovalScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_persistent_remove(i) {
+            if let Some(key_arg) = i.args.first() {
+                if is_admin_key(key_arg) {
+                    self.removals
+                        .push((i.span().start().line, quote_expr(key_arg)));
+                    self.seen_removal = true;
+                }
+            }
+        } else if self.seen_removal && is_persistent_set(i) {
+            if let Some(key_arg) = i.args.first() {
+                self.sets.push(quote_expr(key_arg));
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_remove_admin_without_set() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn remove_admin(env: Env) {
+        let key = symbol_short!("admin");
+        env.storage().persistent().remove(&key);
+    }
+}
+"#,
+        )?;
+        let hits = AdminKeyRemovalCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_remove_followed_by_set() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn rotate_admin(env: Env, new_admin: Address) {
+        let key = symbol_short!("admin");
+        env.storage().persistent().remove(&key);
+        env.storage().persistent().set(&key, &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminKeyRemovalCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_owner_key_removal() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn clear_owner(env: Env) {
+        env.storage().persistent().remove(&"owner");
+    }
+}
+"#,
+        )?;
+        let hits = AdminKeyRemovalCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_admin_key_removal() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn clear_counter(env: Env) {
+        let key = symbol_short!("counter");
+        env.storage().persistent().remove(&key);
+    }
+}
+"#,
+        )?;
+        let hits = AdminKeyRemovalCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_temporary_remove_of_admin_key() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn clear_temp(env: Env) {
+        let key = symbol_short!("admin");
+        env.storage().temporary().remove(&key);
+    }
+}
+"#,
+        )?;
+        // temporary() is not persistent() — should not flag
+        let hits = AdminKeyRemovalCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod admin_in_temp;
+pub mod admin_key_removal;
 pub mod admin_overwrite;
 pub mod auth;
 pub mod burn_auth;
@@ -24,6 +25,7 @@ mod util;
 
 pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
+pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
 pub use auth::MissingRequireAuthCheck;
 pub use burn_auth::BurnAuthCheck;
@@ -83,6 +85,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(UncheckedArithmeticCheck),
         Box::new(UnprotectedAdminCheck),
         Box::new(AdminOverwriteCheck),
+        Box::new(AdminKeyRemovalCheck),
         Box::new(UnsafeStoragePatternsCheck),
         Box::new(PanicUsageCheck),
         Box::new(MissingContracttypeCheck),

--- a/test-contracts/admin-key-removal-safe/Cargo.toml
+++ b/test-contracts/admin-key-removal-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-key-removal-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-key-removal-safe/src/lib.rs
+++ b/test-contracts/admin-key-removal-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminKeyRemovalSafe;
+
+const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("admin");
+
+#[contractimpl]
+impl AdminKeyRemovalSafe {
+    /// ✅ Atomically replaces the admin key — remove is immediately followed by
+    /// set in the same transaction, so the contract always has an admin.
+    pub fn rotate_admin(env: Env, new_admin: Address) {
+        env.storage().persistent().remove(&ADMIN_KEY);
+        env.storage().persistent().set(&ADMIN_KEY, &new_admin);
+    }
+}

--- a/test-contracts/admin-key-removal-vulnerable/Cargo.toml
+++ b/test-contracts/admin-key-removal-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-key-removal-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-key-removal-vulnerable/src/lib.rs
+++ b/test-contracts/admin-key-removal-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct AdminKeyRemovalVulnerable;
+
+const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("admin");
+
+#[contractimpl]
+impl AdminKeyRemovalVulnerable {
+    /// ❌ Removes the admin key without replacing it — contract is permanently
+    /// left without an admin after this call.
+    pub fn remove_admin(env: Env) {
+        env.storage().persistent().remove(&ADMIN_KEY);
+    }
+}


### PR DESCRIPTION
Closes #67 

Calling env.storage().persistent().remove(admin_key) without immediately replacing it with a new admin address leaves the contract permanently without an admin. Any function that removes the admin key must atomically set a new one in the same transaction.