### PR TITLE
feat: add checks #112 #114 #115 #116

### DIFF
--- a/crates/checks/src/auth_loop_dos.rs
+++ b/crates/checks/src/auth_loop_dos.rs
@@ -1,0 +1,223 @@
+//! `require_auth()` called in a loop over a storage-backed Vec (DoS vector).
+//!
+//! Iterating a Vec retrieved from storage and calling `require_auth()` on each
+//! element scales with list size. An attacker who can grow the list can make
+//! every subsequent call prohibitively expensive, DoS-ing the contract.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprForLoop, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "auth-loop-dos";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+/// True if the expression is (or unwraps) a storage `.get(...)` call.
+fn expr_is_storage_get(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            let name = m.method.to_string();
+            if matches!(name.as_str(), "get" | "get_unchecked" | "unwrap" | "unwrap_or"
+                | "unwrap_or_else" | "unwrap_or_default" | "expect")
+            {
+                // Either this call itself is a storage get, or its receiver is.
+                if matches!(name.as_str(), "get" | "get_unchecked")
+                    && receiver_chain_contains_storage(&m.receiver)
+                {
+                    return true;
+                }
+                return expr_is_storage_get(&m.receiver);
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Visitor that detects `require_auth()` calls inside a for-loop body.
+struct LoopBodyVisitor {
+    found_require_auth: bool,
+    line: usize,
+}
+
+impl<'ast> Visit<'ast> for LoopBodyVisitor {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if !self.found_require_auth
+            && matches!(
+                i.method.to_string().as_str(),
+                "require_auth" | "require_auth_for_args"
+            )
+        {
+            self.found_require_auth = true;
+            self.line = i.span().start().line;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct AuthLoopVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for AuthLoopVisitor<'ast> {
+    fn visit_expr_for_loop(&mut self, i: &'ast ExprForLoop) {
+        // Check if the iterable comes from storage.
+        if expr_is_storage_get(&i.expr) {
+            let mut body_scan = LoopBodyVisitor {
+                found_require_auth: false,
+                line: 0,
+            };
+            body_scan.visit_block(&i.body);
+            if body_scan.found_require_auth {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: body_scan.line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Method `{}` calls `require_auth()` inside a loop over a \
+                         storage-backed Vec. The gas cost scales with the list size; an \
+                         attacker who can append to the list can DoS the contract by making \
+                         every call prohibitively expensive. Consider a single-signer or \
+                         threshold pattern instead.",
+                        self.fn_name
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_for_loop(self, i);
+    }
+}
+
+pub struct AuthLoopDosCheck;
+
+impl Check for AuthLoopDosCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = AuthLoopVisitor {
+                fn_name,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_require_auth_in_loop_over_storage_vec() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn multi_auth(env: Env) {
+        let signers: Vec<Address> = env.storage().persistent()
+            .get(&symbol_short!("signers")).unwrap();
+        for signer in signers {
+            signer.require_auth();
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AuthLoopDosCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("DoS"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_loop_over_literal_range() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, signer: Address) {
+        for _ in 0..3u32 {
+            signer.require_auth();
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AuthLoopDosCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_storage_loop_without_auth() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn tally(env: Env) -> u32 {
+        let list: Vec<Address> = env.storage().persistent()
+            .get(&symbol_short!("list")).unwrap();
+        let mut count = 0u32;
+        for _ in list {
+            count += 1;
+        }
+        count
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AuthLoopDosCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_require_auth_for_args_in_storage_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve_all(env: Env) {
+        let approvers: Vec<Address> = env.storage().instance()
+            .get(&symbol_short!("approvers")).unwrap_or_default();
+        for approver in approvers {
+            approver.require_auth_for_args(soroban_sdk::vec![&env]);
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AuthLoopDosCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -2,9 +2,13 @@
 
 pub mod admin;
 pub mod admin_in_temp;
+pub mod auth_loop_dos;
 pub mod dynamic_symbol_key;
 pub mod instance_vec_growth;
 pub mod migration_guard;
+pub mod ownership_transfer;
+pub mod secp256k1_unchecked;
+pub mod temp_set_no_ttl;
 pub mod withdraw_auth;
 pub mod admin_key_removal;
 pub mod admin_overwrite;
@@ -43,9 +47,13 @@ mod util;
 
 pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
+pub use auth_loop_dos::AuthLoopDosCheck;
 pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use instance_vec_growth::InstanceVecGrowthCheck;
 pub use migration_guard::MigrationGuardCheck;
+pub use ownership_transfer::OwnershipTransferCheck;
+pub use secp256k1_unchecked::Secp256k1UncheckedCheck;
+pub use temp_set_no_ttl::TempSetNoTtlCheck;
 pub use withdraw_auth::WithdrawAuthCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
@@ -148,5 +156,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(InstanceVecGrowthCheck),
         Box::new(MigrationGuardCheck),
         Box::new(WithdrawAuthCheck),
+        Box::new(AuthLoopDosCheck),
+        Box::new(OwnershipTransferCheck),
+        Box::new(Secp256k1UncheckedCheck),
+        Box::new(TempSetNoTtlCheck),
     ]
 }

--- a/crates/checks/src/ownership_transfer.rs
+++ b/crates/checks/src/ownership_transfer.rs
@@ -1,0 +1,259 @@
+//! `accept_ownership` / `claim_ownership` without verifying the pending owner from storage.
+//!
+//! Two-step ownership transfer must read the pending-owner key from storage and
+//! verify the caller matches before writing the new admin. Without this check,
+//! any address can claim ownership.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "ownership-transfer-unchecked";
+
+fn is_accept_fn(name: &str) -> bool {
+    matches!(name, "accept_ownership" | "claim_ownership")
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn key_looks_like_pending(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    lower.contains("pending") || lower.contains("proposed") || lower.contains("nominee")
+}
+
+fn key_looks_like_admin(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    lower.contains("admin") || lower.contains("owner") || lower.contains("role")
+}
+
+fn extract_key_str(arg: &Expr) -> String {
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+#[derive(Default)]
+struct OwnershipScan {
+    pending_read: bool,
+    admin_write: bool,
+    admin_write_line: usize,
+    /// True if the pending read precedes the first admin write.
+    pending_before_write: bool,
+    admin_write_seen: bool,
+}
+
+impl<'ast> Visit<'ast> for OwnershipScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let method = i.method.to_string();
+        if matches!(method.as_str(), "get" | "has" | "get_unchecked")
+            && receiver_chain_contains_storage(&i.receiver)
+        {
+            if let Some(arg) = i.args.first() {
+                let key = extract_key_str(arg);
+                if key_looks_like_pending(&key) {
+                    self.pending_read = true;
+                    if !self.admin_write_seen {
+                        self.pending_before_write = true;
+                    }
+                }
+            }
+        }
+        if method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if let Some(arg) = i.args.first() {
+                let key = extract_key_str(arg);
+                if key_looks_like_admin(&key) && !self.admin_write_seen {
+                    self.admin_write = true;
+                    self.admin_write_seen = true;
+                    self.admin_write_line = i.span().start().line;
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct OwnershipTransferCheck;
+
+impl Check for OwnershipTransferCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if !is_accept_fn(&name) {
+                continue;
+            }
+            let mut scan = OwnershipScan::default();
+            scan.visit_block(&method.block);
+
+            if !scan.admin_write {
+                continue; // no admin write — nothing to guard
+            }
+            if scan.pending_before_write {
+                continue; // safe: pending owner verified before write
+            }
+            let line = if scan.admin_write_line > 0 {
+                scan.admin_write_line
+            } else {
+                method.sig.fn_token.span().start().line
+            };
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: name.clone(),
+                description: format!(
+                    "Method `{name}` writes a new admin/owner key without first reading the \
+                     pending-owner key from storage. Any address can call this function and \
+                     claim ownership. Read and verify the pending owner from storage before \
+                     updating the admin key."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_accept_ownership_without_pending_check() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env, new_owner: Address) {
+        // BUG: writes admin without reading pending_owner first
+        env.storage().instance().set(&symbol_short!("admin"), &new_owner);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = OwnershipTransferCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("pending-owner"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_claim_ownership_without_pending_check() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn claim_ownership(env: Env, caller: Address) {
+        env.storage().persistent().set(&symbol_short!("owner"), &caller);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = OwnershipTransferCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_pending_read_precedes_write() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env) {
+        let pending: Address = env.storage().instance()
+            .get(&symbol_short!("pending_owner")).unwrap();
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("admin"), &pending);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = OwnershipTransferCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_admin_write() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env) -> Address {
+        env.storage().instance().get(&symbol_short!("pending_owner")).unwrap()
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = OwnershipTransferCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_private_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    fn accept_ownership(env: Env, new_owner: Address) {
+        env.storage().instance().set(&symbol_short!("admin"), &new_owner);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = OwnershipTransferCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/secp256k1_unchecked.rs
+++ b/crates/checks/src/secp256k1_unchecked.rs
@@ -1,0 +1,312 @@
+//! `env.crypto().secp256k1_recover(...)` result not compared against a trusted key.
+//!
+//! If the recovered public key is never compared (via `==`) against a stored
+//! trusted key, the recovery result is meaningless and provides no authentication.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprMethodCall, File, Pat};
+
+const CHECK_NAME: &str = "secp256k1-unchecked";
+
+fn is_secp256k1_recover(m: &ExprMethodCall) -> bool {
+    if m.method != "secp256k1_recover" {
+        return false;
+    }
+    // Receiver must be a crypto() call chain.
+    receiver_chain_contains_crypto(&m.receiver)
+}
+
+fn receiver_chain_contains_crypto(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "crypto" {
+                return true;
+            }
+            receiver_chain_contains_crypto(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_crypto(&f.base),
+        _ => false,
+    }
+}
+
+/// Collect all local binding names that are assigned from `secp256k1_recover`.
+fn collect_recover_bindings(block: &syn::Block) -> Vec<String> {
+    let mut collector = RecoverBindingCollector { bindings: vec![] };
+    collector.visit_block(block);
+    collector.bindings
+}
+
+struct RecoverBindingCollector {
+    bindings: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for RecoverBindingCollector {
+    fn visit_local(&mut self, i: &'ast syn::Local) {
+        // let <pat> = <init>;
+        if let Some(init) = &i.init {
+            let mut finder = RecoverCallFinder { found: false };
+            finder.visit_expr(&init.expr);
+            if finder.found {
+                // Extract the binding name from the pattern.
+                if let Pat::Ident(pi) = &i.pat {
+                    self.bindings.push(pi.ident.to_string());
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+}
+
+struct RecoverCallFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for RecoverCallFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_secp256k1_recover(i) {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Check whether any of the given binding names appear in an `==` comparison.
+fn bindings_are_eq_compared(block: &syn::Block, bindings: &[String]) -> bool {
+    let mut checker = EqCompareChecker {
+        bindings,
+        found: false,
+    };
+    checker.visit_block(block);
+    checker.found
+}
+
+struct EqCompareChecker<'a> {
+    bindings: &'a [String],
+    found: bool,
+}
+
+fn expr_contains_binding(expr: &Expr, bindings: &[String]) -> bool {
+    match expr {
+        Expr::Path(p) => {
+            if let Some(seg) = p.path.segments.last() {
+                return bindings.contains(&seg.ident.to_string());
+            }
+            false
+        }
+        Expr::Reference(r) => expr_contains_binding(&r.expr, bindings),
+        Expr::MethodCall(m) => expr_contains_binding(&m.receiver, bindings),
+        _ => false,
+    }
+}
+
+impl<'ast> Visit<'ast> for EqCompareChecker<'_> {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if matches!(i.op, BinOp::Eq(_) | BinOp::Ne(_)) {
+            if expr_contains_binding(&i.left, self.bindings)
+                || expr_contains_binding(&i.right, self.bindings)
+            {
+                self.found = true;
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+
+    // Also catch assert_eq! / assert_ne! macros.
+    fn visit_expr_macro(&mut self, i: &'ast syn::ExprMacro) {
+        let mac_name = i
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        if matches!(mac_name.as_str(), "assert_eq" | "assert_ne" | "require") {
+            let tokens = i.mac.tokens.to_string();
+            if self.bindings.iter().any(|b| tokens.contains(b.as_str())) {
+                self.found = true;
+            }
+        }
+        visit::visit_expr_macro(self, i);
+    }
+}
+
+pub struct Secp256k1UncheckedCheck;
+
+impl Check for Secp256k1UncheckedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+
+            // Find all secp256k1_recover call sites (inline, not just let bindings).
+            let mut inline_finder = InlineRecoverFinder {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            // We'll do a two-pass approach: collect bindings, then check comparisons.
+            let bindings = collect_recover_bindings(&method.block);
+            if bindings.is_empty() {
+                // Check for inline (non-bound) recover calls.
+                inline_finder.visit_block(&method.block);
+                continue;
+            }
+            if !bindings_are_eq_compared(&method.block, &bindings) {
+                // Find the line of the first recover call.
+                let mut line_finder = RecoverLineFinder { line: 0 };
+                line_finder.visit_block(&method.block);
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: line_finder.line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Method `{fn_name}` calls `secp256k1_recover()` but the recovered \
+                         public key is never compared (`==`) against a trusted key. The \
+                         recovery result provides no authentication guarantee unless verified \
+                         against a stored or expected public key."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+struct RecoverLineFinder {
+    line: usize,
+}
+
+impl<'ast> Visit<'ast> for RecoverLineFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line == 0 && is_secp256k1_recover(i) {
+            self.line = i.span().start().line;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Flag inline secp256k1_recover calls that are not assigned to any binding.
+struct InlineRecoverFinder<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for InlineRecoverFinder<'ast> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_secp256k1_recover(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Method `{}` calls `secp256k1_recover()` but the result is not stored \
+                     or compared against a trusted key. The recovery provides no \
+                     authentication guarantee.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_recover_result_not_compared() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) {
+        let _recovered = env.crypto().secp256k1_recover(&msg, &sig, 0);
+        // BUG: recovered key is never compared to anything
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = Secp256k1UncheckedCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("secp256k1_recover"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_result_eq_compared() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Bytes, BytesN, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) {
+        let recovered: BytesN<65> = env.crypto().secp256k1_recover(&msg, &sig, 0);
+        let trusted: BytesN<65> = env.storage().persistent()
+            .get(&symbol_short!("pubkey")).unwrap();
+        assert_eq!(recovered, trusted);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = Secp256k1UncheckedCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_result_compared_with_eq_op() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Bytes, BytesN, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) {
+        let recovered: BytesN<65> = env.crypto().secp256k1_recover(&msg, &sig, 0);
+        let trusted: BytesN<65> = env.storage().persistent()
+            .get(&symbol_short!("pubkey")).unwrap();
+        if recovered == trusted {
+            // authorized
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = Secp256k1UncheckedCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_inline_recover_not_bound() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) {
+        // result discarded entirely
+        let _ = env.crypto().secp256k1_recover(&msg, &sig, 0);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = Secp256k1UncheckedCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+}

--- a/crates/checks/src/temp_set_no_ttl.rs
+++ b/crates/checks/src/temp_set_no_ttl.rs
@@ -1,0 +1,217 @@
+//! `env.storage().temporary().set(key, val)` without a matching `extend_ttl` in the same function.
+//!
+//! Temporary entries written without an explicit TTL extension use the default
+//! (potentially very short) TTL. Locks, nonces, and other short-lived state
+//! must have their TTL explicitly set to match the intended validity window.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "temp-set-no-ttl";
+
+fn receiver_chain_contains_temporary(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "temporary" {
+                return true;
+            }
+            receiver_chain_contains_temporary(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_temporary(&f.base),
+        _ => false,
+    }
+}
+
+fn extract_first_arg_str(m: &ExprMethodCall) -> String {
+    let Some(arg) = m.args.first() else {
+        return String::new();
+    };
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+#[derive(Default)]
+struct TempSetEntry {
+    key: String,
+    line: usize,
+}
+
+#[derive(Default)]
+struct TempTtlScan {
+    sets: Vec<TempSetEntry>,
+    extend_ttl_keys: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for TempTtlScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if receiver_chain_contains_temporary(&i.receiver) {
+            let method = i.method.to_string();
+            if method == "set" {
+                self.sets.push(TempSetEntry {
+                    key: extract_first_arg_str(i),
+                    line: i.span().start().line,
+                });
+            } else if matches!(method.as_str(), "extend_ttl" | "bump") {
+                self.extend_ttl_keys.push(extract_first_arg_str(i));
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct TempSetNoTtlCheck;
+
+impl Check for TempSetNoTtlCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = TempTtlScan::default();
+            scan.visit_block(&method.block);
+
+            for entry in &scan.sets {
+                // Flag if no extend_ttl for the same key exists in this function.
+                let has_ttl = scan.extend_ttl_keys.iter().any(|k| {
+                    // Match by key name, or accept a wildcard (empty key = unknown).
+                    k == &entry.key || k.is_empty() || entry.key.is_empty()
+                });
+                if !has_ttl {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line: entry.line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Method `{fn_name}` writes to `env.storage().temporary()` (key: \
+                             `{}`) without calling `extend_ttl` in the same function. The \
+                             entry will use the default TTL, which may be too short for the \
+                             intended validity window. Call `extend_ttl` immediately after \
+                             `set` to explicitly control the entry lifetime.",
+                            if entry.key.is_empty() { "<unknown>" } else { &entry.key }
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_temp_set_without_extend_ttl() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const LOCK: soroban_sdk::Symbol = symbol_short!("lock");
+#[contractimpl]
+impl C {
+    pub fn acquire_lock(env: Env) {
+        // BUG: no extend_ttl after set
+        env.storage().temporary().set(&LOCK, &true);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = TempSetNoTtlCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert!(hits[0].description.contains("extend_ttl"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_extend_ttl_present() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const LOCK: soroban_sdk::Symbol = symbol_short!("lock");
+#[contractimpl]
+impl C {
+    pub fn acquire_lock(env: Env) {
+        env.storage().temporary().set(&LOCK, &true);
+        env.storage().temporary().extend_ttl(&LOCK, 100, 200);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = TempSetNoTtlCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_persistent_set() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const KEY: soroban_sdk::Symbol = symbol_short!("k");
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, val: u32) {
+        env.storage().persistent().set(&KEY, &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = TempSetNoTtlCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_multiple_temp_sets_without_ttl() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const A: soroban_sdk::Symbol = symbol_short!("a");
+const B: soroban_sdk::Symbol = symbol_short!("b");
+#[contractimpl]
+impl C {
+    pub fn store_both(env: Env) {
+        env.storage().temporary().set(&A, &1u32);
+        env.storage().temporary().set(&B, &2u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = TempSetNoTtlCheck.run(&file, "");
+        assert_eq!(hits.len(), 2);
+        Ok(())
+    }
+}

--- a/test-contracts/auth-loop-dos-safe/Cargo.toml
+++ b/test-contracts/auth-loop-dos-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-auth-loop-dos-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/auth-loop-dos-safe/src/lib.rs
+++ b/test-contracts/auth-loop-dos-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AuthLoopDosSafe;
+
+/// Safe: uses a single designated admin rather than iterating a list for auth.
+#[contractimpl]
+impl AuthLoopDosSafe {
+    pub fn execute(env: Env) {
+        // Safe: single require_auth on a stored admin address.
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+    }
+}

--- a/test-contracts/auth-loop-dos-vulnerable/Cargo.toml
+++ b/test-contracts/auth-loop-dos-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-auth-loop-dos-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/auth-loop-dos-vulnerable/src/lib.rs
+++ b/test-contracts/auth-loop-dos-vulnerable/src/lib.rs
@@ -1,0 +1,34 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+#[contract]
+pub struct AuthLoopDosVulnerable;
+
+/// Vulnerable: calls require_auth on every element of a storage-backed Vec.
+/// An attacker who can grow the signers list can DoS the contract.
+#[contractimpl]
+impl AuthLoopDosVulnerable {
+    pub fn add_signer(env: Env, signer: Address) {
+        let mut signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("signers"))
+            .unwrap_or(soroban_sdk::vec![&env]);
+        signers.push_back(signer);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("signers"), &signers);
+    }
+
+    pub fn execute(env: Env) {
+        // BUG: require_auth in a loop over a storage-backed list.
+        let signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("signers"))
+            .unwrap();
+        for signer in signers {
+            signer.require_auth();
+        }
+    }
+}

--- a/test-contracts/ownership-transfer-safe/Cargo.toml
+++ b/test-contracts/ownership-transfer-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-transfer-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-transfer-safe/src/lib.rs
+++ b/test-contracts/ownership-transfer-safe/src/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipTransferSafe;
+
+/// Safe: reads and verifies the pending_owner sentinel before writing the new admin.
+#[contractimpl]
+impl OwnershipTransferSafe {
+    pub fn propose_owner(env: Env, new_owner: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pending"), &new_owner);
+    }
+
+    pub fn accept_ownership(env: Env) {
+        // Safe: read the pending owner first and verify the caller.
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("pending"))
+            .unwrap();
+        pending.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &pending);
+        env.storage()
+            .instance()
+            .remove(&symbol_short!("pending"));
+    }
+}

--- a/test-contracts/ownership-transfer-vulnerable/Cargo.toml
+++ b/test-contracts/ownership-transfer-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-transfer-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-transfer-vulnerable/src/lib.rs
+++ b/test-contracts/ownership-transfer-vulnerable/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipTransferVulnerable;
+
+/// Vulnerable: writes the new admin without reading the pending_owner sentinel.
+/// Any address can call accept_ownership and become the admin.
+#[contractimpl]
+impl OwnershipTransferVulnerable {
+    pub fn propose_owner(env: Env, new_owner: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pending"), &new_owner);
+    }
+
+    pub fn accept_ownership(env: Env, caller: Address) {
+        // BUG: does not read pending_owner before writing admin.
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &caller);
+    }
+}

--- a/test-contracts/secp256k1-unchecked-safe/Cargo.toml
+++ b/test-contracts/secp256k1-unchecked-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-secp256k1-unchecked-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/secp256k1-unchecked-safe/src/lib.rs
+++ b/test-contracts/secp256k1-unchecked-safe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, BytesN, Env};
+
+#[contract]
+pub struct Secp256k1UncheckedSafe;
+
+/// Safe: compares the recovered public key against a stored trusted key.
+#[contractimpl]
+impl Secp256k1UncheckedSafe {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) -> bool {
+        let recovered: BytesN<65> = env.crypto().secp256k1_recover(&msg, &sig, 0);
+        // Safe: compare against the stored trusted public key.
+        let trusted: BytesN<65> = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("pubkey"))
+            .unwrap();
+        recovered == trusted
+    }
+}

--- a/test-contracts/secp256k1-unchecked-vulnerable/Cargo.toml
+++ b/test-contracts/secp256k1-unchecked-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-secp256k1-unchecked-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/secp256k1-unchecked-vulnerable/src/lib.rs
+++ b/test-contracts/secp256k1-unchecked-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct Secp256k1UncheckedVulnerable;
+
+/// Vulnerable: recovers a public key but never compares it against a trusted key.
+/// The recovery result provides no authentication guarantee.
+#[contractimpl]
+impl Secp256k1UncheckedVulnerable {
+    pub fn verify(env: Env, msg: Bytes, sig: Bytes) -> bool {
+        // BUG: recovered key is never compared to a trusted key.
+        let _recovered = env.crypto().secp256k1_recover(&msg, &sig, 0);
+        true
+    }
+}

--- a/test-contracts/temp-set-no-ttl-safe/Cargo.toml
+++ b/test-contracts/temp-set-no-ttl-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-temp-set-no-ttl-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/temp-set-no-ttl-safe/src/lib.rs
+++ b/test-contracts/temp-set-no-ttl-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct TempSetNoTtlSafe;
+
+/// Safe: calls extend_ttl immediately after writing to temporary storage.
+#[contractimpl]
+impl TempSetNoTtlSafe {
+    pub fn acquire_lock(env: Env) {
+        env.storage()
+            .temporary()
+            .set(&symbol_short!("lock"), &true);
+        // Safe: TTL is explicitly extended to match the intended validity window.
+        env.storage()
+            .temporary()
+            .extend_ttl(&symbol_short!("lock"), 100, 200);
+    }
+}

--- a/test-contracts/temp-set-no-ttl-vulnerable/Cargo.toml
+++ b/test-contracts/temp-set-no-ttl-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-temp-set-no-ttl-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/temp-set-no-ttl-vulnerable/src/lib.rs
+++ b/test-contracts/temp-set-no-ttl-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct TempSetNoTtlVulnerable;
+
+/// Vulnerable: writes to temporary storage without calling extend_ttl.
+/// The entry uses the default TTL, which may expire before the lock is released.
+#[contractimpl]
+impl TempSetNoTtlVulnerable {
+    pub fn acquire_lock(env: Env) {
+        // BUG: no extend_ttl after set — entry may expire unexpectedly.
+        env.storage()
+            .temporary()
+            .set(&symbol_short!("lock"), &true);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks:

### closes #112 `auth-loop-dos` (Medium)
Flags `require_auth()` called inside a `for` loop over a storage-backed `Vec`. Gas cost scales with list size — an attacker who can append to the list can DoS the contract.

### closes #114 `temp-set-no-ttl` (Low)
Flags `env.storage().temporary().set(key, val)` calls with no matching `extend_ttl()` in the same function body. Entries use the default TTL which may be too short for the intended validity window.

### closes #115 `ownership-transfer-unchecked` (High)
Flags `accept_ownership` / `claim_ownership` functions that write an admin/owner key without first reading a pending/proposed owner sentinel from storage. Any address can claim ownership.

### closes #116 `secp256k1-unchecked` (High)
Flags `env.crypto().secp256k1_recover()` calls whose result is never compared (`==`) against a trusted key. The recovery provides no authentication guarantee without verification.

## Files changed
- `crates/checks/src/auth_loop_dos.rs` (new)
- `crates/checks/src/ownership_transfer.rs` (new)
- `crates/checks/src/secp256k1_unchecked.rs` (new)
- `crates/checks/src/temp_set_no_ttl.rs` (new)
- `crates/checks/src/lib.rs` (registered all four checks)
- 8 test contracts (safe + vulnerable for each check)