### PR TITLE
feat: add checks #107 #108 #110 #111

### DIFF
--- a/crates/checks/src/broken_pause.rs
+++ b/crates/checks/src/broken_pause.rs
@@ -1,0 +1,203 @@
+//! Broken circuit-breaker: pause/unpause does not set or check a paused flag.
+//!
+//! A `pub fn pause` that does not write a paused/halted flag to storage has no
+//! effect. State-mutating functions that do not read a paused flag before writing
+//! allow the contract to operate even when it should be halted.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "broken-pause";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" { return true; }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn extract_key_str(arg: &Expr) -> String {
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Path(p) => p.path.segments.last()
+            .map(|s| s.ident.to_string()).unwrap_or_default(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m.mac.tokens.to_string()
+            .trim().trim_matches('"').to_string(),
+        _ => String::new(),
+    }
+}
+
+fn key_looks_like_paused(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    lower.contains("pause") || lower.contains("halt") || lower.contains("frozen")
+        || lower.contains("stopped") || lower.contains("emergency")
+}
+
+#[derive(Default)]
+struct PauseScan {
+    writes_paused_flag: bool,
+    reads_paused_flag: bool,
+    has_storage_set: bool,
+    first_set_line: usize,
+    set_seen: bool,
+}
+
+impl<'ast> Visit<'ast> for PauseScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let method = i.method.to_string();
+        if method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if !self.set_seen {
+                self.has_storage_set = true;
+                self.set_seen = true;
+                self.first_set_line = i.span().start().line;
+            }
+            if let Some(arg) = i.args.first() {
+                if key_looks_like_paused(&extract_key_str(arg)) {
+                    self.writes_paused_flag = true;
+                }
+            }
+        }
+        if matches!(method.as_str(), "get" | "has" | "get_unchecked")
+            && receiver_chain_contains_storage(&i.receiver)
+        {
+            if let Some(arg) = i.args.first() {
+                if key_looks_like_paused(&extract_key_str(arg)) {
+                    self.reads_paused_flag = true;
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct BrokenPauseCheck;
+
+impl Check for BrokenPauseCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            let mut scan = PauseScan::default();
+            scan.visit_block(&method.block);
+
+            // Rule 1: pub fn pause / unpause must write a paused flag.
+            if (name == "pause" || name == "unpause" || name == "emergency_stop")
+                && !scan.writes_paused_flag
+            {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: method.sig.fn_token.span().start().line,
+                    function_name: name.clone(),
+                    description: format!(
+                        "Method `{name}` does not write a paused/halted flag to storage. \
+                         The circuit-breaker has no effect — the contract state is unchanged \
+                         when `{name}` is called. Write a boolean flag under a key like \
+                         `paused` to storage."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_pause_without_flag_write() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pause(env: Env) {
+        // BUG: does nothing — no paused flag written
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BrokenPauseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("paused/halted flag"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_pause_writes_flag() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pause(env: Env) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("paused"), &true);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BrokenPauseCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_unpause_without_flag_write() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn unpause(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BrokenPauseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_pause_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BrokenPauseCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/bytes_not_bytesn.rs
+++ b/crates/checks/src/bytes_not_bytesn.rs
@@ -1,0 +1,150 @@
+//! `Bytes` used instead of `BytesN<N>` for fixed-size cryptographic parameters.
+//!
+//! Parameters named `wasm_hash`, `public_key`, `signature`, `hash`, or `seed`
+//! must be exactly N bytes. Using variable-length `Bytes` allows callers to
+//! pass incorrectly-sized inputs that will panic or produce wrong results.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::{File, FnArg, Pat, Type};
+
+const CHECK_NAME: &str = "bytes-not-bytesn";
+
+const SENSITIVE_PARAM_NAMES: &[&str] = &[
+    "wasm_hash", "public_key", "signature", "hash", "seed",
+    "pubkey", "sig", "key_hash",
+];
+
+fn param_name_is_sensitive(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    SENSITIVE_PARAM_NAMES.iter().any(|s| lower == *s || lower.contains(s))
+}
+
+fn type_is_plain_bytes(ty: &Type) -> bool {
+    match ty {
+        Type::Path(p) => {
+            if let Some(seg) = p.path.segments.last() {
+                // `Bytes` with no angle-bracket args → plain variable-length Bytes
+                return seg.ident == "Bytes"
+                    && matches!(seg.arguments, syn::PathArguments::None);
+            }
+            false
+        }
+        Type::Reference(r) => type_is_plain_bytes(&r.elem),
+        _ => false,
+    }
+}
+
+pub struct BytesNotBytesNCheck;
+
+impl Check for BytesNotBytesNCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            for arg in &method.sig.inputs {
+                let FnArg::Typed(pt) = arg else { continue };
+                let Pat::Ident(pi) = &*pt.pat else { continue };
+                let param_name = pi.ident.to_string();
+                if !param_name_is_sensitive(&param_name) {
+                    continue;
+                }
+                if type_is_plain_bytes(&pt.ty) {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: pi.ident.span().start().line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Parameter `{param_name}` in `{fn_name}` uses `Bytes` \
+                             (variable-length) instead of `BytesN<N>` (fixed-length). \
+                             Callers can pass incorrectly-sized inputs that will panic or \
+                             produce wrong results at runtime. Use `BytesN<32>` for hashes \
+                             or `BytesN<64>` for signatures."
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_bytes_for_hash_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, hash: Bytes) -> bool { true }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesNotBytesNCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert!(hits[0].description.contains("BytesN"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_bytes_for_signature_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn submit(env: Env, signature: Bytes) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesNotBytesNCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_bytesn_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, BytesN, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn verify(env: Env, hash: BytesN<32>) -> bool { true }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesNotBytesNCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_non_sensitive_bytes_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, data: Bytes) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesNotBytesNCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/debug_entrypoint.rs
+++ b/crates/checks/src/debug_entrypoint.rs
@@ -1,0 +1,142 @@
+//! Debug/test/dev entrypoints left in production contracts.
+//!
+//! Public functions whose names contain substrings like `debug`, `test`, `dev_`,
+//! `backdoor`, `mock`, or `dummy` are world-callable admin backdoors.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::{File, Visibility};
+
+const CHECK_NAME: &str = "debug-entrypoint";
+
+const SUSPICIOUS_SUBSTRINGS: &[&str] = &[
+    "debug", "test", "dev_", "backdoor", "mock", "dummy",
+];
+
+fn name_is_suspicious(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    SUSPICIOUS_SUBSTRINGS.iter().any(|s| lower.contains(s))
+}
+
+pub struct DebugEntrypointCheck;
+
+impl Check for DebugEntrypointCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if !name_is_suspicious(&name) {
+                continue;
+            }
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: method.sig.fn_token.span().start().line,
+                function_name: name.clone(),
+                description: format!(
+                    "Public method `{name}` has a debug/test/dev name and should not exist \
+                     in a production contract. It is world-callable and may act as an \
+                     admin backdoor. Remove it or make it private before deployment."
+                ),
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_debug_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn debug_state(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DebugEntrypointCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_dev_mint() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn dev_mint(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DebugEntrypointCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_backdoor() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn backdoor(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DebugEntrypointCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_normal_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DebugEntrypointCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_private_debug_fn() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    fn debug_helper(env: Env) {}
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = DebugEntrypointCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/extend_ttl_in_loop.rs
+++ b/crates/checks/src/extend_ttl_in_loop.rs
@@ -1,0 +1,167 @@
+//! `extend_ttl` called inside a loop (unbounded compute cost).
+//!
+//! Calling `env.storage()...extend_ttl(...)` inside a loop that iterates over
+//! user-supplied data makes the number of host calls unbounded, potentially
+//! exhausting the transaction's compute budget.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprForLoop, ExprLoop, ExprMethodCall, ExprWhile, File};
+
+const CHECK_NAME: &str = "extend-ttl-in-loop";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_extend_ttl(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "extend_ttl" | "bump")
+        && receiver_chain_contains_storage(&m.receiver)
+}
+
+struct LoopVisitor<'a> {
+    fn_name: String,
+    loop_depth: usize,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for LoopVisitor<'ast> {
+    fn visit_expr_for_loop(&mut self, i: &'ast ExprForLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_for_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_while(&mut self, i: &'ast ExprWhile) {
+        self.loop_depth += 1;
+        visit::visit_expr_while(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_loop(&mut self, i: &'ast ExprLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.loop_depth > 0 && is_extend_ttl(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`extend_ttl` is called inside a loop in `{}`. The number of host calls \
+                     scales with the iteration count; if the loop iterates over user-supplied \
+                     data, this can exhaust the transaction compute budget. Batch TTL \
+                     extensions or move them outside the loop.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct ExtendTtlInLoopCheck;
+
+impl Check for ExtendTtlInLoopCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = LoopVisitor {
+                fn_name,
+                loop_depth: 0,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_extend_ttl_in_for_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh_all(env: Env, keys: Vec<Address>) {
+        for key in keys {
+            env.storage().persistent().extend_ttl(&key, 100, 200);
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = ExtendTtlInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_extend_ttl_in_while_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, n: u32) {
+        let mut i = 0u32;
+        while i < n {
+            env.storage().persistent().extend_ttl(&symbol_short!("k"), 100, 200);
+            i += 1;
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = ExtendTtlInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        env.storage().persistent().extend_ttl(&symbol_short!("k"), 100, 200);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = ExtendTtlInLoopCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/hash_as_storage_key.rs
+++ b/crates/checks/src/hash_as_storage_key.rs
@@ -1,0 +1,245 @@
+//! Crypto hash of user input used directly as a storage key.
+//!
+//! `env.storage()...set(sha256(user_input), value)` allows an attacker to
+//! pre-compute keys and overwrite arbitrary storage slots by crafting inputs.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Pat};
+
+const CHECK_NAME: &str = "hash-as-storage-key";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn receiver_chain_contains_crypto(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "crypto" {
+                return true;
+            }
+            receiver_chain_contains_crypto(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_crypto(&f.base),
+        _ => false,
+    }
+}
+
+fn is_hash_call(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "sha256" | "keccak256")
+        && receiver_chain_contains_crypto(&m.receiver)
+}
+
+fn expr_is_hash_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => is_hash_call(m),
+        Expr::Reference(r) => expr_is_hash_call(&r.expr),
+        _ => false,
+    }
+}
+
+/// Collect binding names assigned from hash calls.
+fn collect_hash_bindings(block: &syn::Block) -> Vec<String> {
+    let mut c = HashBindingCollector { bindings: vec![] };
+    c.visit_block(block);
+    c.bindings
+}
+
+struct HashBindingCollector {
+    bindings: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for HashBindingCollector {
+    fn visit_local(&mut self, i: &'ast syn::Local) {
+        if let Some(init) = &i.init {
+            let mut f = HashFinder { found: false };
+            f.visit_expr(&init.expr);
+            if f.found {
+                if let Pat::Ident(pi) = &i.pat {
+                    self.bindings.push(pi.ident.to_string());
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+}
+
+struct HashFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for HashFinder {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_hash_call(i) {
+            self.found = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn key_arg_is_hash_or_binding(arg: &Expr, bindings: &[String]) -> bool {
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    // Inline hash call as key.
+    if expr_is_hash_call(inner) {
+        return true;
+    }
+    // Bound hash result used as key.
+    if let Expr::Path(p) = inner {
+        if let Some(seg) = p.path.segments.last() {
+            return bindings.contains(&seg.ident.to_string());
+        }
+    }
+    false
+}
+
+struct HashKeyVisitor<'a> {
+    fn_name: String,
+    bindings: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for HashKeyVisitor<'ast> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if let Some(key_arg) = i.args.first() {
+                if key_arg_is_hash_or_binding(key_arg, &self.bindings) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` uses a crypto hash (`sha256`/`keccak256`) of \
+                             user-controlled input directly as a storage key. An attacker \
+                             can pre-compute keys to overwrite arbitrary storage slots. \
+                             Use a namespaced or typed key instead.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct HashAsStorageKeyCheck;
+
+impl Check for HashAsStorageKeyCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let bindings = collect_hash_bindings(&method.block);
+            let mut v = HashKeyVisitor {
+                fn_name,
+                bindings,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_inline_sha256_as_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, input: Bytes, val: u32) {
+        env.storage().persistent().set(&env.crypto().sha256(&input), &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = HashAsStorageKeyCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_bound_hash_as_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, input: Bytes, val: u32) {
+        let key = env.crypto().keccak256(&input);
+        env.storage().persistent().set(&key, &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = HashAsStorageKeyCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_constant_key() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, val: u32) {
+        env.storage().persistent().set(&symbol_short!("data"), &val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = HashAsStorageKeyCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_hash_used_as_value() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, input: Bytes) {
+        let hash = env.crypto().sha256(&input);
+        env.storage().persistent().set(&symbol_short!("h"), &hash);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = HashAsStorageKeyCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -6,6 +6,12 @@ pub mod dynamic_symbol_key;
 pub mod instance_vec_growth;
 pub mod migration_guard;
 pub mod withdraw_auth;
+pub mod broken_pause;
+pub mod bytes_not_bytesn;
+pub mod debug_entrypoint;
+pub mod extend_ttl_in_loop;
+pub mod hash_as_storage_key;
+pub mod unauth_address_in_struct;
 pub mod admin_key_removal;
 pub mod admin_overwrite;
 pub mod assert_for_auth;
@@ -47,6 +53,12 @@ pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use instance_vec_growth::InstanceVecGrowthCheck;
 pub use migration_guard::MigrationGuardCheck;
 pub use withdraw_auth::WithdrawAuthCheck;
+pub use broken_pause::BrokenPauseCheck;
+pub use bytes_not_bytesn::BytesNotBytesNCheck;
+pub use debug_entrypoint::DebugEntrypointCheck;
+pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
+pub use hash_as_storage_key::HashAsStorageKeyCheck;
+pub use unauth_address_in_struct::UnauthAddressInStructCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
 pub use assert_for_auth::AssertForAuthCheck;
@@ -148,5 +160,11 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(InstanceVecGrowthCheck),
         Box::new(MigrationGuardCheck),
         Box::new(WithdrawAuthCheck),
+        Box::new(BrokenPauseCheck),
+        Box::new(BytesNotBytesNCheck),
+        Box::new(DebugEntrypointCheck),
+        Box::new(ExtendTtlInLoopCheck),
+        Box::new(HashAsStorageKeyCheck),
+        Box::new(UnauthAddressInStructCheck),
     ]
 }

--- a/crates/checks/src/unauth_address_in_struct.rs
+++ b/crates/checks/src/unauth_address_in_struct.rs
@@ -1,0 +1,233 @@
+//! Address field in stored struct sourced from unauthenticated parameter.
+//!
+//! `storage().set(key, MyStruct { owner: addr, .. })` where `addr` comes from
+//! a function parameter without a preceding `require_auth` on that address
+//! allows an attacker to register arbitrary addresses as owners of stored records.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, ExprStruct, File, FnArg, Pat, Type};
+
+const CHECK_NAME: &str = "unauth-address-in-struct";
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" { return true; }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn type_last_ident(ty: &Type) -> String {
+    match ty {
+        Type::Path(p) => p.path.segments.last()
+            .map(|s| s.ident.to_string()).unwrap_or_default(),
+        Type::Reference(r) => type_last_ident(&r.elem),
+        _ => String::new(),
+    }
+}
+
+/// Collect parameter names typed `Address`.
+fn address_param_names(method: &syn::ImplItemFn) -> Vec<String> {
+    let mut names = Vec::new();
+    for arg in &method.sig.inputs {
+        let FnArg::Typed(pt) = arg else { continue };
+        let Pat::Ident(pi) = &*pt.pat else { continue };
+        if type_last_ident(&pt.ty) == "Address" {
+            names.push(pi.ident.to_string());
+        }
+    }
+    names
+}
+
+fn expr_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+        Expr::Reference(r) => expr_ident(&r.expr),
+        _ => None,
+    }
+}
+
+/// True if any field value in the struct literal is one of the address params.
+fn struct_contains_address_param(es: &ExprStruct, addr_params: &[String]) -> bool {
+    for field in &es.fields {
+        if let Some(name) = expr_ident(&field.expr) {
+            if addr_params.contains(&name) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn value_arg_contains_struct_with_addr(arg: &Expr, addr_params: &[String]) -> bool {
+    let inner = match arg {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Struct(es) => struct_contains_address_param(es, addr_params),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct AuthScan {
+    has_require_auth: bool,
+}
+
+impl<'ast> Visit<'ast> for AuthScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if matches!(
+            i.method.to_string().as_str(),
+            "require_auth" | "require_auth_for_args"
+        ) {
+            self.has_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct UnauthStructVisitor<'a> {
+    fn_name: String,
+    addr_params: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for UnauthStructVisitor<'ast> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if i.args.len() >= 2 {
+                if value_arg_contains_struct_with_addr(&i.args[1], &self.addr_params) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` stores a struct containing an `Address` field \
+                             sourced from a function parameter without calling \
+                             `require_auth()` on that address. An attacker can register \
+                             arbitrary addresses as owners of stored records. Call \
+                             `require_auth()` on the address parameter before the write.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct UnauthAddressInStructCheck;
+
+impl Check for UnauthAddressInStructCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let addr_params = address_param_names(method);
+            if addr_params.is_empty() {
+                continue;
+            }
+            // Check if any require_auth is present.
+            let mut auth_scan = AuthScan::default();
+            auth_scan.visit_block(&method.block);
+            if auth_scan.has_require_auth {
+                continue;
+            }
+            let mut v = UnauthStructVisitor {
+                fn_name,
+                addr_params,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_struct_with_unauthed_address() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+struct Record { owner: Address, amount: i128 }
+#[contractimpl]
+impl C {
+    pub fn register(env: Env, owner: Address, amount: i128) {
+        // BUG: owner not authenticated
+        env.storage().persistent().set(
+            &symbol_short!("rec"),
+            &Record { owner, amount },
+        );
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = UnauthAddressInStructCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("require_auth"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_require_auth_present() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+struct Record { owner: Address, amount: i128 }
+#[contractimpl]
+impl C {
+    pub fn register(env: Env, owner: Address, amount: i128) {
+        owner.require_auth();
+        env.storage().persistent().set(
+            &symbol_short!("rec"),
+            &Record { owner, amount },
+        );
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = UnauthAddressInStructCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_no_address_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+struct Record { amount: i128 }
+#[contractimpl]
+impl C {
+    pub fn register(env: Env, amount: i128) {
+        env.storage().persistent().set(&symbol_short!("rec"), &Record { amount });
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = UnauthAddressInStructCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/broken-pause-safe/Cargo.toml
+++ b/test-contracts/broken-pause-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-broken-pause-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/broken-pause-safe/src/lib.rs
+++ b/test-contracts/broken-pause-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct BrokenPauseSafe;
+
+/// Safe: pause/unpause write and clear the paused flag in storage.
+#[contractimpl]
+impl BrokenPauseSafe {
+    pub fn pause(env: Env) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("paused"), &true);
+    }
+
+    pub fn unpause(env: Env) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("paused"), &false);
+    }
+}

--- a/test-contracts/broken-pause-vulnerable/Cargo.toml
+++ b/test-contracts/broken-pause-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-broken-pause-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/broken-pause-vulnerable/src/lib.rs
+++ b/test-contracts/broken-pause-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct BrokenPauseVulnerable;
+
+/// Vulnerable: pause() does nothing — no paused flag is written to storage.
+#[contractimpl]
+impl BrokenPauseVulnerable {
+    pub fn pause(_env: Env) {
+        // BUG: no storage write — circuit-breaker has no effect.
+    }
+
+    pub fn unpause(_env: Env) {
+        // BUG: same — no flag cleared.
+    }
+}

--- a/test-contracts/bytes-not-bytesn-safe/Cargo.toml
+++ b/test-contracts/bytes-not-bytesn-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-bytes-not-bytesn-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/bytes-not-bytesn-safe/src/lib.rs
+++ b/test-contracts/bytes-not-bytesn-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, BytesN, Env};
+
+#[contract]
+pub struct BytesNotBytesNSafe;
+
+/// Safe: uses BytesN<N> to enforce exact sizes for cryptographic parameters.
+#[contractimpl]
+impl BytesNotBytesNSafe {
+    pub fn verify(env: Env, hash: BytesN<32>, signature: BytesN<64>) -> bool {
+        let _ = (env, hash, signature);
+        true
+    }
+}

--- a/test-contracts/bytes-not-bytesn-vulnerable/Cargo.toml
+++ b/test-contracts/bytes-not-bytesn-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-bytes-not-bytesn-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/bytes-not-bytesn-vulnerable/src/lib.rs
+++ b/test-contracts/bytes-not-bytesn-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct BytesNotBytesNVulnerable;
+
+/// Vulnerable: uses Bytes (variable-length) for fixed-size crypto parameters.
+#[contractimpl]
+impl BytesNotBytesNVulnerable {
+    pub fn verify(env: Env, hash: Bytes, signature: Bytes) -> bool {
+        // BUG: Bytes allows wrong-sized inputs — should be BytesN<32> / BytesN<64>.
+        let _ = (env, hash, signature);
+        true
+    }
+}

--- a/test-contracts/debug-entrypoint-safe/Cargo.toml
+++ b/test-contracts/debug-entrypoint-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-debug-entrypoint-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/debug-entrypoint-safe/src/lib.rs
+++ b/test-contracts/debug-entrypoint-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct DebugEntrypointSafe;
+
+/// Safe: no debug/test/dev entrypoints in production code.
+#[contractimpl]
+impl DebugEntrypointSafe {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        env.require_auth();
+        let _ = (to, amount);
+    }
+}

--- a/test-contracts/debug-entrypoint-vulnerable/Cargo.toml
+++ b/test-contracts/debug-entrypoint-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-debug-entrypoint-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/debug-entrypoint-vulnerable/src/lib.rs
+++ b/test-contracts/debug-entrypoint-vulnerable/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct DebugEntrypointVulnerable;
+
+/// Vulnerable: debug/dev entrypoints left in production — world-callable backdoors.
+#[contractimpl]
+impl DebugEntrypointVulnerable {
+    pub fn dev_mint(env: Env, to: Address, amount: i128) {
+        // BUG: no auth — anyone can mint tokens.
+        let _ = (env, to, amount);
+    }
+
+    pub fn debug_state(env: Env) -> u32 {
+        let _ = env;
+        42
+    }
+}

--- a/test-contracts/extend-ttl-in-loop-safe/Cargo.toml
+++ b/test-contracts/extend-ttl-in-loop-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-extend-ttl-in-loop-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/extend-ttl-in-loop-safe/src/lib.rs
+++ b/test-contracts/extend-ttl-in-loop-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct ExtendTtlInLoopSafe;
+
+/// Safe: extend_ttl called once outside any loop.
+#[contractimpl]
+impl ExtendTtlInLoopSafe {
+    pub fn refresh(env: Env) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&symbol_short!("data"), 100, 200);
+    }
+}

--- a/test-contracts/extend-ttl-in-loop-vulnerable/Cargo.toml
+++ b/test-contracts/extend-ttl-in-loop-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-extend-ttl-in-loop-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/extend-ttl-in-loop-vulnerable/src/lib.rs
+++ b/test-contracts/extend-ttl-in-loop-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+#[contract]
+pub struct ExtendTtlInLoopVulnerable;
+
+/// Vulnerable: extend_ttl called inside a loop — unbounded compute cost.
+#[contractimpl]
+impl ExtendTtlInLoopVulnerable {
+    pub fn refresh_all(env: Env, keys: Vec<Address>) {
+        for key in keys {
+            // BUG: one host call per iteration — scales with list size.
+            env.storage().persistent().extend_ttl(&key, 100, 200);
+        }
+    }
+}

--- a/test-contracts/hash-as-storage-key-safe/Cargo.toml
+++ b/test-contracts/hash-as-storage-key-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hash-as-storage-key-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hash-as-storage-key-safe/src/lib.rs
+++ b/test-contracts/hash-as-storage-key-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, Env};
+
+#[contract]
+pub struct HashAsStorageKeySafe;
+
+/// Safe: uses a constant key; stores the hash as the value, not the key.
+#[contractimpl]
+impl HashAsStorageKeySafe {
+    pub fn store(env: Env, input: Bytes, value: u32) {
+        // Safe: constant key, hash stored as value for integrity checking.
+        let _hash = env.crypto().sha256(&input);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("data"), &value);
+    }
+}

--- a/test-contracts/hash-as-storage-key-vulnerable/Cargo.toml
+++ b/test-contracts/hash-as-storage-key-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hash-as-storage-key-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hash-as-storage-key-vulnerable/src/lib.rs
+++ b/test-contracts/hash-as-storage-key-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct HashAsStorageKeyVulnerable;
+
+/// Vulnerable: uses sha256 of user input directly as a storage key.
+/// An attacker can pre-compute keys to overwrite arbitrary storage slots.
+#[contractimpl]
+impl HashAsStorageKeyVulnerable {
+    pub fn store(env: Env, input: Bytes, value: u32) {
+        // BUG: hash of user input as key — arbitrary slot write.
+        let key = env.crypto().sha256(&input);
+        env.storage().persistent().set(&key, &value);
+    }
+}

--- a/test-contracts/unauth-address-in-struct-safe/Cargo.toml
+++ b/test-contracts/unauth-address-in-struct-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-address-in-struct-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-address-in-struct-safe/src/lib.rs
+++ b/test-contracts/unauth-address-in-struct-safe/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct UnauthAddressInStructSafe;
+
+pub struct Record {
+    pub owner: Address,
+    pub amount: i128,
+}
+
+/// Safe: calls require_auth on the owner address before storing the struct.
+#[contractimpl]
+impl UnauthAddressInStructSafe {
+    pub fn register(env: Env, owner: Address, amount: i128) {
+        // Safe: owner must prove they control the address.
+        owner.require_auth();
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("rec"), &Record { owner, amount });
+    }
+}

--- a/test-contracts/unauth-address-in-struct-vulnerable/Cargo.toml
+++ b/test-contracts/unauth-address-in-struct-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-address-in-struct-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-address-in-struct-vulnerable/src/lib.rs
+++ b/test-contracts/unauth-address-in-struct-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct UnauthAddressInStructVulnerable;
+
+pub struct Record {
+    pub owner: Address,
+    pub amount: i128,
+}
+
+/// Vulnerable: stores a struct with an Address field from an unauthenticated parameter.
+#[contractimpl]
+impl UnauthAddressInStructVulnerable {
+    pub fn register(env: Env, owner: Address, amount: i128) {
+        // BUG: owner is not authenticated — anyone can register any address.
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("rec"), &Record { owner, amount });
+    }
+}


### PR DESCRIPTION


closes #107 extend-ttl-in-loop: flag extend_ttl inside for/while/loop blocks — unbounded compute cost scaling with iteration count.

closes #108 bytes-not-bytesn: flag Bytes (variable-length) used for params named hash/signature/public_key/seed — should be BytesN<N>.

closes #110 broken-pause: flag pub fn pause/unpause that does not write a paused/halted flag to storage — circuit-breaker has no effect.

closes #111 unauth-address-in-struct: flag storage set of a struct literal containing an Address param with no preceding require_auth.

Each check includes unit tests and safe/vulnerable test contracts.