### PR TITLE
feat: add checks #117 #118 #121 #122

### DIFF
--- a/crates/checks/src/dynamic_symbol_key.rs
+++ b/crates/checks/src/dynamic_symbol_key.rs
@@ -1,0 +1,227 @@
+//! `Symbol::new` with a runtime (non-literal) string used as a storage key.
+//!
+//! `env.storage()...set(Symbol::new(&env, expr), ...)` where `expr` is not a
+//! string literal allows callers to write to arbitrary storage slots.
+//! All storage keys should be compile-time constants.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "dynamic-symbol-key";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+/// True if the expression is a `Symbol::new(...)` call.
+fn is_symbol_new_call(expr: &Expr) -> Option<&ExprCall> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let Expr::Path(p) = &*call.func else {
+        return None;
+    };
+    let segs = &p.path.segments;
+    if segs.len() == 2 && segs[0].ident == "Symbol" && segs[1].ident == "new" {
+        return Some(call);
+    }
+    None
+}
+
+/// True if the second argument to `Symbol::new` is a string literal.
+fn second_arg_is_string_lit(call: &ExprCall) -> bool {
+    let Some(arg) = call.args.iter().nth(1) else {
+        return false;
+    };
+    // Strip reference if present.
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    matches!(inner, Expr::Lit(syn::ExprLit { lit: Lit::Str(_), .. }))
+}
+
+/// True if the first argument to `.set(key, val)` (after stripping `&`) contains
+/// a `Symbol::new` call with a non-literal second argument.
+fn set_key_is_dynamic_symbol(m: &ExprMethodCall) -> bool {
+    if m.method != "set" {
+        return false;
+    }
+    if !receiver_chain_contains_storage(&m.receiver) {
+        return false;
+    }
+    let Some(key_arg) = m.args.first() else {
+        return false;
+    };
+    let inner = match key_arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    if let Some(call) = is_symbol_new_call(inner) {
+        return !second_arg_is_string_lit(call);
+    }
+    false
+}
+
+struct DynamicSymbolVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for DynamicSymbolVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if set_key_is_dynamic_symbol(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Method `{}` calls `env.storage()...set()` with a `Symbol::new` key \
+                     constructed from a runtime expression (not a string literal). Callers \
+                     can supply arbitrary key strings to write to any storage slot. Use \
+                     `symbol_short!` or a compile-time constant key instead.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct DynamicSymbolKeyCheck;
+
+impl Check for DynamicSymbolKeyCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = DynamicSymbolVisitor {
+                fn_name,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_symbol_new_with_param_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, key: soroban_sdk::String, val: u32) {
+        env.storage().persistent().set(&Symbol::new(&env, key), &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DynamicSymbolKeyCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("Symbol::new"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_symbol_new_with_variable_key() -> Result<(), syn::Error> {
+        // Note: the set call here uses a variable `sym`, not Symbol::new inline.
+        // This test verifies the inline case is caught.
+        let src2 = r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, tag: soroban_sdk::String) {
+        env.storage().instance().set(&Symbol::new(&env, tag), &0u32);
+    }
+}
+"#;
+        let file = parse_file(src2)?;
+        let hits = DynamicSymbolKeyCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_string_literal_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, val: u32) {
+        env.storage().persistent().set(&Symbol::new(&env, "fixed_key"), &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DynamicSymbolKeyCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_symbol_short_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("key");
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, val: u32) {
+        env.storage().persistent().set(&KEY, &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DynamicSymbolKeyCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_get_with_dynamic_symbol() -> Result<(), syn::Error> {
+        // get() with dynamic symbol is not flagged by this check (only set)
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn load(env: Env, key: soroban_sdk::String) -> Option<u32> {
+        env.storage().persistent().get(&Symbol::new(&env, key))
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DynamicSymbolKeyCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/instance_vec_growth.rs
+++ b/crates/checks/src/instance_vec_growth.rs
@@ -1,0 +1,234 @@
+//! Vec in instance storage grows unboundedly without a length cap.
+//!
+//! Detects the pattern: read Vec from `instance()` storage → `push_back` /
+//! `push_front` → write back to `instance()` storage, without a `.len()`
+//! comparison before the push. An unbounded Vec will eventually exceed the
+//! maximum instance storage entry size, permanently bricking the contract.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "instance-vec-growth";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn receiver_chain_contains_instance(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "instance" {
+                return true;
+            }
+            receiver_chain_contains_instance(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_instance(&f.base),
+        _ => false,
+    }
+}
+
+fn is_instance_get(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "get" | "get_unchecked")
+        && receiver_chain_contains_storage(&m.receiver)
+        && receiver_chain_contains_instance(&m.receiver)
+}
+
+fn is_instance_set(m: &ExprMethodCall) -> bool {
+    m.method == "set"
+        && receiver_chain_contains_storage(&m.receiver)
+        && receiver_chain_contains_instance(&m.receiver)
+}
+
+fn is_vec_push(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "push_back" | "push_front")
+}
+
+fn is_len_check(m: &ExprMethodCall) -> bool {
+    m.method == "len"
+}
+
+#[derive(Default)]
+struct VecGrowthScan {
+    instance_get: bool,
+    vec_push: bool,
+    vec_push_line: usize,
+    instance_set: bool,
+    len_check: bool,
+}
+
+impl<'ast> Visit<'ast> for VecGrowthScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_instance_get(i) {
+            self.instance_get = true;
+        }
+        if is_vec_push(i) && !self.vec_push {
+            self.vec_push = true;
+            self.vec_push_line = i.span().start().line;
+        }
+        if is_instance_set(i) {
+            self.instance_set = true;
+        }
+        if is_len_check(i) {
+            self.len_check = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn scan_block(block: &Block) -> VecGrowthScan {
+    let mut s = VecGrowthScan::default();
+    s.visit_block(block);
+    s
+}
+
+pub struct InstanceVecGrowthCheck;
+
+impl Check for InstanceVecGrowthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let scan = scan_block(&method.block);
+            if scan.instance_get && scan.vec_push && scan.instance_set && !scan.len_check {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: scan.vec_push_line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Method `{fn_name}` reads a Vec from `instance()` storage, pushes an \
+                         element, and writes it back without checking `.len()` first. An \
+                         unbounded Vec will eventually exceed the maximum instance storage \
+                         entry size, permanently bricking the contract. Enforce a maximum \
+                         length before appending."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_unbounded_push_to_instance_vec() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, vec, Env, Vec};
+pub struct C;
+const PARTICIPANTS: soroban_sdk::Symbol = symbol_short!("parts");
+#[contractimpl]
+impl C {
+    pub fn register(env: Env, addr: soroban_sdk::Address) {
+        let mut list: Vec<soroban_sdk::Address> = env
+            .storage()
+            .instance()
+            .get(&PARTICIPANTS)
+            .unwrap_or(vec![&env]);
+        list.push_back(addr);
+        env.storage().instance().set(&PARTICIPANTS, &list);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InstanceVecGrowthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("unbounded"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_len_checked() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, vec, Env, Vec};
+pub struct C;
+const PARTICIPANTS: soroban_sdk::Symbol = symbol_short!("parts");
+const MAX: u32 = 100;
+#[contractimpl]
+impl C {
+    pub fn register(env: Env, addr: soroban_sdk::Address) {
+        let mut list: Vec<soroban_sdk::Address> = env
+            .storage()
+            .instance()
+            .get(&PARTICIPANTS)
+            .unwrap_or(vec![&env]);
+        assert!(list.len() < MAX);
+        list.push_back(addr);
+        env.storage().instance().set(&PARTICIPANTS, &list);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InstanceVecGrowthCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_persistent_vec() -> Result<(), syn::Error> {
+        // Uses persistent(), not instance() — out of scope for this check.
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, vec, Env, Vec};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn append(env: Env, val: u32) {
+        let mut v: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&KEY)
+            .unwrap_or(vec![&env]);
+        v.push_back(val);
+        env.storage().persistent().set(&KEY, &v);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InstanceVecGrowthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_push() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Vec};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn reset(env: Env) {
+        let v: Vec<u32> = env.storage().instance().get(&KEY).unwrap();
+        env.storage().instance().set(&KEY, &v);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InstanceVecGrowthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -2,6 +2,10 @@
 
 pub mod admin;
 pub mod admin_in_temp;
+pub mod dynamic_symbol_key;
+pub mod instance_vec_growth;
+pub mod migration_guard;
+pub mod withdraw_auth;
 pub mod admin_key_removal;
 pub mod admin_overwrite;
 pub mod assert_for_auth;
@@ -38,6 +42,10 @@ mod util;
 
 pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
+pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
+pub use instance_vec_growth::InstanceVecGrowthCheck;
+pub use migration_guard::MigrationGuardCheck;
+pub use withdraw_auth::WithdrawAuthCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
 pub use assert_for_auth::AssertForAuthCheck;
@@ -133,5 +141,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(AssertForAuthCheck),
         Box::new(AuthorizeAsContractCheck),
         Box::new(MapKeyExplosionCheck),
+        Box::new(DynamicSymbolKeyCheck),
+        Box::new(InstanceVecGrowthCheck),
+        Box::new(MigrationGuardCheck),
+        Box::new(WithdrawAuthCheck),
     ]
 }

--- a/crates/checks/src/migration_guard.rs
+++ b/crates/checks/src/migration_guard.rs
@@ -1,0 +1,303 @@
+//! Storage migration functions missing a version sentinel guard.
+//!
+//! A `pub fn migrate` / `pub fn upgrade_storage` / `pub fn migrate_v*` in a
+//! `#[contractimpl]` block that writes to storage without first reading a
+//! version/schema key can corrupt data if called twice or out of order.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "migration-guard-missing";
+
+fn is_migration_fn(name: &str) -> bool {
+    name == "migrate"
+        || name == "upgrade_storage"
+        || name.starts_with("migrate_v")
+        || name.starts_with("migrate_")
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_set(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+/// Returns true if the method call looks like a version/schema sentinel read:
+/// `.get(...)`, `.has(...)`, `.get_unchecked(...)` on any storage tier where
+/// the key argument contains "version", "schema", or "migration".
+fn is_version_read(m: &ExprMethodCall) -> bool {
+    let method = m.method.to_string();
+    if !matches!(method.as_str(), "get" | "has" | "get_unchecked") {
+        return false;
+    }
+    if !receiver_chain_contains_storage(&m.receiver) {
+        return false;
+    }
+    // Inspect the first argument for a version/schema/migration hint.
+    if let Some(arg) = m.args.first() {
+        let arg_str = format!("{}", quote_expr(arg)).to_lowercase();
+        return arg_str.contains("version")
+            || arg_str.contains("schema")
+            || arg_str.contains("migration");
+    }
+    false
+}
+
+fn quote_expr(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => quote_expr(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+/// Scan a block for (version_read_before_set, has_set).
+struct MigrationScan {
+    version_read_seen: bool,
+    storage_set_seen: bool,
+    first_set_line: usize,
+    /// True once we've seen a version read; used to track ordering.
+    version_read_before_set: bool,
+}
+
+impl MigrationScan {
+    fn new() -> Self {
+        Self {
+            version_read_seen: false,
+            storage_set_seen: false,
+            first_set_line: 0,
+            version_read_before_set: false,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for MigrationScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_version_read(i) {
+            self.version_read_seen = true;
+            if !self.storage_set_seen {
+                self.version_read_before_set = true;
+            }
+        }
+        if is_storage_set(i) && !self.storage_set_seen {
+            self.storage_set_seen = true;
+            self.first_set_line = i.span().start().line;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn scan_block(block: &Block) -> MigrationScan {
+    let mut s = MigrationScan::new();
+    s.visit_block(block);
+    s
+}
+
+pub struct MigrationGuardCheck;
+
+impl Check for MigrationGuardCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if !is_migration_fn(&name) {
+                continue;
+            }
+            let scan = scan_block(&method.block);
+            if !scan.storage_set_seen {
+                // No storage writes — nothing to guard.
+                continue;
+            }
+            if scan.version_read_before_set {
+                continue;
+            }
+            let line = if scan.first_set_line > 0 {
+                scan.first_set_line
+            } else {
+                method.sig.fn_token.span().start().line
+            };
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: name.clone(),
+                description: format!(
+                    "Migration function `{name}` writes to storage without first reading a \
+                     version/schema sentinel key. Calling this function twice or out of order \
+                     can corrupt contract state. Read and assert the current schema version \
+                     before performing any storage writes, then update the version key."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_migrate_without_version_check() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const OLD_KEY: soroban_sdk::Symbol = symbol_short!("old");
+const NEW_KEY: soroban_sdk::Symbol = symbol_short!("new");
+#[contractimpl]
+impl C {
+    pub fn migrate(env: Env) {
+        let val: u32 = env.storage().persistent().get(&OLD_KEY).unwrap();
+        env.storage().persistent().set(&NEW_KEY, &val);
+        env.storage().persistent().remove(&OLD_KEY);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("version/schema sentinel"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_upgrade_storage_without_version_check() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn upgrade_storage(env: Env) {
+        env.storage().instance().set(&KEY, &42u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_version_read_precedes_set() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const VERSION_KEY: soroban_sdk::Symbol = symbol_short!("version");
+const DATA_KEY: soroban_sdk::Symbol = symbol_short!("data");
+#[contractimpl]
+impl C {
+    pub fn migrate(env: Env) {
+        let v: u32 = env.storage().instance().get(&VERSION_KEY).unwrap();
+        assert_eq!(v, 1u32);
+        env.storage().instance().set(&DATA_KEY, &99u32);
+        env.storage().instance().set(&VERSION_KEY, &2u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_migration_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn update(env: Env) {
+        env.storage().persistent().set(&KEY, &1u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_migrate_v2_without_version_check() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn migrate_v2(env: Env) {
+        env.storage().persistent().set(&KEY, &2u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_storage_writes() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn migrate(env: Env) {
+        // read-only migration check
+        let _v: Option<u32> = env.storage().instance().get(&soroban_sdk::symbol_short!("k"));
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = MigrationGuardCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/withdraw_auth.rs
+++ b/crates/checks/src/withdraw_auth.rs
@@ -1,0 +1,246 @@
+//! `pub fn withdraw` missing `require_auth` before balance read.
+//!
+//! A withdraw function that reads a balance, subtracts an amount, and writes
+//! the new balance back without calling `require_auth` first allows any caller
+//! to drain any account's balance.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Block, Expr, ExprBinary, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "withdraw-missing-auth";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_get(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "get" | "get_unchecked")
+        && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn is_storage_set(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn is_require_auth(m: &ExprMethodCall) -> bool {
+    matches!(
+        m.method.to_string().as_str(),
+        "require_auth" | "require_auth_for_args"
+    )
+}
+
+#[derive(Default)]
+struct WithdrawScan {
+    has_require_auth: bool,
+    has_storage_get: bool,
+    has_subtraction: bool,
+    has_storage_set: bool,
+    /// True if require_auth appears before the first storage get.
+    auth_before_get: bool,
+    first_get_line: usize,
+    get_seen: bool,
+}
+
+impl<'ast> Visit<'ast> for WithdrawScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_require_auth(i) {
+            self.has_require_auth = true;
+            if !self.get_seen {
+                self.auth_before_get = true;
+            }
+        }
+        if is_storage_get(i) && !self.get_seen {
+            self.has_storage_get = true;
+            self.get_seen = true;
+            self.first_get_line = i.span().start().line;
+        }
+        if is_storage_set(i) {
+            self.has_storage_set = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &ExprBinary) {
+        if matches!(i.op, BinOp::Sub(_) | BinOp::SubAssign(_)) {
+            self.has_subtraction = true;
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+fn scan_block(block: &Block) -> WithdrawScan {
+    let mut s = WithdrawScan::default();
+    s.visit_block(block);
+    s
+}
+
+pub struct WithdrawAuthCheck;
+
+impl Check for WithdrawAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if name != "withdraw" {
+                continue;
+            }
+            let scan = scan_block(&method.block);
+            // Must have the balance-read → subtract → write pattern.
+            if !(scan.has_storage_get && scan.has_subtraction && scan.has_storage_set) {
+                continue;
+            }
+            // Flag if auth is absent OR appears after the first storage read.
+            if scan.has_require_auth && scan.auth_before_get {
+                continue;
+            }
+            let line = if scan.first_get_line > 0 {
+                scan.first_get_line
+            } else {
+                method.sig.fn_token.span().start().line
+            };
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: name.clone(),
+                description: format!(
+                    "Method `{name}` reads a balance from storage, subtracts an amount, and \
+                     writes the new balance back, but does not call `require_auth()` before \
+                     the balance read. Any caller can drain any account's balance. Call \
+                     `require_auth()` on the account owner before reading the balance."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_withdraw_without_auth() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, from: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&from).unwrap();
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = WithdrawAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("require_auth"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_auth_before_read() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        let balance: i128 = env.storage().persistent().get(&from).unwrap();
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = WithdrawAuthCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_withdraw_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&from).unwrap();
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = WithdrawAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_subtraction() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, from: Address) {
+        let _balance: i128 = env.storage().persistent().get(&from).unwrap();
+        env.storage().persistent().set(&from, &0i128);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = WithdrawAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_auth_after_read() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn withdraw(env: Env, from: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&from).unwrap();
+        from.require_auth();
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = WithdrawAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1, "auth after read should still be flagged");
+        Ok(())
+    }
+}

--- a/test-contracts/dynamic-symbol-key-safe/Cargo.toml
+++ b/test-contracts/dynamic-symbol-key-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-dynamic-symbol-key-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/dynamic-symbol-key-safe/src/lib.rs
+++ b/test-contracts/dynamic-symbol-key-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct DynamicSymbolKeySafe;
+
+/// Safe: uses a compile-time constant symbol as the storage key.
+#[contractimpl]
+impl DynamicSymbolKeySafe {
+    pub fn store(env: Env, value: u32) {
+        // Safe: key is a compile-time constant.
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("data"), &value);
+    }
+}

--- a/test-contracts/dynamic-symbol-key-vulnerable/Cargo.toml
+++ b/test-contracts/dynamic-symbol-key-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-dynamic-symbol-key-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/dynamic-symbol-key-vulnerable/src/lib.rs
+++ b/test-contracts/dynamic-symbol-key-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, String, Symbol};
+
+#[contract]
+pub struct DynamicSymbolKeyVulnerable;
+
+/// Vulnerable: uses a caller-supplied string as a storage key via Symbol::new.
+/// Any caller can write to an arbitrary storage slot by choosing the key.
+#[contractimpl]
+impl DynamicSymbolKeyVulnerable {
+    pub fn store(env: Env, key: String, value: u32) {
+        // BUG: Symbol::new with a runtime parameter — arbitrary slot write.
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(&env, key), &value);
+    }
+}

--- a/test-contracts/instance-vec-growth-safe/Cargo.toml
+++ b/test-contracts/instance-vec-growth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-instance-vec-growth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/instance-vec-growth-safe/src/lib.rs
+++ b/test-contracts/instance-vec-growth-safe/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Address, Env, Vec};
+
+#[contract]
+pub struct InstanceVecGrowthSafe;
+
+const MAX_PARTICIPANTS: u32 = 100;
+
+/// Safe: enforces a maximum length before appending to the Vec.
+#[contractimpl]
+impl InstanceVecGrowthSafe {
+    pub fn register(env: Env, participant: Address) {
+        let mut list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("parts"))
+            .unwrap_or(vec![&env]);
+        // Safe: length is checked before appending.
+        assert!(list.len() < MAX_PARTICIPANTS, "participant list is full");
+        list.push_back(participant);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("parts"), &list);
+    }
+}

--- a/test-contracts/instance-vec-growth-vulnerable/Cargo.toml
+++ b/test-contracts/instance-vec-growth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-instance-vec-growth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/instance-vec-growth-vulnerable/src/lib.rs
+++ b/test-contracts/instance-vec-growth-vulnerable/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Address, Env, Vec};
+
+#[contract]
+pub struct InstanceVecGrowthVulnerable;
+
+/// Vulnerable: appends to a Vec in instance storage without enforcing a max length.
+/// Eventually the entry will exceed the maximum instance storage size, bricking the contract.
+#[contractimpl]
+impl InstanceVecGrowthVulnerable {
+    pub fn register(env: Env, participant: Address) {
+        let mut list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("parts"))
+            .unwrap_or(vec![&env]);
+        // BUG: no length cap before push_back.
+        list.push_back(participant);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("parts"), &list);
+    }
+}

--- a/test-contracts/migration-guard-safe/Cargo.toml
+++ b/test-contracts/migration-guard-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-migration-guard-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/migration-guard-safe/src/lib.rs
+++ b/test-contracts/migration-guard-safe/src/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct MigrationSafe;
+
+/// Safe: reads the version sentinel before performing any storage writes.
+/// Asserts the pre-migration version and updates it after migration completes.
+#[contractimpl]
+impl MigrationSafe {
+    pub fn migrate(env: Env) {
+        // Read and assert the current schema version before any writes.
+        let version: u32 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("version"))
+            .unwrap_or(0);
+        assert_eq!(version, 1u32, "unexpected schema version");
+
+        let old_val: u32 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("old"))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("new"), &old_val);
+        env.storage()
+            .persistent()
+            .remove(&symbol_short!("old"));
+
+        // Update the version sentinel after migration.
+        env.storage()
+            .instance()
+            .set(&symbol_short!("version"), &2u32);
+    }
+}

--- a/test-contracts/migration-guard-vulnerable/Cargo.toml
+++ b/test-contracts/migration-guard-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-migration-guard-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/migration-guard-vulnerable/src/lib.rs
+++ b/test-contracts/migration-guard-vulnerable/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct MigrationVulnerable;
+
+/// Vulnerable: rewrites storage keys without checking the current schema version.
+/// Calling `migrate` twice will corrupt data because there is no version sentinel guard.
+#[contractimpl]
+impl MigrationVulnerable {
+    pub fn migrate(env: Env) {
+        // BUG: no version/schema sentinel read before writing.
+        let old_val: u32 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("old"))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("new"), &old_val);
+        env.storage()
+            .persistent()
+            .remove(&symbol_short!("old"));
+    }
+}

--- a/test-contracts/withdraw-auth-safe/Cargo.toml
+++ b/test-contracts/withdraw-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-withdraw-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/withdraw-auth-safe/src/lib.rs
+++ b/test-contracts/withdraw-auth-safe/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct WithdrawAuthSafe;
+
+/// Safe: calls require_auth on the account owner before reading the balance.
+#[contractimpl]
+impl WithdrawAuthSafe {
+    pub fn withdraw(env: Env, from: Address, amount: i128) {
+        // Safe: auth is verified before any storage read.
+        from.require_auth();
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&from)
+            .unwrap_or(0);
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}

--- a/test-contracts/withdraw-auth-vulnerable/Cargo.toml
+++ b/test-contracts/withdraw-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-withdraw-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/withdraw-auth-vulnerable/src/lib.rs
+++ b/test-contracts/withdraw-auth-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct WithdrawAuthVulnerable;
+
+/// Vulnerable: reads balance and writes reduced balance without require_auth.
+/// Any caller can drain any account's balance.
+#[contractimpl]
+impl WithdrawAuthVulnerable {
+    pub fn withdraw(env: Env, from: Address, amount: i128) {
+        // BUG: no require_auth before reading the balance.
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&from)
+            .unwrap_or(0);
+        let new_balance = balance - amount;
+        env.storage().persistent().set(&from, &new_balance);
+    }
+}


### PR DESCRIPTION
closes #117 withdraw-missing-auth: flag pub fn withdraw that reads balance, subtracts, and writes back without require_auth before the read.

closes #118 instance-vec-growth: flag Vec pushed to instance() storage without a .len() cap, which can brick the contract when entry size is exceeded.

closes #121 dynamic-symbol-key: high-severity dedicated check for Symbol::new with a runtime (non-literal) key used in storage set calls.

closes #122 migration-guard-missing: flag migrate/upgrade_storage/migrate_v* functions that write storage without first reading a version/schema sentinel key.

Each check includes unit tests and safe/vulnerable test contracts.