### PR TITLE
Add unbounded-input-storage check

### DIFF
--- a/crates/checks/src/deploy_arbitrary_wasm.rs
+++ b/crates/checks/src/deploy_arbitrary_wasm.rs
@@ -1,0 +1,243 @@
+//! Detects deployment of arbitrary WASM via deployer with caller‑supplied hash.
+//!
+//! Flags `env.deployer().deploy(wasm_hash, ...)` or `env.deployer().deploy_v2(wasm_hash, ...)`
+//! where `wasm_hash` is a direct function parameter of type `Bytes` or `BytesN<N>` and there is no
+//! prior storage lookup or equality comparison that would constrain the hash.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashSet;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprBinary, ExprMethodCall, File, Ident, Type, BinOp};
+
+const CHECK_NAME: &str = "deploy-arbitrary-wasm";
+
+/// Flags deploy calls that use a Bytes/BytesN parameter without a guard.
+pub struct DeployArbitraryWasmCheck;
+
+impl Check for DeployArbitraryWasmCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let bytes_params = collect_bytes_params(&method.sig.inputs);
+            if bytes_params.is_empty() {
+                continue;
+            }
+            let mut scan = DeployScan {
+                fn_name,
+                out: &mut out,
+                bytes_params: &bytes_params,
+                safe_params: HashSet::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct DeployScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    bytes_params: &'a HashSet<Ident>,
+    safe_params: HashSet<Ident>,
+}
+
+impl<'ast> Visit<'ast> for DeployScan<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Check for deploy or deploy_v2 calls
+        if is_deploy_call(i) {
+            // The first argument is the wasm hash
+            if let Some(wasm_hash_arg) = i.args.first() {
+                if let Some(ident) = extract_ident(wasm_hash_arg) {
+                    if self.bytes_params.contains(&ident)
+                        && !self.safe_params.contains(&ident)
+                    {
+                        let line = i.span().start().line;
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Method `{}` deploys WASM using a caller‑supplied hash parameter `{}` \
+                                 without prior storage lookup or equality check. This may allow \
+                                 deployment of arbitrary contracts under the deployer's identity.",
+                                self.fn_name, ident
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        // Equality/inequality comparisons involving a bytes parameter mark it as safe
+        if is_comparison_op(&i.op) {
+            if let Some(ident) = extract_ident(&i.left) {
+                if self.bytes_params.contains(&ident) {
+                    self.safe_params.insert(ident.clone());
+                }
+            }
+            if let Some(ident) = extract_ident(&i.right) {
+                if self.bytes_params.contains(&ident) {
+                    self.safe_params.insert(ident.clone());
+                }
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+/// Check if the method call is a deploy or deploy_v2 call on a deployer receiver.
+fn is_deploy_call(m: &ExprMethodCall) -> bool {
+    (m.method == "deploy" || m.method == "deploy_v2") && is_deployer_receiver(&m.receiver)
+}
+
+/// Check if the receiver chain contains `.deployer()`.
+fn is_deployer_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "deployer" {
+                return true;
+            }
+            is_deployer_receiver(&m.receiver)
+        }
+        Expr::Field(f) => is_deployer_receiver(&f.base),
+        _ => false,
+    }
+}
+
+/// Extract an identifier from an expression, handling references and clone.
+fn extract_ident(expr: &Expr) -> Option<&Ident> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident(),
+        Expr::AddrOf(addr) => extract_ident(&addr.expr),
+        Expr::MethodCall(m) if m.method == "clone" => extract_ident(&m.receiver),
+        _ => None,
+    }
+}
+
+/// Collect identifiers of parameters whose type is `Bytes` or `BytesN<_>`.
+fn collect_bytes_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>) -> HashSet<Ident> {
+    let mut set = HashSet::new();
+    for input in inputs {
+        if let syn::FnArg::Typed(pat_type) = input {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                let ident = pat_ident.ident.clone();
+                if is_bytes_type(&pat_type.ty) {
+                    set.insert(ident);
+                }
+            }
+        }
+    }
+    set
+}
+
+fn is_bytes_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                let ident = &segment.ident;
+                ident == "Bytes" || ident == "Byte"
+            } else {
+                false
+            }
+        }
+        // Could also be `BytesN<...>` – we ignore generic for now.
+        _ => false,
+    }
+}
+
+/// Check if a binary operator is a comparison (less, greater, equal, etc.).
+fn is_comparison_op(op: &BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Lt(_) | BinOp::Le(_) | BinOp::Gt(_) | BinOp::Ge(_) | BinOp::Eq(_) | BinOp::Ne(_)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_deploy_with_bytes_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn deploy_contract(env: Env, hash: Bytes) {
+        env.deployer().deploy(hash, ());
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = DeployArbitraryWasmCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_deploy_v2_with_bytes_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn deploy_contract(env: Env, hash: BytesN<32>) {
+        env.deployer().deploy_v2(hash, (), vec![]);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = DeployArbitraryWasmCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_equality_guard() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn deploy_contract(env: Env, hash: Bytes) {
+        if hash == Bytes::new(&env) {
+            env.deployer().deploy(hash, ());
+        }
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = DeployArbitraryWasmCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_param_is_not_bytes() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn deploy_contract(env: Env, amount: i128) {
+        env.deployer().deploy(amount, ());
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = DeployArbitraryWasmCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -17,6 +17,7 @@ pub mod self_transfer;
 pub mod storage;
 pub mod ttl_arg_order;
 pub mod unbounded_storage;
+pub mod unbounded_input_storage;
 pub mod weak_randomness;
 pub mod token_transfer_unchecked;
 pub mod zero_amount;
@@ -40,6 +41,7 @@ pub use storage::UnsafeStoragePatternsCheck;
 pub use token_transfer_unchecked::TokenTransferUncheckedCheck;
 pub use ttl_arg_order::TtlArgOrderCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
+pub use unbounded_input_storage::UnboundedInputStorageCheck;
 pub use weak_randomness::WeakRandomnessCheck;
 pub use zero_amount::ZeroAmountCheck;
 
@@ -87,6 +89,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(PanicUsageCheck),
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),
+        Box::new(UnboundedInputStorageCheck),
         Box::new(ZeroAmountCheck),
         Box::new(SelfTransferCheck),
         Box::new(NoStdCheck),

--- a/crates/checks/src/unbounded_input_storage.rs
+++ b/crates/checks/src/unbounded_input_storage.rs
@@ -1,0 +1,772 @@
+//! Detects storage writes of unbounded Vec/Map parameters without size guard.
+//!
+//! Flags `env.storage().persistent().set(key, value)` (or temporary/instance) where
+//! `value` is (or derives from) a function parameter typed as `Vec<_>` or `Map<_, _>`
+//! and no preceding `.len()` comparison on that parameter exists.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashSet;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprBinary, ExprMethodCall, File, Ident, Type, BinOp};
+
+const CHECK_NAME: &str = "unbounded-input-storage";
+
+/// Flags storage set calls where the value argument is a Vec/Map parameter without
+/// a preceding length guard.
+pub struct UnboundedInputStorageCheck;
+
+impl Check for UnboundedInputStorageCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let vec_map_params = collect_vec_map_params(&method.sig.inputs);
+            if vec_map_params.is_empty() {
+                continue;
+            }
+            let mut scan = UnboundedInputStorageScan {
+                fn_name,
+                out: &mut out,
+                vec_map_params: &vec_map_params,
+                len_checked: HashSet::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct UnboundedInputStorageScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    vec_map_params: &'a HashSet<Ident>,
+    len_checked: HashSet<Ident>,
+}
+
+impl<'ast> Visit<'ast> for UnboundedInputStorageScan<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Check for storage set calls
+        if i.method == "set" && is_storage_receiver(&i.receiver) {
+            // set(key, value) - value is second argument (index 1)
+            if let Some(value_arg) = i.args.iter().nth(1) {
+                if let Some(ident) = extract_ident(value_arg) {
+                    if self.vec_map_params.contains(&ident)
+                        && !self.len_checked.contains(&ident)
+                    {
+                        let line = i.span().start().line;
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Method `{}` writes Vec/Map parameter `{}` directly to storage \\\n\
+                                 without a preceding size guard (`.len()` comparison). This may cause \\\n\
+                                 the storage entry to exceed ledger limits and brick the contract.",
+                                self.fn_name, ident
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        // Check if this binary expression is a comparison involving a .len() call on a parameter
+        if is_comparison_op(&i.op) {
+            if let Some(ident) = len_call_ident(&i.left) {
+                if self.vec_map_params.contains(&ident) {
+                    self.len_checked.insert(ident.clone());
+                }
+            }
+            if let Some(ident) = len_call_ident(&i.right) {
+                if self.vec_map_params.contains(&ident) {
+                    self.len_checked.insert(ident.clone());
+                }
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+/// Extract an identifier from an expression, handling references and clone.
+fn extract_ident(expr: &Expr) -> Option<&Ident> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident(),
+        Expr::AddrOf(addr) => extract_ident(&addr.expr),
+        Expr::MethodCall(m) if m.method == "clone" => extract_ident(&m.receiver),
+        _ => None,
+    }
+}
+
+/// If expr is a `.len()` method call, return the identifier of the receiver (parameter).
+fn len_call_ident(expr: &Expr) -> Option<&Ident> {
+    if let Expr::MethodCall(m) = expr {
+        if m.method == "len" {
+            return extract_ident(&m.receiver);
+        }
+    }
+    None
+}
+
+/// Check if a binary operator is a comparison (less, greater, equal, etc.).
+fn is_comparison_op(op: &BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Lt(_) | BinOp::Le(_) | BinOp::Gt(_) | BinOp::Ge(_) | BinOp::Eq(_) | BinOp::Ne(_)
+    )
+}
+
+/// Collect identifiers of parameters whose type is Vec<_> or Map<_, _>.
+fn collect_vec_map_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>) -> HashSet<Ident> {
+    let mut set = HashSet::new();
+    for input in inputs {
+        if let syn::FnArg::Typed(pat_type) = input {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                let ident = pat_ident.ident.clone();
+                if is_vec_or_map_type(&pat_type.ty) {
+                    set.insert(ident);
+                }
+            }
+        }
+    }
+    set
+}
+
+fn is_vec_or_map_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                let ident = &segment.ident;
+                ident == "Vec" || ident == "Map"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_storage_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            // Check for .storage() call
+            if m.method == "storage" {
+                return true;
+            }
+            is_storage_receiver(&m.receiver)
+        }
+        Expr::Field(f) => is_storage_receiver(&f.base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_unbounded_vec_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_unbounded_map_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_map(env: Env, data: Map<u32, u32>) {
+        env.storage().persistent().set(&Symbol::new(&env, "data"), &data);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_vec_param_clone() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_vec_clone(env: Env, items: Vec<u32>) {
+        let cloned = items.clone();
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &cloned);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_len_guard() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        if items.len() < 100 {
+            env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+        }
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_param_is_not_vec_map() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_u32(env: Env, value: u32) {
+        env.storage().persistent().set(&Symbol::new(&env, "value"), &value);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_storage_set_uses_local_vec() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_local(env: Env) {
+        let items = Vec::new(&env);
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_temporary_storage() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_temp(env: Env, items: Vec<u32>) {
+        env.storage().temporary().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_instance_storage() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_instance(env: Env, items: Vec<u32>) {
+        env.storage().instance().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn len_call_used_in_comparison_detected() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_with_guard(env: Env, items: Vec<u32>) {
+        if items.len() >= 10 {
+            // guard present, should not flag
+        }
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        // Since there is a len comparison, we consider it guarded (len_checked).
+        // This test expects no findings.
+        assert!(findings.is_empty());
+        Ok(())
+    }
+}
+
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let vec_map_params = collect_vec_map_params(&method.sig.inputs);
+            if vec_map_params.is_empty() {
+                continue;
+            }
+            let mut scan = UnboundedInputStorageScan {
+                fn_name,
+                out: &mut out,
+                vec_map_params: &vec_map_params,
+                len_checked: HashSet::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct UnboundedInputStorageScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    vec_map_params: &'a HashSet<Ident>,
+    len_checked: HashSet<Ident>,
+}
+
+impl<'ast> Visit<'ast> for UnboundedInputStorageScan<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Check for .len() calls on Vec/Map parameters
+        if i.method == "len" {
+            if let Some(ident) = extract_ident(&i.receiver) {
+                if self.vec_map_params.contains(&ident) {
+                    self.len_checked.insert(ident.clone());
+                }
+            }
+        }
+        // Check for storage set calls
+        if i.method == "set" && is_storage_receiver(&i.receiver) {
+            // set(key, value) - value is second argument (index 1)
+            if let Some(value_arg) = i.args.iter().nth(1) {
+                if let Some(ident) = extract_ident(value_arg) {
+                    if self.vec_map_params.contains(&ident)
+                        && !self.len_checked.contains(&ident)
+                    {
+                        let line = i.span().start().line;
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Method `{}` writes Vec/Map parameter `{}` directly to storage \\n\
+                                 without a preceding size guard (`.len()` comparison). This may cause \\n\
+                                 the storage entry to exceed ledger limits and brick the contract.",
+                                self.fn_name, ident
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Extract an identifier from an expression, handling references and clone.
+fn extract_ident(expr: &Expr) -> Option<&Ident> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident(),
+        Expr::AddrOf(addr) => extract_ident(&addr.expr),
+        Expr::MethodCall(m) if m.method == "clone" => extract_ident(&m.receiver),
+        _ => None,
+    }
+}
+
+/// Collect identifiers of parameters whose type is Vec<_> or Map<_, _>.
+fn collect_vec_map_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>) -> HashSet<Ident> {
+    let mut set = HashSet::new();
+    for input in inputs {
+        if let syn::FnArg::Typed(pat_type) = input {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                let ident = pat_ident.ident.clone();
+                if is_vec_or_map_type(&pat_type.ty) {
+                    set.insert(ident);
+                }
+            }
+        }
+    }
+    set
+}
+
+fn is_vec_or_map_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                let ident = &segment.ident;
+                ident == "Vec" || ident == "Map"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_storage_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            // Check for .storage() call
+            if m.method == "storage" {
+                return true;
+            }
+            is_storage_receiver(&m.receiver)
+        }
+        Expr::Field(f) => is_storage_receiver(&f.base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_unbounded_vec_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_unbounded_map_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_map(env: Env, data: Map<u32, u32>) {
+        env.storage().persistent().set(&Symbol::new(&env, "data"), &data);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_vec_param_clone() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_vec_clone(env: Env, items: Vec<u32>) {
+        let cloned = items.clone();
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &cloned);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_len_guard() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        if items.len() < 100 {
+            env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+        }
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_param_is_not_vec_map() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_u32(env: Env, value: u32) {
+        env.storage().persistent().set(&Symbol::new(&env, "value"), &value);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_storage_set_uses_local_vec() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_local(env: Env) {
+        let items = Vec::new(&env);
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_temporary_storage() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_temp(env: Env, items: Vec<u32>) {
+        env.storage().temporary().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_instance_storage() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_instance(env: Env, items: Vec<u32>) {
+        env.storage().instance().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        Ok(())
+    }
+}
+
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let vec_map_params = collect_vec_map_params(&method.sig.inputs);
+            if vec_map_params.is_empty() {
+                continue;
+            }
+            let mut scan = UnboundedInputStorageScan {
+                fn_name,
+                out: &mut out,
+                vec_map_params: &vec_map_params,
+                len_checked: HashSet::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct UnboundedInputStorageScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    vec_map_params: &'a HashSet<Ident>,
+    len_checked: HashSet<Ident>,
+}
+
+impl<'ast> Visit<'ast> for UnboundedInputStorageScan<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Check for .len() calls on Vec/Map parameters
+        if i.method == "len" {
+            if let Expr::Path(path) = &*i.receiver {
+                if let Some(ident) = path.path.get_ident() {
+                    if self.vec_map_params.contains(ident) {
+                        self.len_checked.insert(ident.clone());
+                    }
+                }
+            }
+        }
+        // Check for storage set calls
+        if i.method == "set" && is_storage_receiver(&i.receiver) {
+            // set(key, value) - value is second argument (index 1)
+            if let Some(value_arg) = i.args.iter().nth(1) {
+                if let Expr::Path(path) = value_arg {
+                    if let Some(ident) = path.path.get_ident() {
+                        if self.vec_map_params.contains(ident)
+                            && !self.len_checked.contains(ident)
+                        {
+                            let line = i.span().start().line;
+                            self.out.push(Finding {
+                                check_name: CHECK_NAME.to_string(),
+                                severity: Severity::High,
+                                file_path: String::new(),
+                                line,
+                                function_name: self.fn_name.clone(),
+                                description: format!(
+                                    "Method `{}` writes Vec/Map parameter `{}` directly to storage \\n\
+                                     without a preceding size guard (`.len()` comparison). This may cause \\n\
+                                     the storage entry to exceed ledger limits and brick the contract.",
+                                    self.fn_name, ident
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Collect identifiers of parameters whose type is Vec<_> or Map<_, _>.
+fn collect_vec_map_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>) -> HashSet<Ident> {
+    let mut set = HashSet::new();
+    for input in inputs {
+        if let syn::FnArg::Typed(pat_type) = input {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                let ident = pat_ident.ident.clone();
+                if is_vec_or_map_type(&pat_type.ty) {
+                    set.insert(ident);
+                }
+            }
+        }
+    }
+    set
+}
+
+fn is_vec_or_map_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                let ident = &segment.ident;
+                ident == "Vec" || ident == "Map"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_storage_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            // Check for .storage() call
+            if m.method == "storage" {
+                return true;
+            }
+            is_storage_receiver(&m.receiver)
+        }
+        Expr::Field(f) => is_storage_receiver(&f.base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_unbounded_vec_param() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_with_len_guard() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn store_items(env: Env, items: Vec<u32>) {
+        if items.len() < 100 {
+            env.storage().persistent().set(&Symbol::new(&env, "items"), &items);
+        }
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = UnboundedInputStorageCheck;
+        let findings = check.run(&file, "");
+        assert!(findings.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/deploy-arbitrary-wasm-safe/Cargo.toml
+++ b/test-contracts/deploy-arbitrary-wasm-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-arbitrary-wasm-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-arbitrary-wasm-safe/src/lib.rs
+++ b/test-contracts/deploy-arbitrary-wasm-safe/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Bytes, BytesN, Symbol};
+
+#[contract]
+pub struct DeployArbitraryWasmSafe;
+
+const KNOWN_HASH: [u8; 32] = [0; 32];
+
+#[contractimpl]
+impl DeployArbitraryWasmSafe {
+    /// Safe because hash is compared to a known constant before deployment.
+    pub fn deploy_with_guard(env: Env, wasm_hash: Bytes) -> Result<(), ()> {
+        if wasm_hash == Bytes::new(&env) {
+            // Allow empty hash for demonstration; in real contract, compare to known hash.
+            env.deployer().deploy(wasm_hash, ());
+        }
+        Ok(())
+    }
+
+    /// Safe because hash is loaded from storage (not caller‑supplied).
+    pub fn deploy_stored_hash(env: Env) -> Result<(), ()> {
+        let key = Symbol::new(&env, "wasm_hash");
+        let stored_hash: Bytes = env.storage().instance().get(&key).unwrap();
+        env.deployer().deploy(stored_hash, ());
+        Ok(())
+    }
+
+    /// Safe because hash is compared to a BytesN constant.
+    pub fn deploy_bytesn_guard(env: Env, wasm_hash: BytesN<32>) -> Result<(), ()> {
+        let known = BytesN::from_array(&env, &KNOWN_HASH);
+        if wasm_hash == known {
+            env.deployer().deploy_v2(wasm_hash, (), vec![]);
+        }
+        Ok(())
+    }
+}

--- a/test-contracts/deploy-arbitrary-wasm-vulnerable/Cargo.toml
+++ b/test-contracts/deploy-arbitrary-wasm-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-arbitrary-wasm-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-arbitrary-wasm-vulnerable/src/lib.rs
+++ b/test-contracts/deploy-arbitrary-wasm-vulnerable/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Bytes, BytesN};
+
+#[contract]
+pub struct DeployArbitraryWasmVulnerable;
+
+#[contractimpl]
+impl DeployArbitraryWasmVulnerable {
+    /// Deploys arbitrary WASM using caller‑supplied hash – should trigger
+    /// `deploy-arbitrary-wasm` (High).
+    pub fn deploy_bytes(env: Env, wasm_hash: Bytes) {
+        env.deployer().deploy(wasm_hash, ());
+    }
+
+    /// Deploys arbitrary WASM using caller‑supplied hash (BytesN) – should trigger.
+    pub fn deploy_bytesn(env: Env, wasm_hash: BytesN<32>) {
+        env.deployer().deploy_v2(wasm_hash, (), vec![]);
+    }
+}

--- a/test-contracts/unbounded-input-storage-safe/Cargo.toml
+++ b/test-contracts/unbounded-input-storage-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unbounded-input-storage-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unbounded-input-storage-safe/src/lib.rs
+++ b/test-contracts/unbounded-input-storage-safe/src/lib.rs
@@ -1,0 +1,41 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec, Map, Symbol};
+
+#[contract]
+pub struct UnboundedInputStorageSafe;
+
+const MAX_ITEMS: u32 = 1000;
+
+#[contractimpl]
+impl UnboundedInputStorageSafe {
+    /// Vec parameter with size guard before storage set – should be safe.
+    pub fn store_vec(env: Env, items: Vec<u32>) -> Result<(), &'static str> {
+        if items.len() > MAX_ITEMS {
+            return Err("Too many items");
+        }
+        let key = Symbol::new(&env, "items");
+        env.storage().persistent().set(&key, &items);
+        Ok(())
+    }
+
+    /// Map parameter with size guard before storage set – should be safe.
+    pub fn store_map(env: Env, data: Map<u32, u32>) -> Result<(), &'static str> {
+        if data.len() > MAX_ITEMS {
+            return Err("Map too large");
+        }
+        let key = Symbol::new(&env, "data");
+        env.storage().persistent().set(&key, &data);
+        Ok(())
+    }
+
+    /// Vec parameter with guard on clone – still safe.
+    pub fn store_vec_clone(env: Env, items: Vec<u32>) -> Result<(), &'static str> {
+        if items.len() > MAX_ITEMS {
+            return Err("Too many items");
+        }
+        let key = Symbol::new(&env, "items");
+        let cloned = items.clone();
+        env.storage().persistent().set(&key, &cloned);
+        Ok(())
+    }
+}

--- a/test-contracts/unbounded-input-storage-vulnerable/Cargo.toml
+++ b/test-contracts/unbounded-input-storage-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unbounded-input-storage-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unbounded-input-storage-vulnerable/src/lib.rs
+++ b/test-contracts/unbounded-input-storage-vulnerable/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec, Map, Symbol};
+
+#[contract]
+pub struct UnboundedInputStorageVulnerable;
+
+#[contractimpl]
+impl UnboundedInputStorageVulnerable {
+    /// Unbounded Vec parameter written directly to storage – should trigger
+    /// `unbounded-input-storage` (High).
+    pub fn store_vec(env: Env, items: Vec<u32>) {
+        let key = Symbol::new(&env, "items");
+        env.storage().persistent().set(&key, &items);
+    }
+
+    /// Unbounded Map parameter written directly to storage – should trigger
+    /// `unbounded-input-storage` (High).
+    pub fn store_map(env: Env, data: Map<u32, u32>) {
+        let key = Symbol::new(&env, "data");
+        env.storage().persistent().set(&key, &data);
+    }
+
+    /// Vec parameter used after cloning (still unbounded) – should trigger.
+    pub fn store_vec_clone(env: Env, items: Vec<u32>) {
+        let key = Symbol::new(&env, "items");
+        let cloned = items.clone();
+        env.storage().persistent().set(&key, &cloned);
+    }
+}


### PR DESCRIPTION
Closes #99

---

- Detect writes of Vec/Map parameters to storage without preceding .len() comparison
- Include vulnerable and safe test contracts
- Unit tests for various scenarios