### PR TITLE
feat: add vec-push-in-loop check (Medium severity)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -57,6 +57,7 @@ pub mod zero_amount;
 pub mod unvalidated_invoke_target;
 pub mod unbounded_batch;
 pub mod unvalidated_price;
+pub mod vec_push_in_loop;
 pub mod vesting_cliff;
 pub mod transfer_to_self;
 mod util;
@@ -116,6 +117,7 @@ pub use weak_randomness::WeakRandomnessCheck;
 pub use zero_amount::ZeroAmountCheck;
 pub use unbounded_batch::UnboundedBatchCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
+pub use vec_push_in_loop::VecPushInLoopCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 
@@ -203,5 +205,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(Secp256k1UncheckedCheck),
         Box::new(TempSetNoTtlCheck),
         Box::new(BalanceOverflowCheck),
+        Box::new(VecPushInLoopCheck),
     ]
 }

--- a/crates/checks/src/vec_push_in_loop.rs
+++ b/crates/checks/src/vec_push_in_loop.rs
@@ -1,0 +1,224 @@
+//! `push_back` on a `soroban_sdk::Vec` inside a loop without a length guard.
+//!
+//! Calling `push_back` inside a loop driven by user-controlled input without a
+//! `len()` / `size` comparison guard causes unbounded memory growth in the
+//! Soroban host, which can exhaust the contract's resource budget and cause DoS.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprForLoop, ExprLoop, ExprMethodCall, ExprWhile, File};
+
+const CHECK_NAME: &str = "vec-push-in-loop";
+
+/// Returns true if the block contains a `len()` or `size()` method call,
+/// indicating a length guard is present.
+fn block_has_len_guard(block: &Block) -> bool {
+    struct LenFinder(bool);
+    impl<'ast> Visit<'ast> for LenFinder {
+        fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+            if matches!(i.method.to_string().as_str(), "len" | "size") {
+                self.0 = true;
+            }
+            visit::visit_expr_method_call(self, i);
+        }
+    }
+    let mut f = LenFinder(false);
+    f.visit_block(block);
+    f.0
+}
+
+struct PushInLoopVisitor<'a> {
+    fn_name: String,
+    /// Stack of loop body blocks; each entry records whether that loop body
+    /// contains a len guard.
+    loop_stack: Vec<bool>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for PushInLoopVisitor<'ast> {
+    fn visit_expr_for_loop(&mut self, i: &'ast ExprForLoop) {
+        self.loop_stack.push(block_has_len_guard(&i.body));
+        visit::visit_expr_for_loop(self, i);
+        self.loop_stack.pop();
+    }
+
+    fn visit_expr_while(&mut self, i: &'ast ExprWhile) {
+        self.loop_stack.push(block_has_len_guard(&i.body));
+        visit::visit_expr_while(self, i);
+        self.loop_stack.pop();
+    }
+
+    fn visit_expr_loop(&mut self, i: &'ast ExprLoop) {
+        self.loop_stack.push(block_has_len_guard(&i.body));
+        visit::visit_expr_loop(self, i);
+        self.loop_stack.pop();
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "push_back" {
+            // Only flag if we are inside at least one loop that has no len guard.
+            let unguarded = self.loop_stack.iter().any(|guarded| !guarded);
+            if unguarded {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "`push_back` is called inside a loop in `{}` without a `len()` guard. \
+                         Unbounded growth exhausts the Soroban host resource budget and can \
+                         cause a DoS. Add a maximum-length check before pushing.",
+                        self.fn_name
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct VecPushInLoopCheck;
+
+impl Check for VecPushInLoopCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = PushInLoopVisitor {
+                fn_name,
+                loop_stack: Vec::new(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_push_back_in_for_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn collect(env: Env, items: Vec<u32>, extra: u32) {
+        let mut out: Vec<u32> = Vec::new(&env);
+        for item in items {
+            out.push_back(item);
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = VecPushInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_push_back_in_while_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn fill(env: Env, n: u32) {
+        let mut v: Vec<u32> = Vec::new(&env);
+        let mut i = 0u32;
+        while i < n {
+            v.push_back(i);
+            i += 1;
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = VecPushInLoopCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_when_len_guard_present() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+pub struct C;
+const MAX: u32 = 100;
+#[contractimpl]
+impl C {
+    pub fn collect(env: Env, items: Vec<u32>) {
+        let mut out: Vec<u32> = Vec::new(&env);
+        for item in items {
+            if out.len() >= MAX { break; }
+            out.push_back(item);
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = VecPushInLoopCheck.run(&file, "");
+        assert!(hits.is_empty(), "{hits:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_loop() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn add_one(env: Env, val: u32) {
+        let mut v: Vec<u32> = Vec::new(&env);
+        v.push_back(val);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = VecPushInLoopCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_push_back_in_loop_block() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn run(env: Env, n: u32) {
+        let mut v: Vec<u32> = Vec::new(&env);
+        let mut i = 0u32;
+        loop {
+            if i >= n { break; }
+            v.push_back(i);
+            i += 1;
+        }
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = VecPushInLoopCheck.run(&file, "");
+        // loop body has no len() call, so it should be flagged
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+}

--- a/test-contracts/vec-push-in-loop-safe/Cargo.toml
+++ b/test-contracts/vec-push-in-loop-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-vec-push-in-loop-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/vec-push-in-loop-safe/src/lib.rs
+++ b/test-contracts/vec-push-in-loop-safe/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+#[contract]
+pub struct VecPushInLoopSafe;
+
+const MAX_ITEMS: u32 = 100;
+
+/// Safe: push_back inside a loop guarded by a len() check.
+#[contractimpl]
+impl VecPushInLoopSafe {
+    pub fn collect(env: Env, items: Vec<u32>) -> Vec<u32> {
+        let mut out: Vec<u32> = Vec::new(&env);
+        for item in items {
+            // ✅ Length cap prevents unbounded growth.
+            if out.len() >= MAX_ITEMS {
+                break;
+            }
+            out.push_back(item);
+        }
+        out
+    }
+}

--- a/test-contracts/vec-push-in-loop-vulnerable/Cargo.toml
+++ b/test-contracts/vec-push-in-loop-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-vec-push-in-loop-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/vec-push-in-loop-vulnerable/src/lib.rs
+++ b/test-contracts/vec-push-in-loop-vulnerable/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+#[contract]
+pub struct VecPushInLoopVulnerable;
+
+/// Vulnerable: push_back inside a loop with no len() guard — unbounded growth.
+#[contractimpl]
+impl VecPushInLoopVulnerable {
+    pub fn collect(env: Env, items: Vec<u32>) -> Vec<u32> {
+        let mut out: Vec<u32> = Vec::new(&env);
+        for item in items {
+            // BUG: no length cap — caller can grow `out` without bound,
+            // exhausting the Soroban host resource budget (DoS).
+            out.push_back(item);
+        }
+        out
+    }
+}


### PR DESCRIPTION
closes #158 

feat: add vec-push-in-loop check (Medium)
  
  Summary
  
  Adds a new static analysis check that detects push_back calls on a soroban_sdk::Vec inside a
  loop without a len() guard. Unbounded growth exhausts the Soroban host resource budget and can
  cause a DoS.
  
  Changes
  
  - crates/checks/src/vec_push_in_loop.rs — new VecPushInLoopCheck implementing the Check trait
  - crates/checks/src/lib.rs — registered the check in default_checks()
  - test-contracts/vec-push-in-loop-vulnerable/ — triggers the finding
  - test-contracts/vec-push-in-loop-safe/ — passes (loop guarded by len() check)
  
  Detection logic
  
  Flags any push_back method call nested inside a for / while / loop block where the loop body
  contains no len() or size() comparison. Uses a loop_stack visitor to handle nested loops
  correctly.
  
  Severity
  
  Medium — exploitable by any caller supplying a large input collection.
  
  Tests
  
  5 unit tests covering: for-loop flag, while-loop flag, guarded no-finding, outside-loop
  no-finding, bare loop {} flag.