### PR TITLE
Feat/issues 134 137 138 147

### DIFF
--- a/crates/checks/src/addr_param_no_auth.rs
+++ b/crates/checks/src/addr_param_no_auth.rs
@@ -1,0 +1,264 @@
+//! Address parameter without `require_auth` before storage write or token call.
+//!
+//! A `#[contractimpl]` function that receives an `Address` parameter and writes to
+//! storage or calls a token client must call `addr.require_auth()` (or
+//! `env.require_auth_for_address(addr, ...)`) on that parameter. Omitting this lets
+//! any caller impersonate any address.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, FnArg, Pat, Type};
+
+const CHECK_NAME: &str = "addr-param-no-auth";
+
+/// Token-client method names that constitute a privileged operation.
+const TOKEN_METHODS: &[&str] = &["transfer", "mint", "burn", "transfer_from", "burn_from"];
+
+pub struct AddrParamNoAuthCheck;
+
+impl Check for AddrParamNoAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            // Collect Address-typed parameter names.
+            let addr_params: Vec<String> = method
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|arg| {
+                    let FnArg::Typed(pt) = arg else { return None };
+                    if !type_is_address(&pt.ty) {
+                        return None;
+                    }
+                    if let Pat::Ident(pi) = &*pt.pat {
+                        Some(pi.ident.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if addr_params.is_empty() {
+                continue;
+            }
+
+            let mut scan = BodyScan::new(addr_params.clone());
+            scan.visit_block(&method.block);
+
+            if !scan.has_storage_write && !scan.has_token_call {
+                continue;
+            }
+
+            // Report each Address param that is never authenticated.
+            for param in &addr_params {
+                if !scan.authed_params.contains(param) {
+                    let fn_name = method.sig.ident.to_string();
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: scan
+                            .write_line
+                            .unwrap_or_else(|| method.sig.ident.span().start().line),
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Method `{fn_name}` has an `Address` parameter `{param}` but \
+                             never calls `{param}.require_auth()` or \
+                             `env.require_auth_for_address({param}, ...)` before writing to \
+                             storage or calling a token client. Any caller can impersonate \
+                             this address."
+                        ),
+                    });
+                    break; // one finding per function is enough
+                }
+            }
+        }
+        out
+    }
+}
+
+fn type_is_address(ty: &Type) -> bool {
+    match ty {
+        Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "Address"),
+        _ => false,
+    }
+}
+
+struct BodyScan {
+    addr_params: Vec<String>,
+    authed_params: Vec<String>,
+    has_storage_write: bool,
+    has_token_call: bool,
+    write_line: Option<usize>,
+}
+
+impl BodyScan {
+    fn new(addr_params: Vec<String>) -> Self {
+        Self {
+            addr_params,
+            authed_params: Vec::new(),
+            has_storage_write: false,
+            has_token_call: false,
+            write_line: None,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for BodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+
+        // addr.require_auth()
+        if method == "require_auth" {
+            if let Expr::Path(p) = &*i.receiver {
+                let name = p.path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
+                if self.addr_params.contains(&name) && !self.authed_params.contains(&name) {
+                    self.authed_params.push(name);
+                }
+            }
+        }
+
+        // env.require_auth_for_address(addr, ...)
+        if method == "require_auth_for_address" {
+            if let Some(first_arg) = i.args.first() {
+                if let Expr::Path(p) = first_arg {
+                    let name = p.path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
+                    if self.addr_params.contains(&name) && !self.authed_params.contains(&name) {
+                        self.authed_params.push(name);
+                    }
+                }
+            }
+        }
+
+        // Storage write
+        if matches!(method.as_str(), "set" | "remove") && receiver_chain_contains_storage(&i.receiver) {
+            self.has_storage_write = true;
+            if self.write_line.is_none() {
+                self.write_line = Some(i.span().start().line);
+            }
+        }
+
+        // Token client call
+        if TOKEN_METHODS.contains(&method.as_str()) {
+            self.has_token_call = true;
+            if self.write_line.is_none() {
+                self.write_line = Some(i.span().start().line);
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        AddrParamNoAuthCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_address_param_without_require_auth() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        env.storage().persistent().set(&symbol_short!("bal"), &amount);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "deposit");
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn passes_when_require_auth_called_on_param() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        env.storage().persistent().set(&symbol_short!("bal"), &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_require_auth_for_address_called() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        env.require_auth_for_address(user, ());
+        env.storage().persistent().set(&symbol_short!("bal"), &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_function_without_storage_write_or_token_call() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn get_info(env: Env, user: Address) -> bool {
+        true
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_function_without_address_params() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn bump(env: Env, amount: i128) {
+        env.storage().persistent().set(&symbol_short!("k"), &amount);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/commitment_not_cleared.rs
+++ b/crates/checks/src/commitment_not_cleared.rs
@@ -1,0 +1,237 @@
+//! Commitment not cleared after reveal — replay attack vector.
+//!
+//! A `reveal` or `claim` function that reads a commitment from storage but never
+//! removes or overwrites it allows an attacker to replay the same reveal transaction.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "commitment-not-cleared";
+
+/// Commitment key heuristics — any storage key whose ident text contains one of these.
+const COMMIT_KEY_HINTS: &[&str] = &["commit", "hash", "nonce", "secret"];
+
+pub struct CommitmentNotClearedCheck;
+
+impl Check for CommitmentNotClearedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !matches!(fn_name.as_str(), "reveal" | "claim") {
+                continue;
+            }
+
+            let mut scan = BodyScan::default();
+            scan.visit_block(&method.block);
+
+            if scan.commitment_get && !scan.commitment_cleared {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: scan.get_line.unwrap_or_else(|| method.sig.ident.span().start().line),
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Method `{fn_name}` reads a commitment from storage but never removes \
+                         or overwrites it. An attacker can replay the same reveal transaction \
+                         to trigger the reveal logic multiple times."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct BodyScan {
+    commitment_get: bool,
+    commitment_cleared: bool,
+    get_line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for BodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+
+        if receiver_chain_contains_storage(&i.receiver) {
+            match method.as_str() {
+                "get" | "get_unchecked" => {
+                    if i.args.iter().any(|a| expr_contains_commit_hint(a)) {
+                        self.commitment_get = true;
+                        if self.get_line.is_none() {
+                            self.get_line = Some(i.span().start().line);
+                        }
+                    }
+                }
+                "remove" => {
+                    if i.args.iter().any(|a| expr_contains_commit_hint(a)) {
+                        self.commitment_cleared = true;
+                    }
+                }
+                "set" if i.args.len() == 2 => {
+                    if i.args.iter().next().is_some_and(|a| expr_contains_commit_hint(a)) {
+                        self.commitment_cleared = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+/// Collect all ident/string-literal text from an expression and check for commit hints.
+fn expr_contains_commit_hint(expr: &Expr) -> bool {
+    let text = expr_to_text(expr).to_lowercase();
+    COMMIT_KEY_HINTS.iter().any(|hint| text.contains(hint))
+}
+
+fn expr_to_text(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("_"),
+        Expr::Macro(m) => {
+            // e.g. symbol_short!("commit") — grab the token stream as string
+            m.mac.tokens.to_string()
+        }
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            syn::Lit::ByteStr(b) => String::from_utf8_lossy(&b.value()).into_owned(),
+            _ => String::new(),
+        },
+        Expr::Reference(r) => expr_to_text(&r.expr),
+        Expr::Call(c) => {
+            // e.g. DataKey::Commit
+            let mut s = expr_to_text(&c.func);
+            for arg in &c.args {
+                s.push('_');
+                s.push_str(&expr_to_text(arg));
+            }
+            s
+        }
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        CommitmentNotClearedCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_reveal_without_remove() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reveal(env: Env, secret: u64) {
+        let stored: u64 = env.storage().persistent().get(&symbol_short!("commit")).unwrap();
+        assert_eq!(stored, secret);
+        // BUG: commitment never removed — replay possible
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "reveal");
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn passes_when_remove_called() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reveal(env: Env, secret: u64) {
+        let stored: u64 = env.storage().persistent().get(&symbol_short!("commit")).unwrap();
+        assert_eq!(stored, secret);
+        env.storage().persistent().remove(&symbol_short!("commit"));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_overwrite_set_called() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn reveal(env: Env, secret: u64) {
+        let stored: u64 = env.storage().persistent().get(&symbol_short!("commit")).unwrap();
+        assert_eq!(stored, secret);
+        env.storage().persistent().set(&symbol_short!("commit"), &0u64);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_reveal_functions() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env) {
+        let _: u64 = env.storage().persistent().get(&symbol_short!("commit")).unwrap();
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_claim_without_remove() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn claim(env: Env) {
+        let _: u64 = env.storage().persistent().get(&symbol_short!("commit")).unwrap();
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "claim");
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -61,6 +61,7 @@ pub mod vesting_cliff;
 pub mod transfer_to_self;
 pub mod unauth_address_tuple;
 pub mod commitment_not_cleared;
+pub mod supply_cap;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
@@ -122,6 +123,7 @@ pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 pub use unauth_address_tuple::UnauthAddressTupleCheck;
 pub use commitment_not_cleared::CommitmentNotClearedCheck;
+pub use supply_cap::SupplyCapCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -209,5 +211,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(BalanceOverflowCheck),
         Box::new(UnauthAddressTupleCheck),
         Box::new(CommitmentNotClearedCheck),
+        Box::new(SupplyCapCheck),
     ]
 }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -60,6 +60,7 @@ pub mod unvalidated_price;
 pub mod vesting_cliff;
 pub mod transfer_to_self;
 pub mod unauth_address_tuple;
+pub mod commitment_not_cleared;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
@@ -120,6 +121,7 @@ pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 pub use unauth_address_tuple::UnauthAddressTupleCheck;
+pub use commitment_not_cleared::CommitmentNotClearedCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -206,5 +208,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TempSetNoTtlCheck),
         Box::new(BalanceOverflowCheck),
         Box::new(UnauthAddressTupleCheck),
+        Box::new(CommitmentNotClearedCheck),
     ]
 }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -59,6 +59,7 @@ pub mod unbounded_batch;
 pub mod unvalidated_price;
 pub mod vesting_cliff;
 pub mod transfer_to_self;
+pub mod unauth_address_tuple;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
@@ -118,6 +119,7 @@ pub use unbounded_batch::UnboundedBatchCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
+pub use unauth_address_tuple::UnauthAddressTupleCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -203,5 +205,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(Secp256k1UncheckedCheck),
         Box::new(TempSetNoTtlCheck),
         Box::new(BalanceOverflowCheck),
+        Box::new(UnauthAddressTupleCheck),
     ]
 }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -62,6 +62,7 @@ pub mod transfer_to_self;
 pub mod unauth_address_tuple;
 pub mod commitment_not_cleared;
 pub mod supply_cap;
+pub mod addr_param_no_auth;
 mod util;
 
 pub use admin::UnprotectedAdminCheck;
@@ -124,6 +125,7 @@ pub use transfer_to_self::TransferToSelfCheck;
 pub use unauth_address_tuple::UnauthAddressTupleCheck;
 pub use commitment_not_cleared::CommitmentNotClearedCheck;
 pub use supply_cap::SupplyCapCheck;
+pub use addr_param_no_auth::AddrParamNoAuthCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -212,5 +214,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(UnauthAddressTupleCheck),
         Box::new(CommitmentNotClearedCheck),
         Box::new(SupplyCapCheck),
+        Box::new(AddrParamNoAuthCheck),
     ]
 }

--- a/crates/checks/src/supply_cap.rs
+++ b/crates/checks/src/supply_cap.rs
@@ -1,0 +1,221 @@
+//! Mint function without max-supply cap enforcement.
+//!
+//! A `pub fn mint` in a `#[contractimpl]` block that reads a total supply from storage
+//! and adds an amount to it must assert `current_supply + amount <= max_supply` before
+//! the storage write. Without this guard, minting can exceed the declared cap.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "supply-cap-not-enforced";
+
+/// Supply key heuristics.
+const SUPPLY_KEY_HINTS: &[&str] = &["supply", "total", "minted", "cap", "max"];
+
+pub struct SupplyCapCheck;
+
+impl Check for SupplyCapCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if method.sig.ident != "mint" {
+                continue;
+            }
+            if !matches!(method.vis, syn::Visibility::Public(_)) {
+                continue;
+            }
+
+            let mut scan = BodyScan::default();
+            scan.visit_block(&method.block);
+
+            if scan.supply_get && scan.storage_write && !scan.cap_comparison {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: scan.write_line.unwrap_or_else(|| method.sig.ident.span().start().line),
+                    function_name: "mint".to_string(),
+                    description: "Method `mint` reads a supply value from storage and writes \
+                                  back an increased amount, but contains no `<=` or `<` \
+                                  comparison against a max-supply cap before the write. \
+                                  Minting can exceed the declared cap."
+                        .to_string(),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct BodyScan {
+    supply_get: bool,
+    storage_write: bool,
+    cap_comparison: bool,
+    write_line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for BodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+
+        if receiver_chain_contains_storage(&i.receiver) {
+            match method.as_str() {
+                "get" | "get_unchecked" => {
+                    if i.args.iter().any(|a| expr_contains_supply_hint(a)) {
+                        self.supply_get = true;
+                    }
+                }
+                "set" => {
+                    self.storage_write = true;
+                    if self.write_line.is_none() {
+                        self.write_line = Some(i.span().start().line);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if matches!(i.op, BinOp::Le(_) | BinOp::Lt(_)) {
+            self.cap_comparison = true;
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn expr_contains_supply_hint(expr: &Expr) -> bool {
+    let text = expr_to_text(expr).to_lowercase();
+    SUPPLY_KEY_HINTS.iter().any(|hint| text.contains(hint))
+}
+
+fn expr_to_text(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("_"),
+        Expr::Macro(m) => m.mac.tokens.to_string(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Reference(r) => expr_to_text(&r.expr),
+        Expr::Call(c) => {
+            let mut s = expr_to_text(&c.func);
+            for arg in &c.args {
+                s.push('_');
+                s.push_str(&expr_to_text(arg));
+            }
+            s
+        }
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        SupplyCapCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_mint_without_cap_check() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let supply: i128 = env.storage().persistent().get(&symbol_short!("supply")).unwrap_or(0);
+        env.storage().persistent().set(&symbol_short!("supply"), &(supply + amount));
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "mint");
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn passes_when_le_guard_present() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let supply: i128 = env.storage().persistent().get(&symbol_short!("supply")).unwrap_or(0);
+        let max: i128 = env.storage().persistent().get(&symbol_short!("max_supply")).unwrap();
+        assert!(supply + amount <= max);
+        env.storage().persistent().set(&symbol_short!("supply"), &(supply + amount));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_lt_guard_present() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let supply: i128 = env.storage().persistent().get(&symbol_short!("supply")).unwrap_or(0);
+        let cap: i128 = 1_000_000;
+        assert!(supply + amount < cap);
+        env.storage().persistent().set(&symbol_short!("supply"), &(supply + amount));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_mint_functions() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, amount: i128) {
+        let supply: i128 = env.storage().persistent().get(&symbol_short!("supply")).unwrap_or(0);
+        env.storage().persistent().set(&symbol_short!("supply"), &(supply + amount));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/unauth_address_tuple.rs
+++ b/crates/checks/src/unauth_address_tuple.rs
@@ -1,0 +1,212 @@
+//! Storage `set` with a tuple value containing Address parameters and no `require_auth`.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprMethodCall, File, FnArg, Pat, Type};
+
+const CHECK_NAME: &str = "unauth-address-tuple";
+
+pub struct UnauthAddressTupleCheck;
+
+impl Check for UnauthAddressTupleCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            // Collect Address-typed parameter names.
+            let addr_params: Vec<String> = method
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|arg| {
+                    let FnArg::Typed(pt) = arg else { return None };
+                    if !type_is_address(&pt.ty) {
+                        return None;
+                    }
+                    if let Pat::Ident(pi) = &*pt.pat {
+                        Some(pi.ident.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if addr_params.is_empty() {
+                continue;
+            }
+
+            let mut scan = BodyScan::new(addr_params);
+            scan.visit_block(&method.block);
+
+            if scan.tuple_set && !scan.has_require_auth {
+                let fn_name = method.sig.ident.to_string();
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: scan.set_line.unwrap_or_else(|| method.sig.ident.span().start().line),
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Method `{fn_name}` stores a tuple containing Address parameters \
+                         without calling `require_auth()` on any of them. An attacker can \
+                         record arbitrary address pairs as authorized relationships."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn type_is_address(ty: &Type) -> bool {
+    match ty {
+        Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "Address"),
+        _ => false,
+    }
+}
+
+struct BodyScan {
+    addr_params: Vec<String>,
+    tuple_set: bool,
+    has_require_auth: bool,
+    set_line: Option<usize>,
+}
+
+impl BodyScan {
+    fn new(addr_params: Vec<String>) -> Self {
+        Self {
+            addr_params,
+            tuple_set: false,
+            has_require_auth: false,
+            set_line: None,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for BodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Detect require_auth on any Address parameter.
+        if i.method == "require_auth" {
+            if let syn::Expr::Path(p) = &*i.receiver {
+                let name = p.path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
+                if self.addr_params.contains(&name) {
+                    self.has_require_auth = true;
+                }
+            }
+        }
+
+        // Detect storage().*.set(key, tuple_with_address_param)
+        if i.method == "set" && i.args.len() == 2 {
+            if receiver_chain_contains_storage(&i.receiver) {
+                let value_arg = i.args.iter().nth(1).unwrap();
+                if self.expr_is_tuple_with_addr_param(value_arg) {
+                    self.tuple_set = true;
+                    if self.set_line.is_none() {
+                        self.set_line = Some(i.span().start().line);
+                    }
+                }
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+impl BodyScan {
+    fn expr_is_tuple_with_addr_param(&self, expr: &syn::Expr) -> bool {
+        let syn::Expr::Tuple(t) = expr else { return false };
+        t.elems.iter().any(|e| self.expr_references_addr_param(e))
+    }
+
+    fn expr_references_addr_param(&self, expr: &syn::Expr) -> bool {
+        match expr {
+            syn::Expr::Path(p) => {
+                let name = p.path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
+                self.addr_params.contains(&name)
+            }
+            syn::Expr::Reference(r) => self.expr_references_addr_param(&r.expr),
+            _ => false,
+        }
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        syn::Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        UnauthAddressTupleCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_tuple_set_without_require_auth() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve(env: Env, from: Address, to: Address) {
+        env.storage().persistent().set(&symbol_short!("appr"), &(from, to));
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "approve");
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn passes_when_require_auth_called() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve(env: Env, from: Address, to: Address) {
+        from.require_auth();
+        env.storage().persistent().set(&symbol_short!("appr"), &(from, to));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_address_tuple() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, a: u32, b: u32) {
+        env.storage().persistent().set(&symbol_short!("k"), &(a, b));
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/test-contracts/addr-param-no-auth-safe/Cargo.toml
+++ b/test-contracts/addr-param-no-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-addr-param-no-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/addr-param-no-auth-safe/src/lib.rs
+++ b/test-contracts/addr-param-no-auth-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AddrParamNoAuthSafe;
+
+#[contractimpl]
+impl AddrParamNoAuthSafe {
+    /// Safe: `user` must prove they control the address before the storage write.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("bal"), &amount);
+    }
+}

--- a/test-contracts/addr-param-no-auth-vulnerable/Cargo.toml
+++ b/test-contracts/addr-param-no-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-addr-param-no-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/addr-param-no-auth-vulnerable/src/lib.rs
+++ b/test-contracts/addr-param-no-auth-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AddrParamNoAuthVulnerable;
+
+#[contractimpl]
+impl AddrParamNoAuthVulnerable {
+    /// BUG: `user` is an Address parameter but require_auth is never called on it.
+    /// Any caller can write to storage on behalf of any address.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        let _ = user; // address accepted but never authenticated
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("bal"), &amount);
+    }
+}

--- a/test-contracts/commitment-not-cleared-safe/Cargo.toml
+++ b/test-contracts/commitment-not-cleared-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-commitment-not-cleared-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/commitment-not-cleared-safe/src/lib.rs
+++ b/test-contracts/commitment-not-cleared-safe/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct CommitmentNotClearedSafe;
+
+#[contractimpl]
+impl CommitmentNotClearedSafe {
+    /// Store a commitment hash during the commit phase.
+    pub fn commit(env: Env, hash: u64) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("commit"), &hash);
+    }
+
+    /// Safe: removes the commitment after a successful reveal to prevent replay.
+    pub fn reveal(env: Env, secret: u64) {
+        let stored: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("commit"))
+            .unwrap();
+        assert_eq!(stored, secret);
+        env.storage().persistent().remove(&symbol_short!("commit"));
+    }
+}

--- a/test-contracts/commitment-not-cleared-vulnerable/Cargo.toml
+++ b/test-contracts/commitment-not-cleared-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-commitment-not-cleared-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/commitment-not-cleared-vulnerable/src/lib.rs
+++ b/test-contracts/commitment-not-cleared-vulnerable/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct CommitmentNotClearedVulnerable;
+
+#[contractimpl]
+impl CommitmentNotClearedVulnerable {
+    /// Store a commitment hash during the commit phase.
+    pub fn commit(env: Env, hash: u64) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("commit"), &hash);
+    }
+
+    /// BUG: reads the commitment but never removes it — replay attack possible.
+    pub fn reveal(env: Env, secret: u64) {
+        let stored: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("commit"))
+            .unwrap();
+        assert_eq!(stored, secret);
+        // Missing: env.storage().persistent().remove(&symbol_short!("commit"));
+    }
+}

--- a/test-contracts/supply-cap-safe/Cargo.toml
+++ b/test-contracts/supply-cap-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-supply-cap-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/supply-cap-safe/src/lib.rs
+++ b/test-contracts/supply-cap-safe/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct SupplyCapSafe;
+
+#[contractimpl]
+impl SupplyCapSafe {
+    /// Safe: enforces max_supply cap before minting.
+    pub fn mint(env: Env, _to: Address, amount: i128) {
+        let supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("supply"))
+            .unwrap_or(0);
+        let max_supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("max_supply"))
+            .unwrap();
+        assert!(supply + amount <= max_supply, "exceeds max supply");
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("supply"), &(supply + amount));
+    }
+}

--- a/test-contracts/supply-cap-vulnerable/Cargo.toml
+++ b/test-contracts/supply-cap-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-supply-cap-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/supply-cap-vulnerable/src/lib.rs
+++ b/test-contracts/supply-cap-vulnerable/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct SupplyCapVulnerable;
+
+#[contractimpl]
+impl SupplyCapVulnerable {
+    /// BUG: mints tokens without checking against max_supply cap.
+    /// An attacker (or admin) can mint unlimited tokens, breaking tokenomics.
+    pub fn mint(env: Env, _to: Address, amount: i128) {
+        let supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("supply"))
+            .unwrap_or(0);
+        // Missing: assert!(supply + amount <= max_supply);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("supply"), &(supply + amount));
+    }
+}

--- a/test-contracts/unauth-address-tuple-safe/Cargo.toml
+++ b/test-contracts/unauth-address-tuple-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-address-tuple-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-address-tuple-safe/src/lib.rs
+++ b/test-contracts/unauth-address-tuple-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct UnauthAddressTupleSafe;
+
+#[contractimpl]
+impl UnauthAddressTupleSafe {
+    /// Safe: `from` must prove they control the address before the pair is stored.
+    pub fn approve(env: Env, from: Address, to: Address) {
+        from.require_auth();
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("appr"), &(from, to));
+    }
+}

--- a/test-contracts/unauth-address-tuple-vulnerable/Cargo.toml
+++ b/test-contracts/unauth-address-tuple-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-address-tuple-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-address-tuple-vulnerable/src/lib.rs
+++ b/test-contracts/unauth-address-tuple-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct UnauthAddressTupleVulnerable;
+
+#[contractimpl]
+impl UnauthAddressTupleVulnerable {
+    /// BUG: stores (from, to) tuple without calling require_auth on either address.
+    /// An attacker can record arbitrary address pairs as fake approvals.
+    pub fn approve(env: Env, from: Address, to: Address) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("appr"), &(from, to));
+    }
+}


### PR DESCRIPTION
Add 4 new vulnerability checks: #134, #137, #138, #147
  
  Closes #134
  Closes #137
  Closes #138
  Closes #147
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Summary
  
  This PR implements four new static analysis checks for the Soroban Guard Core engine. Each check follows the existing Check trait pattern, includes unit
  tests, and ships with a paired vulnerable/safe test contract.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Changes
  
  #134 — unauth-address-tuple (crates/checks/src/unauth_address_tuple.rs)
  
  Vulnerability: env.storage().*.set(key, (from, to)) where the tuple value contains two or more Address-typed function parameters and no require_auth()
  is called on any of them. An attacker can record arbitrary address pairs as fake approvals or delegations.
  
  Detection logic:
  
  - Walks #[contractimpl] functions and collects Address-typed parameter names.
  - Flags any storage().*.set(key, value) call where value is an ExprTuple containing a reference to one of those parameters.
  - Passes if addr.require_auth() is called on any of the Address parameters before the write.
  
  Test contracts:
  
  - test-contracts/unauth-address-tuple-vulnerable/ — stores (from, to) tuple without auth
  - test-contracts/unauth-address-tuple-safe/ — calls from.require_auth() before storing
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #137 — commitment-not-cleared (crates/checks/src/commitment_not_cleared.rs)
  
  Vulnerability: A reveal or claim function that reads a commitment hash from storage but never removes or overwrites it. An attacker can replay the same
  reveal transaction to trigger the reveal logic multiple times.
  
  Detection logic:
  
  - Matches function names reveal and claim inside #[contractimpl] blocks.
  - Detects a storage get on a key whose text contains a commitment hint (commit, hash, nonce, secret).
  - Flags if no storage().*.remove(key) or overwriting storage().*.set(key, ...) on the same hinted key follows in the function body.
  
  Test contracts:
  
  - test-contracts/commitment-not-cleared-vulnerable/ — reads commitment, never removes it
  - test-contracts/commitment-not-cleared-safe/ — calls remove() after successful reveal
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #138 — supply-cap-not-enforced (crates/checks/src/supply_cap.rs)
  
  Vulnerability: A pub fn mint in a #[contractimpl] block that reads a total supply from storage and writes back an increased amount without asserting
  current_supply + amount <= max_supply. Without this guard, minting can exceed the declared cap, breaking tokenomics.
  
  Detection logic:
  
  - Matches pub fn mint inside #[contractimpl] blocks.
  - Detects a storage get on a key hinted as supply-related (supply, total, minted, cap, max).
  - Detects a storage set (the write-back).
  - Flags if no BinOp::Le (<=) or BinOp::Lt (<) binary expression appears anywhere in the function body.
  
  Test contracts:
  
  - test-contracts/supply-cap-vulnerable/ — mints without any cap comparison
  - test-contracts/supply-cap-safe/ — asserts supply + amount <= max_supply before writing
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #147 — addr-param-no-auth (crates/checks/src/addr_param_no_auth.rs)
  
  Vulnerability: A #[contractimpl] function that accepts an Address parameter and writes to storage or calls a token client method (transfer, mint, burn,
  etc.) without calling addr.require_auth() or env.require_auth_for_address(addr, ...) on that parameter. Any caller can impersonate any address.
  
  Detection logic:
  
  - Walks #[contractimpl] functions and collects Address-typed parameter names.
  - Checks the function body for a storage write (set/remove) or a token client call.
  - If either is present, verifies that each Address parameter has a corresponding param.require_auth() or env.require_auth_for_address(param, ...) call.
  - Emits one finding per function (for the first unauthenticated Address param found).
  
  Test contracts:
  
  - test-contracts/addr-param-no-auth-vulnerable/ — accepts user: Address, writes to storage without auth
  - test-contracts/addr-param-no-auth-safe/ — calls user.require_auth() before the storage write
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Files changed
  
  ┌─────────────────────────────────────────────┬──────────────────┐
  │ File                                        │ Description      │
  ├─────────────────────────────────────────────┼──────────────────┤
  │ crates/checks/src/unauth_address_tuple.rs   │ New check — #134                            │
  ├────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ crates/checks/src/commitment_not_cleared.rs            │ New check — #137                            │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ crates/checks/src/supply_cap.rs                          │ New check — #138                            │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ crates/checks/src/addr_param_no_auth.rs                  │ New check — #147                            │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ crates/checks/src/lib.rs                                 │ Registered all 4 checks in default_checks() │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ test-contracts/unauth-address-tuple-{vulnerable,safe}/   │ Test contracts — #134                       │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ test-contracts/commitment-not-cleared-{vulnerable,safe}/ │ Test contracts — #137                       │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ test-contracts/supply-cap-{vulnerable,safe}/             │ Test contracts — #138                       │
  ├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ test-contracts/addr-param-no-auth-{vulnerable,safe}/     │ Test contracts — #147                       │
  └──────────────────────────────────────────────────────────┴─────────────────────────────────────────────┘
