### PR TITLE
feat: add unauth-fee-setter check (High severity)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -56,7 +56,9 @@ pub mod token_burn_auth;
 pub mod zero_amount;
 pub mod unvalidated_invoke_target;
 pub mod unbounded_batch;
+pub mod unauth_fee_setter;
 pub mod unvalidated_price;
+pub mod vec_push_in_loop;
 pub mod vesting_cliff;
 pub mod transfer_to_self;
 mod util;
@@ -115,7 +117,9 @@ pub use unbounded_input_storage::UnboundedInputStorageCheck;
 pub use weak_randomness::WeakRandomnessCheck;
 pub use zero_amount::ZeroAmountCheck;
 pub use unbounded_batch::UnboundedBatchCheck;
+pub use unauth_fee_setter::UnauthFeeSetterCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
+pub use vec_push_in_loop::VecPushInLoopCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 
@@ -203,5 +207,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(Secp256k1UncheckedCheck),
         Box::new(TempSetNoTtlCheck),
         Box::new(BalanceOverflowCheck),
+        Box::new(UnauthFeeSetterCheck),
+        Box::new(VecPushInLoopCheck),
     ]
 }

--- a/crates/checks/src/unauth_fee_setter.rs
+++ b/crates/checks/src/unauth_fee_setter.rs
@@ -1,0 +1,228 @@
+//! Fee-setter functions missing `require_auth`.
+//!
+//! A function named `set_fee`, `set_rate`, `set_commission`, or `update_fee`
+//! that writes a value to storage without first calling `require_auth` allows
+//! any user to manipulate protocol economics.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File, Visibility};
+
+const CHECK_NAME: &str = "unauth-fee-setter";
+
+const FEE_SETTER_NAMES: &[&str] = &["set_fee", "set_rate", "set_commission", "update_fee"];
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct FeeScan {
+    has_require_auth: bool,
+    has_storage_set: bool,
+    storage_set_line: usize,
+}
+
+impl<'ast> Visit<'ast> for FeeScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if matches!(
+            i.method.to_string().as_str(),
+            "require_auth" | "require_auth_for_args"
+        ) {
+            self.has_require_auth = true;
+        }
+        if i.method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            if self.storage_set_line == 0 {
+                self.storage_set_line = i.span().start().line;
+            }
+            self.has_storage_set = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn scan_block(block: &Block) -> FeeScan {
+    let mut s = FeeScan::default();
+    s.visit_block(block);
+    s
+}
+
+pub struct UnauthFeeSetterCheck;
+
+impl Check for UnauthFeeSetterCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let name = method.sig.ident.to_string();
+            if !FEE_SETTER_NAMES.contains(&name.as_str()) {
+                continue;
+            }
+            let scan = scan_block(&method.block);
+            if scan.has_storage_set && !scan.has_require_auth {
+                let line = if scan.storage_set_line > 0 {
+                    scan.storage_set_line
+                } else {
+                    method.sig.fn_token.span().start().line
+                };
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: name.clone(),
+                    description: format!(
+                        "Function `{name}` writes a fee/rate value to storage without calling \
+                         `require_auth()`. Any caller can manipulate protocol economics. \
+                         Verify the caller is the admin before updating the fee."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        UnauthFeeSetterCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_set_fee_without_auth() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_fee(env: Env, fee: u32) {
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn flags_set_rate_without_auth() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_rate(env: Env, rate: u32) {
+        env.storage().persistent().set(&RATE_KEY, &rate);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn flags_set_commission_without_auth() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_commission(env: Env, bps: u32) {
+        env.storage().instance().set(&COMM_KEY, &bps);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_update_fee_without_auth() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn update_fee(env: Env, fee: u32) {
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn no_finding_when_require_auth_present() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_fee(env: Env, admin: Address, fee: u32) {
+        admin.require_auth();
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+}
+"#);
+        assert!(hits.is_empty(), "{hits:?}");
+    }
+
+    #[test]
+    fn no_finding_for_unrelated_function() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn configure(env: Env, fee: u32) {
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn no_finding_for_private_function() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    fn set_fee(env: Env, fee: u32) {
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn no_finding_when_no_storage_write() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_fee(env: Env, fee: u32) {
+        let _ = fee;
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/test-contracts/unauth-fee-setter-safe/Cargo.toml
+++ b/test-contracts/unauth-fee-setter-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-fee-setter-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-fee-setter-safe/src/lib.rs
+++ b/test-contracts/unauth-fee-setter-safe/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct UnauthFeeSetterSafe;
+
+const FEE_KEY: Symbol = symbol_short!("fee");
+
+/// Safe: set_fee requires admin authorization before writing to storage.
+#[contractimpl]
+impl UnauthFeeSetterSafe {
+    pub fn set_fee(env: Env, admin: Address, fee: u32) {
+        // ✅ Only the admin can update the fee.
+        admin.require_auth();
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+
+    pub fn get_fee(env: Env) -> u32 {
+        env.storage().instance().get(&FEE_KEY).unwrap_or(0)
+    }
+}

--- a/test-contracts/unauth-fee-setter-vulnerable/Cargo.toml
+++ b/test-contracts/unauth-fee-setter-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unauth-fee-setter-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unauth-fee-setter-vulnerable/src/lib.rs
+++ b/test-contracts/unauth-fee-setter-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct UnauthFeeSetterVulnerable;
+
+const FEE_KEY: Symbol = symbol_short!("fee");
+
+/// Vulnerable: set_fee writes to storage without require_auth.
+/// Any caller can manipulate the protocol fee.
+#[contractimpl]
+impl UnauthFeeSetterVulnerable {
+    pub fn set_fee(env: Env, fee: u32) {
+        // BUG: no require_auth — anyone can change the fee.
+        env.storage().instance().set(&FEE_KEY, &fee);
+    }
+
+    pub fn get_fee(env: Env) -> u32 {
+        env.storage().instance().get(&FEE_KEY).unwrap_or(0)
+    }
+}


### PR DESCRIPTION
closes #159 

feat: add unauth-fee-setter check (High)
  
  Summary
  
  Adds a new static analysis check that detects fee/rate setter functions writing to storage
  without require_auth. Any caller can manipulate protocol economics (fees, rates, commissions)
  if these functions are unprotected.
  
  Changes
  
  - crates/checks/src/unauth_fee_setter.rs — new UnauthFeeSetterCheck implementing the Check
  - crates/checks/src/lib.rs — registered the check in default_checks()
  - test-contracts/unauth-fee-setter-vulnerable/ — triggers the finding (set_fee with no auth)
  - test-contracts/unauth-fee-setter-safe/ — passes (set_fee guarded by admin.require_auth())
  
  Detection logic
  
  Matches pub fn names against set_fee, set_rate, set_commission, update_fee inside
  #[contractimpl] blocks. Flags if the body contains a storage().*.set() call with no
  require_auth or require_auth_for_args anywhere in the function.
  
  Severity
  
  High — any unauthenticated caller can alter protocol fee parameters, directly impacting all
  users of the contract.
  
  Tests
  
  8 unit tests covering: all four function name variants flagged, guarded no-finding, unrelated
  function name no-finding, private function no-finding, no-storage-write no-finding.