### PR TITLE
feat: add four critical security checks for Soroban contracts

### DIFF
--- a/crates/checks/src/instance_remove_critical.rs
+++ b/crates/checks/src/instance_remove_critical.rs
@@ -1,0 +1,269 @@
+//! Instance storage remove on critical key (self-destruct risk).
+//!
+//! Calling env.storage().instance().remove() on a key that holds critical contract state
+//! (e.g. admin, owner, paused flag, total supply) without strict authorization and a
+//! re-initialization guard can permanently brick the contract.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprLit, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "instance-remove-critical";
+
+/// Critical state key patterns that should not be removed without authorization
+const CRITICAL_PATTERNS: &[&str] = &["admin", "owner", "paused", "supply", "initialized"];
+
+/// Flags storage().instance().remove() calls on keys whose literal name matches a
+/// critical-state pattern without require_auth in the same function.
+pub struct InstanceRemoveCriticalCheck;
+
+impl Check for InstanceRemoveCriticalCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            
+            // Check if function has require_auth
+            let mut auth_scan = AuthScan { has_require_auth: false };
+            auth_scan.visit_block(&method.block);
+            
+            // Scan for instance().remove() calls on critical keys
+            let mut v = RemoveVisitor {
+                fn_name: fn_name.clone(),
+                has_require_auth: auth_scan.has_require_auth,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct AuthScan {
+    has_require_auth: bool,
+}
+
+impl Visit<'_> for AuthScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "require_auth" {
+            self.has_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct RemoveVisitor<'a> {
+    fn_name: String,
+    has_require_auth: bool,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for RemoveVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "remove" && is_instance_storage_call(i) {
+            // Check if the key is a critical literal
+            if let Some(key_str) = extract_key_literal(i) {
+                let key_lower = key_str.to_lowercase();
+                if CRITICAL_PATTERNS.iter().any(|pattern| key_lower.contains(pattern)) {
+                    if !self.has_require_auth {
+                        self.out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line: i.span().start().line,
+                            function_name: self.fn_name.clone(),
+                            description: format!(
+                                "Function `{}` calls storage().instance().remove() on critical key '{}' \
+                                 without require_auth(). Removing critical state can permanently brick \
+                                 the contract. Add strict authorization and re-initialization guards.",
+                                self.fn_name, key_str
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn is_instance_storage_call(m: &ExprMethodCall) -> bool {
+    receiver_chain_contains(&m.receiver, "instance") && receiver_chain_contains(&m.receiver, "storage")
+}
+
+fn receiver_chain_contains(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            m.method == name || receiver_chain_contains(&m.receiver, name)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, name),
+        _ => false,
+    }
+}
+
+fn extract_key_literal(call: &ExprMethodCall) -> Option<String> {
+    if let Some(first_arg) = call.args.first() {
+        match first_arg {
+            Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
+                return Some(lit_str.value());
+            }
+            Expr::Reference(r) => {
+                match &*r.expr {
+                    Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
+                        return Some(lit_str.value());
+                    }
+                    Expr::Call(c) => {
+                        // Handle &Symbol::new(&env, "key") pattern where Symbol::new is a Call, not MethodCall
+                        if let Expr::Path(p) = &*c.func {
+                            if let Some(last_seg) = p.path.segments.last() {
+                                if last_seg.ident == "new" && c.args.len() >= 2 {
+                                    if let Some(second_arg) = c.args.iter().nth(1) {
+                                        if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                            return Some(lit_str.value());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Expr::MethodCall(m) => {
+                        // Handle &Symbol::new(&env, "key") pattern
+                        if m.method == "new" && m.args.len() >= 2 {
+                            if let Some(second_arg) = m.args.iter().nth(1) {
+                                if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                    return Some(lit_str.value());
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Expr::Call(c) => {
+                // Handle Symbol::new(&env, "key") pattern (without reference)
+                if let Expr::Path(p) = &*c.func {
+                    if let Some(last_seg) = p.path.segments.last() {
+                        if last_seg.ident == "new" && c.args.len() >= 2 {
+                            if let Some(second_arg) = c.args.iter().nth(1) {
+                                if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                    return Some(lit_str.value());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Expr::MethodCall(m) => {
+                // Handle Symbol::new(&env, "key") pattern (without reference)
+                if m.method == "new" && m.args.len() >= 2 {
+                    if let Some(second_arg) = m.args.iter().nth(1) {
+                        if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                            return Some(lit_str.value());
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn detects_remove_admin_without_auth() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn remove_admin(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "admin"));
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = InstanceRemoveCriticalCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn allows_remove_admin_with_auth() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn remove_admin(env: Env) {
+        env.require_auth();
+        env.storage().instance().remove(&Symbol::new(&env, "admin"));
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = InstanceRemoveCriticalCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn detects_remove_owner_without_auth() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn clear_owner(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "owner"));
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = InstanceRemoveCriticalCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn allows_remove_non_critical_key() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn clear_cache(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "cache"));
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = InstanceRemoveCriticalCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -37,6 +37,7 @@ pub mod no_std;
 pub mod env_in_struct;
 pub mod sequence_as_key;
 pub mod temp_get_no_has;
+pub mod contracterror_attr;
 pub mod balance_overflow;
 pub mod overflow;
 pub mod uncapped_fee;
@@ -59,6 +60,10 @@ pub mod unbounded_batch;
 pub mod unvalidated_price;
 pub mod vesting_cliff;
 pub mod transfer_to_self;
+pub mod wrapping_balance_op;
+pub mod unauth_sensitive_read;
+pub mod instance_remove_critical;
+pub mod map_user_key_bloat;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
@@ -97,6 +102,8 @@ pub use missing_ttl::MissingTtlExtensionCheck;
 pub use no_std::NoStdCheck;
 pub use sequence_as_key::SequenceAsKeyCheck;
 pub use env_in_struct::EnvInStructCheck;
+pub use temp_get_no_has::TempGetNoHasCheck;
+pub use contracterror_attr::ContracterrorAttrCheck;
 pub use balance_overflow::BalanceOverflowCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use uncapped_fee::UncappedFeeCheck;
@@ -118,6 +125,10 @@ pub use unbounded_batch::UnboundedBatchCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
+pub use wrapping_balance_op::WrappingBalanceOpCheck;
+pub use unauth_sensitive_read::UnauthSensitiveReadCheck;
+pub use instance_remove_critical::InstanceRemoveCriticalCheck;
+pub use map_user_key_bloat::MapUserKeyBloatCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -203,5 +214,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(Secp256k1UncheckedCheck),
         Box::new(TempSetNoTtlCheck),
         Box::new(BalanceOverflowCheck),
+        Box::new(WrappingBalanceOpCheck),
+        Box::new(UnauthSensitiveReadCheck),
+        Box::new(InstanceRemoveCriticalCheck),
+        Box::new(MapUserKeyBloatCheck),
     ]
 }

--- a/crates/checks/src/map_user_key_bloat.rs
+++ b/crates/checks/src/map_user_key_bloat.rs
@@ -1,0 +1,205 @@
+//! Map with user-supplied keys without size limit (map bloat).
+//!
+//! Inserting into a soroban_sdk::Map stored in instance or persistent storage using a key
+//! derived from user input without a maximum-entry guard allows an attacker to bloat the map
+//! indefinitely, increasing read/write costs for all users.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, FnArg, Pat};
+
+const CHECK_NAME: &str = "map-user-key-bloat";
+
+/// Detects Map::set() calls where the key argument traces back to a function parameter
+/// and there is no map.len() guard in the same function.
+pub struct MapUserKeyBloatCheck;
+
+impl Check for MapUserKeyBloatCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            
+            // Collect parameter names
+            let mut param_names = Vec::new();
+            for input in &method.sig.inputs {
+                if let FnArg::Typed(pat_type) = input {
+                    if let Pat::Ident(pat_ident) = &*pat_type.pat {
+                        param_names.push(pat_ident.ident.to_string());
+                    }
+                }
+            }
+            
+            // Scan for Map::set() calls and len() checks
+            let mut v = MapSetVisitor {
+                param_names: &param_names,
+                map_set_with_user_key: Vec::new(),
+                has_len_check: false,
+            };
+            v.visit_block(&method.block);
+            
+            // Report findings for Map::set() calls with user keys and no len() guard
+            if !v.map_set_with_user_key.is_empty() && !v.has_len_check {
+                for line in v.map_set_with_user_key {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Function `{}` calls Map::set() with a user-supplied key without a \
+                             map.len() guard. An attacker can bloat the map indefinitely, \
+                             increasing storage costs for all users. Add a maximum size check.",
+                            fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+struct MapSetVisitor<'a> {
+    param_names: &'a [String],
+    map_set_with_user_key: Vec<usize>,
+    has_len_check: bool,
+}
+
+impl Visit<'_> for MapSetVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        // Check for Map::set() calls (but not storage().*.set())
+        if i.method == "set" && !i.args.is_empty() && !is_storage_set(i) {
+            // Check if first argument (key) references a parameter
+            if let Some(first_arg) = i.args.first() {
+                if expr_references_params(first_arg, self.param_names) {
+                    self.map_set_with_user_key.push(i.span().start().line);
+                }
+            }
+        }
+        
+        // Check for len() method calls (size guard)
+        if i.method == "len" {
+            self.has_len_check = true;
+        }
+        
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn is_storage_set(m: &ExprMethodCall) -> bool {
+    receiver_chain_contains(&m.receiver, "storage")
+}
+
+fn receiver_chain_contains(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            m.method == name || receiver_chain_contains(&m.receiver, name)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, name),
+        _ => false,
+    }
+}
+
+/// Check if an expression directly references any function parameter (not nested in method calls)
+fn expr_references_params(expr: &Expr, param_names: &[String]) -> bool {
+    match expr {
+        Expr::Path(p) => {
+            if let Some(ident) = p.path.get_ident() {
+                let ident_str = ident.to_string();
+                // Exclude "env" as it's commonly used for Symbol::new(&env, "key")
+                return param_names.contains(&ident_str) && ident_str != "env";
+            }
+            false
+        }
+        Expr::Reference(r) => expr_references_params(&r.expr, param_names),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn detects_map_set_with_user_key_no_guard() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add_item(env: Env, user_key: Symbol, value: u32) {
+        let mut map: Map<Symbol, u32> = env.storage().instance().get(&Symbol::new(&env, "map")).unwrap_or(Map::new(&env));
+        map.set(user_key, value);
+        env.storage().instance().set(&Symbol::new(&env, "map"), &map);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = MapUserKeyBloatCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn allows_map_set_with_len_guard() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add_item(env: Env, user_key: Symbol, value: u32) {
+        let mut map: Map<Symbol, u32> = env.storage().instance().get(&Symbol::new(&env, "map")).unwrap_or(Map::new(&env));
+        if map.len() >= 100 {
+            panic!("Map is full");
+        }
+        map.set(user_key, value);
+        env.storage().instance().set(&Symbol::new(&env, "map"), &map);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = MapUserKeyBloatCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn allows_map_set_with_literal_key() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn init(env: Env) {
+        let mut map: Map<Symbol, u32> = Map::new(&env);
+        map.set(Symbol::new(&env, "fixed_key"), 42);
+        env.storage().instance().set(&Symbol::new(&env, "map"), &map);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = MapUserKeyBloatCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/unauth_sensitive_read.rs
+++ b/crates/checks/src/unauth_sensitive_read.rs
@@ -1,0 +1,295 @@
+//! Unauth sensitive storage read (data exposure).
+//!
+//! A public function that reads and returns a sensitive storage value (e.g. admin address,
+//! private key material, secret nonce) without require_auth exposes that data to any
+//! on-chain observer or off-chain caller.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprLit, ExprMethodCall, File, Lit, ReturnType};
+
+const CHECK_NAME: &str = "unauth-sensitive-read";
+
+/// Sensitive key patterns that should not be exposed without authorization
+const SENSITIVE_PATTERNS: &[&str] = &["admin", "owner", "secret", "key", "priv"];
+
+/// Flags public functions that return a value read from storage under a key whose name
+/// contains admin, owner, secret, key, or priv without any require_auth call.
+pub struct UnauthSensitiveReadCheck;
+
+impl Check for UnauthSensitiveReadCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            
+            // Skip if function returns unit type ()
+            if matches!(method.sig.output, ReturnType::Default) {
+                continue;
+            }
+            
+            // Check if function has require_auth
+            let mut auth_scan = AuthScan { has_require_auth: false };
+            auth_scan.visit_block(&method.block);
+            
+            if auth_scan.has_require_auth {
+                continue;
+            }
+            
+            // Scan for storage get calls on sensitive keys
+            let mut v = SensitiveReadVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct AuthScan {
+    has_require_auth: bool,
+}
+
+impl Visit<'_> for AuthScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "require_auth" {
+            self.has_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct SensitiveReadVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for SensitiveReadVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "get" && is_storage_call(i) {
+            // Check if the key is a sensitive literal
+            if let Some(key_str) = extract_key_literal(i) {
+                let key_lower = key_str.to_lowercase();
+                if SENSITIVE_PATTERNS.iter().any(|pattern| key_lower.contains(pattern)) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Function `{}` reads and returns sensitive storage key '{}' without \
+                             require_auth(). This exposes sensitive data to any caller. Add \
+                             authorization checks before returning sensitive values.",
+                            self.fn_name, key_str
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn is_storage_call(m: &ExprMethodCall) -> bool {
+    receiver_chain_contains(&m.receiver, "storage")
+}
+
+fn receiver_chain_contains(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            m.method == name || receiver_chain_contains(&m.receiver, name)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, name),
+        _ => false,
+    }
+}
+
+fn extract_key_literal(call: &ExprMethodCall) -> Option<String> {
+    if let Some(first_arg) = call.args.first() {
+        match first_arg {
+            Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
+                return Some(lit_str.value());
+            }
+            Expr::Reference(r) => {
+                match &*r.expr {
+                    Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) => {
+                        return Some(lit_str.value());
+                    }
+                    Expr::Call(c) => {
+                        // Handle &Symbol::new(&env, "key") pattern where Symbol::new is a Call, not MethodCall
+                        if let Expr::Path(p) = &*c.func {
+                            if let Some(last_seg) = p.path.segments.last() {
+                                if last_seg.ident == "new" && c.args.len() >= 2 {
+                                    if let Some(second_arg) = c.args.iter().nth(1) {
+                                        if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                            return Some(lit_str.value());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Expr::MethodCall(m) => {
+                        // Handle &Symbol::new(&env, "key") pattern
+                        if m.method == "new" && m.args.len() >= 2 {
+                            if let Some(second_arg) = m.args.iter().nth(1) {
+                                if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                    return Some(lit_str.value());
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Expr::Call(c) => {
+                // Handle Symbol::new(&env, "key") pattern (without reference)
+                if let Expr::Path(p) = &*c.func {
+                    if let Some(last_seg) = p.path.segments.last() {
+                        if last_seg.ident == "new" && c.args.len() >= 2 {
+                            if let Some(second_arg) = c.args.iter().nth(1) {
+                                if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                                    return Some(lit_str.value());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Expr::MethodCall(m) => {
+                // Handle Symbol::new(&env, "key") pattern (without reference)
+                if m.method == "new" && m.args.len() >= 2 {
+                    if let Some(second_arg) = m.args.iter().nth(1) {
+                        if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = second_arg {
+                            return Some(lit_str.value());
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn detects_unauth_admin_read() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&Symbol::new(&env, "admin")).unwrap()
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = UnauthSensitiveReadCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn allows_auth_admin_read() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn get_admin(env: Env) -> Address {
+        env.require_auth();
+        env.storage().instance().get(&Symbol::new(&env, "admin")).unwrap()
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = UnauthSensitiveReadCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn detects_secret_key_read() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn get_secret(env: Env) -> u64 {
+        env.storage().persistent().get(&Symbol::new(&env, "secret_key")).unwrap()
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = UnauthSensitiveReadCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn allows_non_sensitive_read() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn get_balance(env: Env) -> i128 {
+        env.storage().persistent().get(&Symbol::new(&env, "balance")).unwrap()
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = UnauthSensitiveReadCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn allows_void_function() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn log_admin(env: Env) {
+        let _admin = env.storage().instance().get(&Symbol::new(&env, "admin"));
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = UnauthSensitiveReadCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/wrapping_balance_op.rs
+++ b/crates/checks/src/wrapping_balance_op.rs
@@ -1,0 +1,222 @@
+//! Wrapping arithmetic on token balance (silent overflow).
+//!
+//! Explicitly using wrapping_add or wrapping_sub on a variable used as a token balance
+//! bypasses Rust's overflow checks and can silently wrap balances to incorrect values,
+//! enabling theft or minting of tokens.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Stmt};
+
+const CHECK_NAME: &str = "wrapping-balance-op";
+
+/// Flags wrapping_add / wrapping_sub / wrapping_mul method calls on variables that are
+/// subsequently stored via storage().*.set() or passed to a token client.
+pub struct WrappingBalanceOpCheck;
+
+impl Check for WrappingBalanceOpCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            
+            // Check if function has storage writes or token operations
+            let has_storage_write = method.block.stmts.iter().any(stmt_has_storage_set);
+            let has_token_op = method.block.stmts.iter().any(stmt_has_token_call);
+            
+            if has_storage_write || has_token_op {
+                let mut v = WrappingOpVisitor {
+                    fn_name: fn_name.clone(),
+                    out: &mut out,
+                };
+                v.visit_block(&method.block);
+            }
+        }
+        out
+    }
+}
+
+struct WrappingOpVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for WrappingOpVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let method_name = i.method.to_string();
+        if matches!(method_name.as_str(), "wrapping_add" | "wrapping_sub" | "wrapping_mul") {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Function `{}` uses `{}` on a value that flows into storage or token operations. \
+                     Wrapping arithmetic bypasses overflow checks and can silently produce incorrect \
+                     balances, enabling theft or unauthorized minting. Use checked arithmetic instead.",
+                    self.fn_name, method_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn method_chain_contains(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == name {
+                return true;
+            }
+            method_chain_contains(&m.receiver, name)
+        }
+        _ => false,
+    }
+}
+
+fn expr_has_storage_set(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "set" && method_chain_contains(&m.receiver, "storage") {
+                return true;
+            }
+            expr_has_storage_set(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn expr_has_token_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            let method_name = m.method.to_string();
+            if matches!(method_name.as_str(), "transfer" | "mint" | "burn" | "approve") {
+                return true;
+            }
+            expr_has_token_call(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn stmt_has_storage_set(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Expr(e, _) => expr_has_storage_set(e),
+        _ => false,
+    }
+}
+
+fn stmt_has_token_call(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Expr(e, _) => expr_has_token_call(e),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn detects_wrapping_add_with_storage() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn deposit(env: Env, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&Symbol::new(&env, "bal")).unwrap_or(0);
+        let new_balance = balance.wrapping_add(amount);
+        env.storage().persistent().set(&Symbol::new(&env, "bal"), &new_balance);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = WrappingBalanceOpCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn detects_wrapping_sub_with_storage() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn withdraw(env: Env, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&Symbol::new(&env, "bal")).unwrap_or(0);
+        let new_balance = balance.wrapping_sub(amount);
+        env.storage().persistent().set(&Symbol::new(&env, "bal"), &new_balance);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = WrappingBalanceOpCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn allows_checked_add() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn deposit(env: Env, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&Symbol::new(&env, "bal")).unwrap_or(0);
+        let new_balance = balance.checked_add(amount).expect("overflow");
+        env.storage().persistent().set(&Symbol::new(&env, "bal"), &new_balance);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = WrappingBalanceOpCheck;
+        let findings = check.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn detects_wrapping_mul_with_token() {
+        let code = r#"
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn multiply_and_transfer(env: Env, token: Address, to: Address, amount: i128, multiplier: i128) {
+        let total = amount.wrapping_mul(multiplier);
+        token.transfer(&env, &to, &total);
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let check = WrappingBalanceOpCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+}

--- a/test-contracts/instance-remove-critical-safe/Cargo.toml
+++ b/test-contracts/instance-remove-critical-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-instance-remove-critical-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/instance-remove-critical-safe/src/lib.rs
+++ b/test-contracts/instance-remove-critical-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct InstanceRemoveCriticalSafe;
+
+#[contractimpl]
+impl InstanceRemoveCriticalSafe {
+    /// Removes admin with auth — should pass `instance-remove-critical`.
+    pub fn remove_admin(env: Env) {
+        env.require_auth();
+        env.storage().instance().remove(&Symbol::new(&env, "admin"));
+    }
+}

--- a/test-contracts/instance-remove-critical-vulnerable/Cargo.toml
+++ b/test-contracts/instance-remove-critical-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-instance-remove-critical-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/instance-remove-critical-vulnerable/src/lib.rs
+++ b/test-contracts/instance-remove-critical-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct InstanceRemoveCriticalVulnerable;
+
+#[contractimpl]
+impl InstanceRemoveCriticalVulnerable {
+    /// Removes admin without auth — should trigger `instance-remove-critical` (High).
+    pub fn remove_admin(env: Env) {
+        env.storage().instance().remove(&Symbol::new(&env, "admin"));
+    }
+}

--- a/test-contracts/map-user-key-bloat-safe/Cargo.toml
+++ b/test-contracts/map-user-key-bloat-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-map-user-key-bloat-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/map-user-key-bloat-safe/src/lib.rs
+++ b/test-contracts/map-user-key-bloat-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol};
+
+#[contract]
+pub struct MapUserKeyBloatSafe;
+
+#[contractimpl]
+impl MapUserKeyBloatSafe {
+    /// Map::set with user key but has len guard — should pass `map-user-key-bloat`.
+    pub fn add_item(env: Env, user_key: Symbol, value: u32) {
+        let mut map: Map<Symbol, u32> = env.storage().instance().get(&Symbol::new(&env, "map")).unwrap_or(Map::new(&env));
+        if map.len() >= 100 {
+            panic!("Map is full");
+        }
+        map.set(user_key, value);
+        env.storage().instance().set(&Symbol::new(&env, "map"), &map);
+    }
+}

--- a/test-contracts/map-user-key-bloat-vulnerable/Cargo.toml
+++ b/test-contracts/map-user-key-bloat-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-map-user-key-bloat-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/map-user-key-bloat-vulnerable/src/lib.rs
+++ b/test-contracts/map-user-key-bloat-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol};
+
+#[contract]
+pub struct MapUserKeyBloatVulnerable;
+
+#[contractimpl]
+impl MapUserKeyBloatVulnerable {
+    /// Map::set with user key, no len guard — should trigger `map-user-key-bloat` (Medium).
+    pub fn add_item(env: Env, user_key: Symbol, value: u32) {
+        let mut map: Map<Symbol, u32> = env.storage().instance().get(&Symbol::new(&env, "map")).unwrap_or(Map::new(&env));
+        map.set(user_key, value);
+        env.storage().instance().set(&Symbol::new(&env, "map"), &map);
+    }
+}

--- a/test-contracts/unauth-sensitive-read-safe/Cargo.toml
+++ b/test-contracts/unauth-sensitive-read-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-sensitive-read-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-sensitive-read-safe/src/lib.rs
+++ b/test-contracts/unauth-sensitive-read-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct UnauthSensitiveReadSafe;
+
+#[contractimpl]
+impl UnauthSensitiveReadSafe {
+    /// Returns admin with auth — should pass `unauth-sensitive-read`.
+    pub fn get_admin(env: Env) -> Address {
+        env.require_auth();
+        env.storage().instance().get(&Symbol::new(&env, "admin")).unwrap()
+    }
+}

--- a/test-contracts/unauth-sensitive-read-vulnerable/Cargo.toml
+++ b/test-contracts/unauth-sensitive-read-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-sensitive-read-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-sensitive-read-vulnerable/src/lib.rs
+++ b/test-contracts/unauth-sensitive-read-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct UnauthSensitiveReadVulnerable;
+
+#[contractimpl]
+impl UnauthSensitiveReadVulnerable {
+    /// Returns admin without auth — should trigger `unauth-sensitive-read` (Medium).
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&Symbol::new(&env, "admin")).unwrap()
+    }
+}

--- a/test-contracts/wrapping-balance-op-safe/Cargo.toml
+++ b/test-contracts/wrapping-balance-op-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-wrapping-balance-op-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/wrapping-balance-op-safe/src/lib.rs
+++ b/test-contracts/wrapping-balance-op-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct WrappingBalanceOpSafe;
+
+#[contractimpl]
+impl WrappingBalanceOpSafe {
+    /// Uses checked_add on balance — should pass `wrapping-balance-op`.
+    pub fn deposit(env: Env, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&Symbol::new(&env, "bal")).unwrap_or(0);
+        let new_balance = balance.checked_add(amount).expect("overflow");
+        env.storage().persistent().set(&Symbol::new(&env, "bal"), &new_balance);
+    }
+}

--- a/test-contracts/wrapping-balance-op-vulnerable/Cargo.toml
+++ b/test-contracts/wrapping-balance-op-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-wrapping-balance-op-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/wrapping-balance-op-vulnerable/src/lib.rs
+++ b/test-contracts/wrapping-balance-op-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct WrappingBalanceOpVulnerable;
+
+#[contractimpl]
+impl WrappingBalanceOpVulnerable {
+    /// Uses wrapping_add on balance — should trigger `wrapping-balance-op` (High).
+    pub fn deposit(env: Env, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&Symbol::new(&env, "bal")).unwrap_or(0);
+        let new_balance = balance.wrapping_add(amount);
+        env.storage().persistent().set(&Symbol::new(&env, "bal"), &new_balance);
+    }
+}


### PR DESCRIPTION
Add four new vulnerability detectors to enhance smart contract security:

1. Map User Key Bloat (Medium Severity)
   - Detects Map::set() calls with user-supplied keys without size limits
   - Prevents attackers from bloating storage indefinitely
   - Requires len() guard before insertion

2. Wrapping Balance Operations (High Severity)
   - Flags wrapping_add/sub/mul on values flowing to storage or token ops
   - Prevents silent overflow bypassing Rust's safety checks
   - Enforces checked arithmetic for balance operations

3. Unauthorized Sensitive Read (Medium Severity)
   - Detects public functions returning sensitive storage without auth
   - Protects admin, owner, secret, key, and private data
   - Requires require_auth() before exposing sensitive values

4. Instance Remove Critical (High Severity)
   - Flags removal of critical state keys without authorization
   - Prevents contract bricking via admin/owner/supply removal
   - Enforces strict auth checks before removing critical state

Each check includes:
- Comprehensive unit tests
- Safe and vulnerable test contracts
- Clear severity levels and descriptions
- Integration with default_checks()

Closes #160 
Closes #161 
Closes #162 
Closes #163 