### PR TITLE
feat: add checks #103 #104 #105 #106

### DIFF
--- a/crates/checks/src/invoke_unchecked_cast.rs
+++ b/crates/checks/src/invoke_unchecked_cast.rs
@@ -1,0 +1,300 @@
+//! `invoke_contract` return value cast without error handling.
+//!
+//! `env.invoke_contract(...)` returns a generic `Val`. Casting it directly via
+//! `.unwrap()` or `.expect()` on `try_into_val` / `from_val` silently produces
+//! a zero/default value on type mismatch, leading to logic errors.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Pat};
+
+const CHECK_NAME: &str = "invoke-unchecked-cast";
+
+fn is_invoke_contract(m: &ExprMethodCall) -> bool {
+    m.method == "invoke_contract"
+}
+
+fn is_unchecked_unwrap(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "unwrap" | "expect")
+}
+
+fn is_cast_method(m: &ExprMethodCall) -> bool {
+    matches!(
+        m.method.to_string().as_str(),
+        "try_into_val" | "from_val" | "try_from_val"
+    )
+}
+
+/// True if the expression chain is: <invoke_contract_result>.try_into_val(...).unwrap()
+/// or <invoke_contract_result>.from_val(...).unwrap()
+fn is_unchecked_cast_chain(expr: &Expr) -> bool {
+    let Expr::MethodCall(outer) = expr else {
+        return false;
+    };
+    if !is_unchecked_unwrap(outer) {
+        return false;
+    }
+    // The receiver of unwrap() must be a cast method call.
+    let Expr::MethodCall(cast) = &*outer.receiver else {
+        return false;
+    };
+    if !is_cast_method(cast) {
+        return false;
+    }
+    // The receiver of the cast must be (or contain) invoke_contract.
+    expr_contains_invoke_contract(&cast.receiver)
+}
+
+fn expr_contains_invoke_contract(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if is_invoke_contract(m) {
+                return true;
+            }
+            expr_contains_invoke_contract(&m.receiver)
+        }
+        Expr::Reference(r) => expr_contains_invoke_contract(&r.expr),
+        _ => false,
+    }
+}
+
+/// Collect binding names assigned from invoke_contract.
+fn collect_invoke_bindings(block: &syn::Block) -> Vec<String> {
+    let mut c = InvokeBindingCollector { bindings: vec![] };
+    c.visit_block(block);
+    c.bindings
+}
+
+struct InvokeBindingCollector {
+    bindings: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for InvokeBindingCollector {
+    fn visit_local(&mut self, i: &'ast syn::Local) {
+        if let Some(init) = &i.init {
+            let mut f = InvokeFinder { found: false };
+            f.visit_expr(&init.expr);
+            if f.found {
+                if let Pat::Ident(pi) = &i.pat {
+                    self.bindings.push(pi.ident.to_string());
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+}
+
+struct InvokeFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for InvokeFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_invoke_contract(i) {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Check if any binding from invoke_contract is later cast with unwrap/expect.
+fn binding_is_unchecked_cast(block: &syn::Block, bindings: &[String]) -> Option<usize> {
+    let mut checker = UncheckedCastChecker {
+        bindings,
+        line: None,
+    };
+    checker.visit_block(block);
+    checker.line
+}
+
+struct UncheckedCastChecker<'a> {
+    bindings: &'a [String],
+    line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for UncheckedCastChecker<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line.is_some() {
+            return;
+        }
+        // Pattern: binding.try_into_val(...).unwrap()
+        if is_unchecked_unwrap(i) {
+            if let Expr::MethodCall(cast) = &*i.receiver {
+                if is_cast_method(cast) {
+                    if let Expr::Path(p) = &*cast.receiver {
+                        if let Some(seg) = p.path.segments.last() {
+                            if self.bindings.contains(&seg.ident.to_string()) {
+                                self.line = Some(i.span().start().line);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct InvokeUncheckedCastCheck;
+
+impl Check for InvokeUncheckedCastCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+
+            // Check for inline unchecked cast chains.
+            let mut inline = InlineUncheckedCastVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            inline.visit_block(&method.block);
+
+            // Check for bound-then-cast patterns.
+            let bindings = collect_invoke_bindings(&method.block);
+            if !bindings.is_empty() {
+                if let Some(line) = binding_is_unchecked_cast(&method.block, &bindings) {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Method `{fn_name}` casts the result of `invoke_contract` via \
+                             `try_into_val`/`from_val` with `.unwrap()` or `.expect()`. A \
+                             type mismatch silently produces a zero/default value. Use a \
+                             `match` or `if let Ok(...)` to handle the error explicitly."
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+struct InlineUncheckedCastVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for InlineUncheckedCastVisitor<'ast> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_unchecked_cast_chain(&Expr::MethodCall(i.clone())) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Method `{}` casts the result of `invoke_contract` via \
+                     `try_into_val`/`from_val` with `.unwrap()`. A type mismatch silently \
+                     produces a zero/default value. Use `match` or `if let Ok(...)` instead.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_inline_try_into_val_unwrap() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn call_other(env: Env, contract: Address) -> i128 {
+        env.invoke_contract::<i128>(&contract, &Symbol::short("get"), soroban_sdk::vec![&env])
+            .try_into_val(&env)
+            .unwrap()
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InvokeUncheckedCastCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("try_into_val"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_bound_result_cast_with_unwrap() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol, Val};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn call_other(env: Env, contract: Address) -> i128 {
+        let result = env.invoke_contract::<Val>(
+            &contract, &Symbol::short("get"), soroban_sdk::vec![&env]
+        );
+        result.try_into_val(&env).unwrap()
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InvokeUncheckedCastCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_match_used() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol, Val};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn call_other(env: Env, contract: Address) -> Option<i128> {
+        let result = env.invoke_contract::<Val>(
+            &contract, &Symbol::short("get"), soroban_sdk::vec![&env]
+        );
+        match result.try_into_val(&env) {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InvokeUncheckedCastCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_invoke_unwrap() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn read(env: Env, key: Address) -> i128 {
+        env.storage().persistent().get(&key).unwrap()
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = InvokeUncheckedCastCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -4,7 +4,11 @@ pub mod admin;
 pub mod admin_in_temp;
 pub mod dynamic_symbol_key;
 pub mod instance_vec_growth;
+pub mod invoke_unchecked_cast;
 pub mod migration_guard;
+pub mod negative_deposit;
+pub mod no_param_no_auth;
+pub mod storage_type_confusion;
 pub mod withdraw_auth;
 pub mod admin_key_removal;
 pub mod admin_overwrite;
@@ -45,7 +49,11 @@ pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
 pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use instance_vec_growth::InstanceVecGrowthCheck;
+pub use invoke_unchecked_cast::InvokeUncheckedCastCheck;
 pub use migration_guard::MigrationGuardCheck;
+pub use negative_deposit::NegativeDepositCheck;
+pub use no_param_no_auth::NoParamNoAuthCheck;
+pub use storage_type_confusion::StorageTypeConfusionCheck;
 pub use withdraw_auth::WithdrawAuthCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
@@ -148,5 +156,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(InstanceVecGrowthCheck),
         Box::new(MigrationGuardCheck),
         Box::new(WithdrawAuthCheck),
+        Box::new(InvokeUncheckedCastCheck),
+        Box::new(NegativeDepositCheck),
+        Box::new(NoParamNoAuthCheck),
+        Box::new(StorageTypeConfusionCheck),
     ]
 }

--- a/crates/checks/src/negative_deposit.rs
+++ b/crates/checks/src/negative_deposit.rs
@@ -1,0 +1,281 @@
+//! `deposit` / `fund` / `add` functions accepting a negative `i128` amount without a guard.
+//!
+//! A caller passing a negative amount to a deposit function effectively withdraws
+//! funds while appearing to deposit. The amount must be checked > 0 before use.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprMethodCall, File, FnArg, Pat, Type, Visibility};
+
+const CHECK_NAME: &str = "negative-deposit";
+
+const DEPOSIT_NAMES: &[&str] = &["deposit", "fund", "add", "add_funds", "deposit_funds"];
+
+fn is_deposit_fn(name: &str) -> bool {
+    DEPOSIT_NAMES.contains(&name)
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_set(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+/// Collect parameter names that are typed `i128` (or `&i128`).
+fn i128_param_names(method: &syn::ImplItemFn) -> Vec<String> {
+    let mut names = Vec::new();
+    for arg in &method.sig.inputs {
+        let FnArg::Typed(pt) = arg else { continue };
+        let Pat::Ident(pi) = &*pt.pat else { continue };
+        let ty_str = type_to_str(&pt.ty);
+        if ty_str.contains("i128") {
+            names.push(pi.ident.to_string());
+        }
+    }
+    names
+}
+
+fn type_to_str(ty: &Type) -> String {
+    match ty {
+        Type::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Type::Reference(r) => type_to_str(&r.elem),
+        _ => String::new(),
+    }
+}
+
+/// Count non-Env parameters.
+fn non_env_param_count(method: &syn::ImplItemFn) -> usize {
+    method
+        .sig
+        .inputs
+        .iter()
+        .filter(|arg| match arg {
+            FnArg::Typed(pt) => {
+                let ty = type_to_str(&pt.ty);
+                ty != "Env" && ty != "env"
+            }
+            FnArg::Receiver(_) => false,
+        })
+        .count()
+}
+
+fn expr_contains_ident(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::Path(p) => p.path.is_ident(name),
+        Expr::Reference(r) => expr_contains_ident(&r.expr, name),
+        Expr::Binary(b) => {
+            expr_contains_ident(&b.left, name) || expr_contains_ident(&b.right, name)
+        }
+        Expr::MethodCall(m) => {
+            expr_contains_ident(&m.receiver, name)
+                || m.args.iter().any(|a| expr_contains_ident(a, name))
+        }
+        Expr::Call(c) => c.args.iter().any(|a| expr_contains_ident(a, name)),
+        Expr::Unary(u) => expr_contains_ident(&u.expr, name),
+        Expr::Paren(p) => expr_contains_ident(&p.expr, name),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct DepositScan {
+    has_positive_guard: bool,
+    has_storage_set: bool,
+    first_set_line: usize,
+    set_seen: bool,
+}
+
+impl<'ast> Visit<'ast> for DepositScan {
+    fn visit_expr_binary(&mut self, i: &ExprBinary) {
+        // Look for `amount > 0`, `amount >= 1`, `0 < amount`, `1 <= amount`
+        // or assert!(amount > 0) — we catch the BinOp directly.
+        if matches!(
+            i.op,
+            BinOp::Gt(_) | BinOp::Ge(_) | BinOp::Lt(_) | BinOp::Le(_)
+        ) {
+            self.has_positive_guard = true;
+        }
+        visit::visit_expr_binary(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_storage_set(i) && !self.set_seen {
+            self.has_storage_set = true;
+            self.set_seen = true;
+            self.first_set_line = i.span().start().line;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct NegativeDepositCheck;
+
+impl Check for NegativeDepositCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if !is_deposit_fn(&name) {
+                continue;
+            }
+            let i128_params = i128_param_names(method);
+            if i128_params.is_empty() {
+                continue;
+            }
+            let mut scan = DepositScan::default();
+            scan.visit_block(&method.block);
+            if !scan.has_storage_set {
+                continue;
+            }
+            if scan.has_positive_guard {
+                continue;
+            }
+            let line = if scan.first_set_line > 0 {
+                scan.first_set_line
+            } else {
+                method.sig.fn_token.span().start().line
+            };
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: name.clone(),
+                description: format!(
+                    "Method `{name}` accepts an `i128` amount parameter and writes to storage \
+                     without a positive-value guard (`amount > 0`). A caller passing a \
+                     negative amount can effectively withdraw funds while appearing to \
+                     deposit. Add an explicit check that `amount > 0` before any storage write."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_deposit_without_positive_guard() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        env.storage().persistent().set(&from, &(bal + amount));
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NegativeDepositCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("amount > 0"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_positive_guard_present() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        env.storage().persistent().set(&from, &(bal + amount));
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NegativeDepositCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_fund_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn fund(env: Env, account: Address, amount: i128) {
+        env.storage().persistent().set(&account, &amount);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NegativeDepositCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_deposit_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, amount: i128) {
+        env.storage().persistent().set(&from, &amount);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NegativeDepositCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_i128_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, from: Address) {
+        env.storage().persistent().set(&from, &true);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NegativeDepositCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/no_param_no_auth.rs
+++ b/crates/checks/src/no_param_no_auth.rs
@@ -1,0 +1,223 @@
+//! Public zero-parameter functions that write to storage without auth.
+//!
+//! A `pub fn` with no non-Env parameters and no `require_auth` call that
+//! writes to storage is callable by anyone. These are often forgotten utility
+//! functions that should be private or removed.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, FnArg, Type, Visibility};
+
+const CHECK_NAME: &str = "no-param-no-auth";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn type_last_ident(ty: &Type) -> String {
+    match ty {
+        Type::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Type::Reference(r) => type_last_ident(&r.elem),
+        _ => String::new(),
+    }
+}
+
+fn is_env_param(arg: &FnArg) -> bool {
+    match arg {
+        FnArg::Typed(pt) => {
+            let ty = type_last_ident(&pt.ty);
+            ty == "Env"
+        }
+        FnArg::Receiver(_) => false,
+    }
+}
+
+fn has_only_env_params(method: &syn::ImplItemFn) -> bool {
+    method
+        .sig
+        .inputs
+        .iter()
+        .all(|arg| matches!(arg, FnArg::Receiver(_)) || is_env_param(arg))
+}
+
+#[derive(Default)]
+struct BodyScan {
+    has_storage_set: bool,
+    has_require_auth: bool,
+    first_set_line: usize,
+}
+
+impl<'ast> Visit<'ast> for BodyScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let method = i.method.to_string();
+        if method == "set" && receiver_chain_contains_storage(&i.receiver) && self.first_set_line == 0 {
+            self.has_storage_set = true;
+            self.first_set_line = i.span().start().line;
+        }
+        if matches!(method.as_str(), "require_auth" | "require_auth_for_args") {
+            self.has_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct NoParamNoAuthCheck;
+
+impl Check for NoParamNoAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            if !has_only_env_params(method) {
+                continue;
+            }
+            let mut scan = BodyScan::default();
+            scan.visit_block(&method.block);
+            if !scan.has_storage_set || scan.has_require_auth {
+                continue;
+            }
+            let fn_name = method.sig.ident.to_string();
+            let line = if scan.first_set_line > 0 {
+                scan.first_set_line
+            } else {
+                method.sig.fn_token.span().start().line
+            };
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line,
+                function_name: fn_name.clone(),
+                description: format!(
+                    "Public method `{fn_name}` has no non-Env parameters and no \
+                     `require_auth()` call, but writes to storage. Any caller can invoke \
+                     this function and mutate contract state. Make it private, add \
+                     parameters, or add an authorization check."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_zero_param_storage_write_no_auth() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reset(env: Env) {
+        env.storage().instance().set(&symbol_short!("count"), &0u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NoParamNoAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("no non-Env parameters"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_has_extra_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reset(env: Env, val: u32) {
+        env.storage().instance().set(&symbol_short!("count"), &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NoParamNoAuthCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_auth_present() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reset(env: Env) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("count"), &0u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NoParamNoAuthCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_private_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    fn reset(env: Env) {
+        env.storage().instance().set(&symbol_short!("count"), &0u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NoParamNoAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_storage_write() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn read(env: Env) -> u32 {
+        env.storage().instance().get(&symbol_short!("count")).unwrap_or(0)
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = NoParamNoAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/storage_type_confusion.rs
+++ b/crates/checks/src/storage_type_confusion.rs
@@ -1,0 +1,306 @@
+//! Same storage key written with different value types across functions.
+//!
+//! `set(key, value)` called with the same string literal key in two or more
+//! functions of the same `#[contractimpl]` block but with structurally different
+//! value expressions causes silent type confusion on reads.
+
+use crate::util::is_contractimpl;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, ImplItem, Item};
+
+const CHECK_NAME: &str = "storage-type-confusion";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn extract_key_literal(arg: &Expr) -> Option<String> {
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Lit(l) => {
+            if let syn::Lit::Str(s) = &l.lit {
+                return Some(s.value());
+            }
+            None
+        }
+        // symbol_short!("key") macro
+        Expr::Macro(m) => {
+            let tokens = m.mac.tokens.to_string();
+            // Extract the string literal from the macro tokens.
+            let trimmed = tokens.trim().trim_matches('"');
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Produce a coarse type hint string from a value expression.
+fn value_type_hint(expr: &Expr) -> String {
+    let inner = match expr {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Int(i) => {
+                let suffix = i.suffix();
+                if suffix.is_empty() {
+                    "int_lit".to_string()
+                } else {
+                    suffix.to_string()
+                }
+            }
+            syn::Lit::Bool(_) => "bool".to_string(),
+            syn::Lit::Str(_) => "str".to_string(),
+            _ => "lit".to_string(),
+        },
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_else(|| "path".to_string()),
+        Expr::Call(c) => {
+            if let Expr::Path(p) = &*c.func {
+                p.path
+                    .segments
+                    .last()
+                    .map(|s| s.ident.to_string())
+                    .unwrap_or_else(|| "call".to_string())
+            } else {
+                "call".to_string()
+            }
+        }
+        Expr::Cast(c) => {
+            // `val as i128` → "i128"
+            match &*c.ty {
+                syn::Type::Path(p) => p
+                    .path
+                    .segments
+                    .last()
+                    .map(|s| s.ident.to_string())
+                    .unwrap_or_else(|| "cast".to_string()),
+                _ => "cast".to_string(),
+            }
+        }
+        _ => "expr".to_string(),
+    }
+}
+
+#[derive(Debug)]
+struct SetEntry {
+    key: String,
+    type_hint: String,
+    fn_name: String,
+    line: usize,
+}
+
+struct SetCollector {
+    fn_name: String,
+    entries: Vec<SetEntry>,
+}
+
+impl<'ast> Visit<'ast> for SetCollector {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if i.args.len() >= 2 {
+                if let Some(key) = extract_key_literal(&i.args[0]) {
+                    let hint = value_type_hint(&i.args[1]);
+                    self.entries.push(SetEntry {
+                        key,
+                        type_hint: hint,
+                        fn_name: self.fn_name.clone(),
+                        line: i.span().start().line,
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct StorageTypeConfusionCheck;
+
+impl Check for StorageTypeConfusionCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+
+        for item in &file.items {
+            let Item::Impl(item_impl) = item else {
+                continue;
+            };
+            if !is_contractimpl(item_impl) {
+                continue;
+            }
+
+            // Collect all set entries across all functions in this impl block.
+            let mut all_entries: Vec<SetEntry> = Vec::new();
+            for impl_item in &item_impl.items {
+                let ImplItem::Fn(method) = impl_item else {
+                    continue;
+                };
+                let fn_name = method.sig.ident.to_string();
+                let mut collector = SetCollector {
+                    fn_name,
+                    entries: vec![],
+                };
+                collector.visit_block(&method.block);
+                all_entries.extend(collector.entries);
+            }
+
+            // Group by key; flag if the same key has different type hints.
+            let keys: Vec<String> = {
+                let mut ks: Vec<String> = all_entries.iter().map(|e| e.key.clone()).collect();
+                ks.sort();
+                ks.dedup();
+                ks
+            };
+
+            for key in &keys {
+                let entries_for_key: Vec<&SetEntry> =
+                    all_entries.iter().filter(|e| &e.key == key).collect();
+                if entries_for_key.len() < 2 {
+                    continue;
+                }
+                let first_hint = &entries_for_key[0].type_hint;
+                let mismatch = entries_for_key
+                    .iter()
+                    .skip(1)
+                    .find(|e| &e.type_hint != first_hint);
+                if let Some(second) = mismatch {
+                    let first = entries_for_key[0];
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: second.line,
+                        function_name: second.fn_name.clone(),
+                        description: format!(
+                            "Storage key `{key}` is written with type `{}` in `{}` (line {}) \
+                             but with type `{}` in `{}` (line {}). Readers expecting one type \
+                             will deserialize garbage when the other type was stored.",
+                            first.type_hint,
+                            first.fn_name,
+                            first.line,
+                            second.type_hint,
+                            second.fn_name,
+                            second.line,
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_same_key_different_types() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_addr(env: Env, addr: Address) {
+        env.storage().instance().set(&"owner", &addr);
+    }
+    pub fn set_count(env: Env) {
+        env.storage().instance().set(&"owner", &42i128);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = StorageTypeConfusionCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("owner"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_same_key_same_type() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_a(env: Env, addr: Address) {
+        env.storage().instance().set(&"owner", &addr);
+    }
+    pub fn set_b(env: Env, addr: Address) {
+        env.storage().instance().set(&"owner", &addr);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = StorageTypeConfusionCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_different_keys() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_a(env: Env, addr: Address) {
+        env.storage().instance().set(&"admin", &addr);
+    }
+    pub fn set_b(env: Env) {
+        env.storage().instance().set(&"count", &0u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = StorageTypeConfusionCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_single_writer() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_a(env: Env) {
+        env.storage().instance().set(&"count", &0u32);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = StorageTypeConfusionCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/invoke-unchecked-cast-safe/Cargo.toml
+++ b/test-contracts/invoke-unchecked-cast-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-unchecked-cast-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-unchecked-cast-safe/src/lib.rs
+++ b/test-contracts/invoke-unchecked-cast-safe/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct InvokeUncheckedCastSafe;
+
+/// Safe: uses match to handle the cast result explicitly.
+#[contractimpl]
+impl InvokeUncheckedCastSafe {
+    pub fn get_balance(env: Env, contract: Address) -> Option<i128> {
+        let result = env.invoke_contract::<i128>(
+            &contract,
+            &Symbol::new(&env, "balance"),
+            soroban_sdk::vec![&env],
+        );
+        // Safe: type error is handled explicitly rather than silently swallowed.
+        match result.try_into_val(&env) {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+}

--- a/test-contracts/invoke-unchecked-cast-vulnerable/Cargo.toml
+++ b/test-contracts/invoke-unchecked-cast-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-unchecked-cast-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-unchecked-cast-vulnerable/src/lib.rs
+++ b/test-contracts/invoke-unchecked-cast-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct InvokeUncheckedCastVulnerable;
+
+/// Vulnerable: casts invoke_contract result with .unwrap() — a type mismatch
+/// silently produces a zero/default value instead of surfacing an error.
+#[contractimpl]
+impl InvokeUncheckedCastVulnerable {
+    pub fn get_balance(env: Env, contract: Address) -> i128 {
+        // BUG: .try_into_val(...).unwrap() silently returns 0 on type mismatch.
+        env.invoke_contract::<i128>(
+            &contract,
+            &Symbol::new(&env, "balance"),
+            soroban_sdk::vec![&env],
+        )
+        .try_into_val(&env)
+        .unwrap()
+    }
+}

--- a/test-contracts/negative-deposit-safe/Cargo.toml
+++ b/test-contracts/negative-deposit-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-negative-deposit-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/negative-deposit-safe/src/lib.rs
+++ b/test-contracts/negative-deposit-safe/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct NegativeDepositSafe;
+
+/// Safe: asserts amount > 0 before writing to storage.
+#[contractimpl]
+impl NegativeDepositSafe {
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        // Safe: negative amounts are rejected before any state change.
+        assert!(amount > 0, "deposit amount must be positive");
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&from)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&from, &(balance + amount));
+    }
+}

--- a/test-contracts/negative-deposit-vulnerable/Cargo.toml
+++ b/test-contracts/negative-deposit-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-negative-deposit-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/negative-deposit-vulnerable/src/lib.rs
+++ b/test-contracts/negative-deposit-vulnerable/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct NegativeDepositVulnerable;
+
+/// Vulnerable: accepts a negative i128 amount without a positive-value guard.
+/// A caller passing a negative amount effectively withdraws while appearing to deposit.
+#[contractimpl]
+impl NegativeDepositVulnerable {
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        // BUG: no check that amount > 0.
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&from)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&from, &(balance + amount));
+    }
+}

--- a/test-contracts/no-param-no-auth-safe/Cargo.toml
+++ b/test-contracts/no-param-no-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-no-param-no-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/no-param-no-auth-safe/src/lib.rs
+++ b/test-contracts/no-param-no-auth-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct NoParamNoAuthSafe;
+
+/// Safe: requires auth before writing to storage.
+#[contractimpl]
+impl NoParamNoAuthSafe {
+    pub fn reset(env: Env) {
+        // Safe: only the contract itself (or an authorized caller) can reset.
+        env.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("count"), &0u32);
+    }
+}

--- a/test-contracts/no-param-no-auth-vulnerable/Cargo.toml
+++ b/test-contracts/no-param-no-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-no-param-no-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/no-param-no-auth-vulnerable/src/lib.rs
+++ b/test-contracts/no-param-no-auth-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct NoParamNoAuthVulnerable;
+
+/// Vulnerable: public zero-parameter function writes to storage without auth.
+/// Any caller can invoke this and reset the counter.
+#[contractimpl]
+impl NoParamNoAuthVulnerable {
+    pub fn reset(env: Env) {
+        // BUG: no require_auth, no parameters — anyone can call this.
+        env.storage()
+            .instance()
+            .set(&symbol_short!("count"), &0u32);
+    }
+}

--- a/test-contracts/storage-type-confusion-safe/Cargo.toml
+++ b/test-contracts/storage-type-confusion-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-storage-type-confusion-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/storage-type-confusion-safe/src/lib.rs
+++ b/test-contracts/storage-type-confusion-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct StorageTypeConfusionSafe;
+
+/// Safe: each key is always written with the same type.
+#[contractimpl]
+impl StorageTypeConfusionSafe {
+    pub fn set_owner(env: Env, owner: Address) {
+        env.storage().instance().set(&"owner", &owner);
+    }
+
+    pub fn update_owner(env: Env, new_owner: Address) {
+        // Safe: same key "owner" always stores an Address.
+        env.storage().instance().set(&"owner", &new_owner);
+    }
+}

--- a/test-contracts/storage-type-confusion-vulnerable/Cargo.toml
+++ b/test-contracts/storage-type-confusion-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-storage-type-confusion-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/storage-type-confusion-vulnerable/src/lib.rs
+++ b/test-contracts/storage-type-confusion-vulnerable/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct StorageTypeConfusionVulnerable;
+
+/// Vulnerable: the same key "owner" is written with an Address in one function
+/// and with an i128 in another. Readers will deserialize garbage.
+#[contractimpl]
+impl StorageTypeConfusionVulnerable {
+    pub fn set_owner(env: Env, owner: Address) {
+        // Writes Address under "owner".
+        env.storage().instance().set(&"owner", &owner);
+    }
+
+    pub fn reset_owner_id(env: Env) {
+        // BUG: writes i128 under the same "owner" key.
+        env.storage().instance().set(&"owner", &0i128);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks:

### closes #103 `negative-deposit` (High)
Flags `pub fn deposit` / `fund` / `add` in `#[contractimpl]` blocks that accept an `i128` amount parameter and write to storage without a preceding `amount > 0` guard. A caller passing a negative amount effectively withdraws while appearing to deposit.

### closes #104 `storage-type-confusion` (Medium)
Flags cases where the same string literal key is passed to `set(key, value)` in two or more functions within the same `#[contractimpl]` block but with structurally different value types. Readers expecting one type will deserialize garbage when the other type was stored.

### closes #105 `invoke-unchecked-cast` (Medium)
Flags `env.invoke_contract(...)` return values that are cast via `try_into_val`/`from_val` with `.unwrap()` or `.expect()`. A type mismatch silently produces a zero/default value. Use `match` or `if let Ok(...)` instead.

### closes #106 `no-param-no-auth` (Medium)
Flags `pub fn` methods in `#[contractimpl]` blocks that have zero non-Env parameters, no `require_auth` call, and write to storage. Any caller can invoke these and mutate contract state.

## Files changed
- `crates/checks/src/invoke_unchecked_cast.rs` (new)
- `crates/checks/src/negative_deposit.rs` (new)
- `crates/checks/src/no_param_no_auth.rs` (new)
- `crates/checks/src/storage_type_confusion.rs` (new)
- `crates/checks/src/lib.rs` (registered all four checks)
- 8 test contracts (safe + vulnerable for each check)