### PR TITLE
feat: add unlimited-allowance check (Medium severity)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -43,6 +43,7 @@ pub mod contracterror_attr;
 pub mod balance_overflow;
 pub mod overflow;
 pub mod uncapped_fee;
+pub mod unlimited_allowance;
 pub mod panic_usage;
 pub mod partial_write_on_error;
 pub mod reentrancy;
@@ -113,6 +114,7 @@ pub use contracterror_attr::ContracterrorAttrCheck;
 pub use balance_overflow::BalanceOverflowCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use uncapped_fee::UncappedFeeCheck;
+pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use panic_usage::PanicUsageCheck;
 pub use partial_write_on_error::PartialWriteOnErrorCheck;
 pub use reentrancy::ReentrancyCheck;
@@ -229,5 +231,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(InstanceRemoveCriticalCheck),
         Box::new(MapUserKeyBloatCheck),
         Box::new(TimestampTruncationCheck),
+        Box::new(UnlimitedAllowanceCheck),
     ]
 }

--- a/crates/checks/src/unlimited_allowance.rs
+++ b/crates/checks/src/unlimited_allowance.rs
@@ -1,0 +1,206 @@
+//! Detects token allowance set to i128::MAX / u128::MAX (unlimited approval).
+//!
+//! Setting an allowance to the maximum integer value is an unlimited-approval
+//! anti-pattern. If the spender is compromised or the contract is buggy, all
+//! funds can be drained.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Lit};
+
+const CHECK_NAME: &str = "unlimited-allowance";
+
+/// i128::MAX = 170141183460469231731687303715884105727
+const I128_MAX: u128 = 170_141_183_460_469_231_731_687_303_715_884_105_727;
+/// u128::MAX = 340282366920938463463374607431768211455
+const U128_MAX: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
+
+pub struct UnlimitedAllowanceCheck;
+
+impl Check for UnlimitedAllowanceCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = ApproveScan::default();
+            scan.visit_block(&method.block);
+            for line in scan.findings {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: "Call to `approve` with an amount equal to `i128::MAX` or \
+                                  `u128::MAX` grants unlimited token approval. If the spender \
+                                  is compromised, all funds can be drained. Use a bounded \
+                                  allowance instead."
+                        .to_string(),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn is_max_literal(expr: &Expr) -> bool {
+    match expr {
+        // &i128::MAX — unwrap the reference
+        Expr::Reference(r) => is_max_literal(&r.expr),
+        // Plain integer literal: 170141183460469231731687303715884105727
+        Expr::Lit(l) => {
+            if let Lit::Int(i) = &l.lit {
+                if let Ok(v) = i.base10_parse::<u128>() {
+                    return v == I128_MAX || v == U128_MAX;
+                }
+            }
+            false
+        }
+        // i128::MAX or u128::MAX path expression
+        Expr::Path(p) => {
+            let segs: Vec<_> = p.path.segments.iter().collect();
+            if segs.len() == 2 {
+                let ty = segs[0].ident.to_string();
+                let field = segs[1].ident.to_string();
+                return field == "MAX" && matches!(ty.as_str(), "i128" | "u128");
+            }
+            false
+        }
+        // Handle cast just in case
+        Expr::Cast(c) => is_max_literal(&c.expr),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct ApproveScan {
+    findings: Vec<usize>,
+}
+
+impl<'ast> Visit<'ast> for ApproveScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "approve" {
+            // approve(from, spender, amount, expiration_ledger)
+            // The amount is the 3rd argument (index 2).
+            if let Some(amount_arg) = i.args.iter().nth(2) {
+                if is_max_literal(amount_arg) {
+                    self.findings.push(i.method.span().start().line);
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_i128_max_path() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve_all(env: Env, from: Address, spender: Address) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &i128::MAX, &999999);
+    }
+}
+"#,
+        )?;
+        let hits = UnlimitedAllowanceCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_u128_max_path() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve_all(env: Env, from: Address, spender: Address) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &u128::MAX, &999999);
+    }
+}
+"#,
+        )?;
+        let hits = UnlimitedAllowanceCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_i128_max_literal() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve_all(env: Env, from: Address, spender: Address) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &170141183460469231731687303715884105727_i128, &999999);
+    }
+}
+"#,
+        )?;
+        let hits = UnlimitedAllowanceCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_bounded_allowance() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn approve_bounded(env: Env, from: Address, spender: Address, amount: i128) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &amount, &999999);
+    }
+}
+"#,
+        )?;
+        let hits = UnlimitedAllowanceCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_no_approve_call() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let token = token::Client::new(&env, &token_id);
+        token.transfer(&from, &to, &amount);
+    }
+}
+"#,
+        )?;
+        let hits = UnlimitedAllowanceCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/unlimited-allowance-safe/Cargo.toml
+++ b/test-contracts/unlimited-allowance-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unlimited-allowance-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unlimited-allowance-safe/src/lib.rs
+++ b/test-contracts/unlimited-allowance-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct UnlimitedAllowanceSafe;
+
+#[contractimpl]
+impl UnlimitedAllowanceSafe {
+    /// Approves a caller-supplied bounded amount — safe.
+    pub fn approve(env: Env, from: Address, spender: Address, token_id: Address, amount: i128) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &amount, &999999);
+    }
+}

--- a/test-contracts/unlimited-allowance-vulnerable/Cargo.toml
+++ b/test-contracts/unlimited-allowance-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-unlimited-allowance-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/unlimited-allowance-vulnerable/src/lib.rs
+++ b/test-contracts/unlimited-allowance-vulnerable/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct UnlimitedAllowanceVulnerable;
+
+#[contractimpl]
+impl UnlimitedAllowanceVulnerable {
+    /// Approves i128::MAX — unlimited approval anti-pattern.
+    /// Should trigger `unlimited-allowance` (Medium).
+    pub fn approve_max(env: Env, from: Address, spender: Address, token_id: Address) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(&from, &spender, &i128::MAX, &999999);
+    }
+
+    /// Approves using the raw i128::MAX literal.
+    /// Should trigger `unlimited-allowance` (Medium).
+    pub fn approve_max_literal(env: Env, from: Address, spender: Address, token_id: Address) {
+        let token = token::Client::new(&env, &token_id);
+        token.approve(
+            &from,
+            &spender,
+            &170141183460469231731687303715884105727_i128,
+            &999999,
+        );
+    }
+}


### PR DESCRIPTION
### Overview
Implemented a new security check to detect and flag "unlimited token allowance" anti-patterns ($i128::MAX$ / $u128::MAX$). This prevents potential total fund drainage in the event of a compromised spender or contract logic bug.

### Core Changes
* **New Check Module:** Created `crates/checks/src/unlimited_allowance.rs` implementing the `Check` trait.
    * Detects `token::Client::approve()` calls where the amount is set to maximum integer values.
    * Specifically identifies both path expressions (`i128::MAX`, `u128::MAX`) and their corresponding raw numeric literals.
* **Analyzer Integration:** Registered `UnlimitedAllowanceCheck` in the default check pipeline (`crates/checks/src/lib.rs`).
* **Test Contracts:**
    * **Vulnerable:** `test-contracts/unlimited-allowance-vulnerable/` (approves max values via path and literal).
    * **Safe:** `test-contracts/unlimited-allowance-safe/` (uses bounded, parameter-based amounts).

### Validation & Quality
* **Unit Tests:** 5 passing tests covering path detection, literal detection, and false-positive prevention for bounded allowances.
* **Severity:** Set to **Medium**, aligned with standard security auditing practices for this pattern.
* **Consistency:** Follows existing AST visitor patterns established in `allowance_clear.rs`.

**Closes #150 **