### PR TITLE
feat: add four new vulnerability checks (#178, #179, #180, #181)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -26,6 +26,8 @@ pub mod instance_domain_mixing;
 pub mod instance_remove_critical;
 pub mod instance_ttl;
 pub mod instance_vec_growth;
+pub mod linear_whitelist_scan;
+pub mod lock_period_truncation;
 pub mod invoke_unchecked_cast;
 pub mod map_key_explosion;
 pub mod map_user_key_bloat;
@@ -35,7 +37,9 @@ pub mod missing_ttl;
 pub mod negative_deposit;
 pub mod no_param_no_auth;
 pub mod no_std;
+pub mod nonce_increment_order;
 pub mod overflow;
+pub mod ownership_transfer;
 pub mod uncapped_fee;
 pub mod unlimited_allowance;
 pub mod panic_usage;
@@ -57,12 +61,12 @@ pub mod token_transfer_unchecked;
 pub mod transfer_to_self;
 pub mod ttl_arg_order;
 pub mod unauth_address_in_struct;
+pub mod uncapped_slippage;
 pub mod unauth_fee_setter;
 pub mod unauth_sensitive_read;
 pub mod unbounded_batch;
 pub mod unbounded_input_storage;
 pub mod unbounded_storage;
-pub mod uncapped_fee;
 pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
 mod util;
@@ -100,6 +104,8 @@ pub use instance_remove_critical::InstanceRemoveCriticalCheck;
 pub use instance_ttl::InstanceTtlCheck;
 pub use instance_vec_growth::InstanceVecGrowthCheck;
 pub use invoke_unchecked_cast::InvokeUncheckedCastCheck;
+pub use linear_whitelist_scan::LinearWhitelistScanCheck;
+pub use lock_period_truncation::LockPeriodTruncationCheck;
 pub use map_key_explosion::MapKeyExplosionCheck;
 pub use map_user_key_bloat::MapUserKeyBloatCheck;
 pub use migration_guard::MigrationGuardCheck;
@@ -108,7 +114,9 @@ pub use missing_ttl::MissingTtlExtensionCheck;
 pub use negative_deposit::NegativeDepositCheck;
 pub use no_param_no_auth::NoParamNoAuthCheck;
 pub use no_std::NoStdCheck;
+pub use nonce_increment_order::NonceIncrementOrderCheck;
 pub use overflow::UncheckedArithmeticCheck;
+pub use ownership_transfer::OwnershipTransferCheck;
 pub use uncapped_fee::UncappedFeeCheck;
 pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use panic_usage::PanicUsageCheck;
@@ -129,12 +137,12 @@ pub use token_transfer_unchecked::TokenTransferUncheckedCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 pub use ttl_arg_order::TtlArgOrderCheck;
 pub use unauth_address_in_struct::UnauthAddressInStructCheck;
+pub use uncapped_slippage::UncappedSlippageCheck;
 pub use unauth_fee_setter::UnauthFeeSetterCheck;
 pub use unauth_sensitive_read::UnauthSensitiveReadCheck;
 pub use unbounded_batch::UnboundedBatchCheck;
 pub use unbounded_input_storage::UnboundedInputStorageCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
-pub use uncapped_fee::UncappedFeeCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vec_push_in_loop::VecPushInLoopCheck;
 pub use vesting_cliff::VestingCliffCheck;
@@ -234,5 +242,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MapUserKeyBloatCheck),
         Box::new(TimestampTruncationCheck),
         Box::new(UnlimitedAllowanceCheck),
+        Box::new(LockPeriodTruncationCheck),
+        Box::new(LinearWhitelistScanCheck),
+        Box::new(UncappedSlippageCheck),
+        Box::new(NonceIncrementOrderCheck),
     ]
 }

--- a/crates/checks/src/linear_whitelist_scan.rs
+++ b/crates/checks/src/linear_whitelist_scan.rs
@@ -1,0 +1,165 @@
+//! Detects linear `.iter().any(…)` scans over a storage-backed `Vec` used as a whitelist.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "linear-whitelist-scan";
+
+/// Flags `.iter().any(…)` chains in functions that also read from storage,
+/// indicating an O(n) whitelist membership check that can be DoS'd.
+pub struct LinearWhitelistScanCheck;
+
+impl Check for LinearWhitelistScanCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+
+            // First pass: does this function read from storage?
+            let mut storage_scan = StorageScan::default();
+            storage_scan.visit_block(&method.block);
+            if !storage_scan.has_storage_get {
+                continue;
+            }
+
+            // Second pass: find .iter().any(…) calls
+            let mut v = Visitor { fn_name, out: &mut out };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct StorageScan {
+    has_storage_get: bool,
+}
+
+impl Visit<'_> for StorageScan {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        let name = i.method.to_string();
+        if matches!(name.as_str(), "get" | "get_unchecked") {
+            // Check if receiver chain contains "storage"
+            if receiver_has_storage(&i.receiver) {
+                self.has_storage_get = true;
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn receiver_has_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_has_storage(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        // Detect `.iter().any(…)` — receiver is `.iter()` call
+        if i.method == "any" {
+            if let Expr::MethodCall(iter_call) = &*i.receiver {
+                if iter_call.method == "iter" {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Medium,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "`{}` performs a linear `.iter().any(…)` scan over a storage-backed Vec. \
+                             An attacker who can grow the list makes every call O(n), enabling DoS. \
+                             Use a `Map<Address, bool>` for O(1) membership checks.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_iter_any_on_storage_vec() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn is_allowed(env: soroban_sdk::Env, caller: soroban_sdk::Address) -> bool {
+        let list: soroban_sdk::Vec<soroban_sdk::Address> =
+            env.storage().persistent().get(&1u32).unwrap_or_default();
+        list.iter().any(|a| a == caller)
+    }
+}
+"#,
+        )?;
+        let hits = LinearWhitelistScanCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_map_contains_key() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn is_allowed(env: soroban_sdk::Env, caller: soroban_sdk::Address) -> bool {
+        let map: soroban_sdk::Map<soroban_sdk::Address, bool> =
+            env.storage().persistent().get(&1u32).unwrap_or_default();
+        map.contains_key(caller)
+    }
+}
+"#,
+        )?;
+        let hits = LinearWhitelistScanCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+impl C {
+    pub fn check(env: soroban_sdk::Env, caller: soroban_sdk::Address) -> bool {
+        let list: soroban_sdk::Vec<soroban_sdk::Address> =
+            env.storage().persistent().get(&1u32).unwrap_or_default();
+        list.iter().any(|a| a == caller)
+    }
+}
+"#,
+        )?;
+        let hits = LinearWhitelistScanCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lock_period_truncation.rs
+++ b/crates/checks/src/lock_period_truncation.rs
@@ -1,0 +1,195 @@
+//! Detects `timestamp() + lock_period` result cast/stored as `u32` (truncation bypass).
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprCast, File, Type};
+
+const CHECK_NAME: &str = "lock-period-truncation";
+
+/// Flags `env.ledger().timestamp() + x` expressions whose result is cast to `u32`
+/// or assigned into a `u32`-typed `let` binding.
+pub struct LockPeriodTruncationCheck;
+
+impl Check for LockPeriodTruncationCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = Visitor { fn_name, out: &mut out };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+/// Returns true if the expression is (or contains) `env.ledger().timestamp()`.
+fn contains_timestamp(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "timestamp" {
+                return true;
+            }
+            contains_timestamp(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn is_timestamp_add(e: &ExprBinary) -> bool {
+    matches!(e.op, BinOp::Add(_))
+        && (contains_timestamp(&e.left) || contains_timestamp(&e.right))
+}
+
+fn type_is_u32(ty: &Type) -> bool {
+    if let Type::Path(tp) = ty {
+        tp.path.is_ident("u32")
+    } else {
+        false
+    }
+}
+
+/// Strip parentheses and return the inner `ExprBinary` if present.
+fn unwrap_to_binary(expr: &Expr) -> Option<&ExprBinary> {
+    match expr {
+        Expr::Binary(b) => Some(b),
+        Expr::Paren(p) => unwrap_to_binary(&p.expr),
+        _ => None,
+    }
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    // `(expr) as u32`
+    fn visit_expr_cast(&mut self, i: &ExprCast) {
+        if type_is_u32(&i.ty) {
+            if let Some(bin) = unwrap_to_binary(&i.expr) {
+                if is_timestamp_add(bin) {
+                    self.out.push(finding(i.span().start().line, &self.fn_name));
+                }
+            }
+        }
+        visit::visit_expr_cast(self, i);
+    }
+
+    // `let unlock: u32 = timestamp() + period`
+    fn visit_local(&mut self, i: &syn::Local) {
+        if let syn::Pat::Type(pt) = &i.pat {
+            if type_is_u32(&pt.ty) {
+                if let Some(init) = &i.init {
+                    if let Some(bin) = unwrap_to_binary(&init.expr) {
+                        if is_timestamp_add(bin) {
+                            self.out.push(finding(i.span().start().line, &self.fn_name));
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+}
+
+fn finding(line: usize, fn_name: &str) -> Finding {
+    Finding {
+        check_name: CHECK_NAME.to_string(),
+        severity: Severity::Medium,
+        file_path: String::new(),
+        line,
+        function_name: fn_name.to_string(),
+        description: format!(
+            "`{fn_name}` adds a lock/cooldown period to `env.ledger().timestamp()` and stores \
+             the result as `u32`. After year 2106 the value wraps, silently bypassing the \
+             time-lock. Use `u64` for all unlock timestamps."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_cast_to_u32() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn lock(env: soroban_sdk::Env, period: u64) {
+        let unlock = (env.ledger().timestamp() + period) as u32;
+        env.storage().instance().set(&1u32, &unlock);
+    }
+}
+"#,
+        )?;
+        let hits = LockPeriodTruncationCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_u32_typed_binding() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn lock(env: soroban_sdk::Env, period: u64) {
+        let unlock: u32 = env.ledger().timestamp() + period;
+        env.storage().instance().set(&1u32, &unlock);
+    }
+}
+"#,
+        )?;
+        let hits = LockPeriodTruncationCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_u64_binding() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn lock(env: soroban_sdk::Env, period: u64) {
+        let unlock: u64 = env.ledger().timestamp() + period;
+        env.storage().instance().set(&1u32, &unlock);
+    }
+}
+"#,
+        )?;
+        let hits = LockPeriodTruncationCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+impl C {
+    pub fn lock(env: soroban_sdk::Env, period: u64) {
+        let unlock: u32 = env.ledger().timestamp() + period;
+    }
+}
+"#,
+        )?;
+        let hits = LockPeriodTruncationCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/nonce_increment_order.rs
+++ b/crates/checks/src/nonce_increment_order.rs
@@ -1,0 +1,183 @@
+//! Detects nonce incremented after an external call/transfer instead of before.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Stmt};
+
+const CHECK_NAME: &str = "nonce-increment-order";
+
+pub struct NonceIncrementOrderCheck;
+
+impl Check for NonceIncrementOrderCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let stmts = &method.block.stmts;
+
+            // Collect statement indices for nonce-set and external calls
+            let mut nonce_set_idx: Option<usize> = None;
+            let mut earliest_external_idx: Option<usize> = None;
+
+            for (idx, stmt) in stmts.iter().enumerate() {
+                let mut sv = StmtVisitor::default();
+                sv.visit_stmt(stmt);
+
+                if sv.has_nonce_set && nonce_set_idx.is_none() {
+                    nonce_set_idx = Some(idx);
+                }
+                if sv.has_external_call && earliest_external_idx.is_none() {
+                    earliest_external_idx = Some(idx);
+                }
+            }
+
+            // Flag if there is a nonce set AND an external call that comes BEFORE it
+            if let (Some(set_idx), Some(ext_idx)) = (nonce_set_idx, earliest_external_idx) {
+                if ext_idx < set_idx {
+                    let line = stmts[ext_idx].span().start().line;
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "`{fn_name}` performs an external call or token transfer before \
+                             writing the incremented nonce back to storage. A reentrant caller \
+                             can reuse the same nonce. Increment and store the nonce before \
+                             any external interaction."
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct StmtVisitor {
+    has_nonce_set: bool,
+    has_external_call: bool,
+}
+
+fn is_nonce_storage_set(m: &ExprMethodCall) -> bool {
+    if m.method != "set" {
+        return false;
+    }
+    // Check if any argument looks like a nonce key
+    for arg in &m.args {
+        if expr_contains_nonce(arg) {
+            return true;
+        }
+    }
+    false
+}
+
+fn expr_contains_nonce(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(p) => {
+            let s = p.path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
+            s.to_lowercase().contains("nonce")
+        }
+        Expr::Reference(r) => expr_contains_nonce(&r.expr),
+        Expr::Lit(l) => {
+            if let syn::Lit::Str(ls) = &l.lit {
+                ls.value().to_lowercase().contains("nonce")
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_external_call(m: &ExprMethodCall) -> bool {
+    let name = m.method.to_string();
+    matches!(name.as_str(), "invoke_contract" | "transfer" | "transfer_from" | "call")
+}
+
+impl Visit<'_> for StmtVisitor {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_nonce_storage_set(i) {
+            self.has_nonce_set = true;
+        }
+        if is_external_call(i) {
+            self.has_external_call = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_external_call_before_nonce_set() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn execute(env: soroban_sdk::Env, nonce: u64) {
+        let stored: u64 = env.storage().persistent().get(&"nonce").unwrap_or(0);
+        // external call BEFORE nonce update — vulnerable
+        token.transfer(&env, &from, &to, &amount);
+        env.storage().persistent().set(&"nonce", &(stored + 1));
+    }
+}
+"#,
+        )?;
+        let hits = NonceIncrementOrderCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_nonce_set_before_external_call() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn execute(env: soroban_sdk::Env, nonce: u64) {
+        let stored: u64 = env.storage().persistent().get(&"nonce").unwrap_or(0);
+        env.storage().persistent().set(&"nonce", &(stored + 1));
+        token.transfer(&env, &from, &to, &amount);
+    }
+}
+"#,
+        )?;
+        let hits = NonceIncrementOrderCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_no_external_call() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn bump_nonce(env: soroban_sdk::Env) {
+        let n: u64 = env.storage().persistent().get(&"nonce").unwrap_or(0);
+        env.storage().persistent().set(&"nonce", &(n + 1));
+    }
+}
+"#,
+        )?;
+        let hits = NonceIncrementOrderCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/uncapped_slippage.rs
+++ b/crates/checks/src/uncapped_slippage.rs
@@ -1,0 +1,201 @@
+//! Detects swap/trade/exchange functions that accept a slippage parameter without capping it.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::Visit;
+use syn::{BinOp, Expr, ExprBinary, ExprMacro, File, FnArg, Pat, Visibility};
+use proc_macro2::TokenTree;
+
+const CHECK_NAME: &str = "uncapped-slippage";
+
+const SWAP_FN_NAMES: &[&str] = &["swap", "trade", "exchange"];
+const SLIPPAGE_PARAM_NAMES: &[&str] = &["slippage", "slippage_bps", "max_slippage"];
+
+pub struct UncappedSlippageCheck;
+
+impl Check for UncappedSlippageCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let fn_name = method.sig.ident.to_string();
+            if !SWAP_FN_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+            // Find a slippage parameter
+            let slippage_param = method.sig.inputs.iter().find_map(|arg| {
+                if let FnArg::Typed(pt) = arg {
+                    if let Pat::Ident(pi) = &*pt.pat {
+                        let name = pi.ident.to_string();
+                        if SLIPPAGE_PARAM_NAMES.contains(&name.as_str()) {
+                            return Some(name);
+                        }
+                    }
+                }
+                None
+            });
+            let Some(param) = slippage_param else { continue };
+
+            // Check AST for a `<= …` guard on the slippage param
+            let mut v = LeGuardVisitor { param: &param, found: false };
+            v.visit_block(&method.block);
+
+            // Fallback: check source text for `param <=` (catches assert! and similar macros)
+            if !v.found {
+                let fn_start = method.sig.fn_token.span().start().line.saturating_sub(1);
+                let fn_end = method.block.brace_token.span.close().start().line;
+                let body_src: String = source
+                    .lines()
+                    .enumerate()
+                    .filter(|(i, _)| *i >= fn_start && *i <= fn_end)
+                    .map(|(_, l)| l)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let pattern = format!("{param} <=");
+                let pattern2 = format!("{param}<=");
+                if body_src.contains(&pattern) || body_src.contains(&pattern2) {
+                    v.found = true;
+                }
+            }
+
+            if !v.found {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: method.sig.fn_token.span().start().line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "`{fn_name}` accepts `{param}` but never asserts `{param} <= MAX`. \
+                         A caller can pass 100% slippage, disabling price protection and \
+                         enabling sandwich attacks."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+struct LeGuardVisitor<'a> {
+    param: &'a str,
+    found: bool,
+}
+
+fn expr_is_ident(expr: &Expr, name: &str) -> bool {
+    if let Expr::Path(p) = expr {
+        p.path.is_ident(name)
+    } else {
+        false
+    }
+}
+
+impl Visit<'_> for LeGuardVisitor<'_> {
+    fn visit_expr_binary(&mut self, i: &ExprBinary) {
+        if matches!(i.op, BinOp::Le(_)) && expr_is_ident(&i.left, self.param) {
+            self.found = true;
+        }
+        syn::visit::visit_expr_binary(self, i);
+    }
+
+    // Also detect `assert!(slippage <= MAX)` — the `<=` lives inside a macro token stream
+    fn visit_expr_macro(&mut self, i: &ExprMacro) {
+        if tokens_contain_le_guard(i.mac.tokens.clone(), self.param) {
+            self.found = true;
+        }
+        syn::visit::visit_expr_macro(self, i);
+    }
+}
+
+/// Returns true if the token stream contains `<param_name> <=` (as consecutive tokens).
+fn tokens_contain_le_guard(tokens: proc_macro2::TokenStream, param: &str) -> bool {
+    let tokens: Vec<TokenTree> = tokens.into_iter().collect();
+    for window in tokens.windows(2) {
+        if let (TokenTree::Ident(id), TokenTree::Punct(p)) = (&window[0], &window[1]) {
+            if id == param && p.as_char() == '<' {
+                return true; // `<=` is two puncts `<` then `=` in proc_macro2
+            }
+        }
+    }
+    // Also handle the case where `<=` is a single joint punct sequence
+    for window in tokens.windows(3) {
+        if let (TokenTree::Ident(id), TokenTree::Punct(p1), TokenTree::Punct(p2)) =
+            (&window[0], &window[1], &window[2])
+        {
+            if id == param && p1.as_char() == '<' && p2.as_char() == '=' {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_swap_without_cap() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn swap(env: soroban_sdk::Env, amount: i128, slippage: u32) {
+        let out = amount - (amount * slippage as i128 / 10000);
+        env.storage().instance().set(&1u32, &out);
+    }
+}
+"#,
+        )?;
+        let hits = UncappedSlippageCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_swap_with_cap() -> Result<(), syn::Error> {
+        let src = r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn swap(env: soroban_sdk::Env, amount: i128, slippage: u32) {
+        assert!(slippage <= 1000);
+        let out = amount - (amount * slippage as i128 / 10000);
+        env.storage().instance().set(&1u32, &out);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = UncappedSlippageCheck.run(&file, src);
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_unrelated_fn_name() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: soroban_sdk::Env, amount: i128, slippage: u32) {
+        let _ = (env, amount, slippage);
+    }
+}
+"#,
+        )?;
+        let hits = UncappedSlippageCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/linear-whitelist-scan-safe/Cargo.toml
+++ b/test-contracts/linear-whitelist-scan-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-linear-whitelist-scan-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/linear-whitelist-scan-safe/src/lib.rs
+++ b/test-contracts/linear-whitelist-scan-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map};
+
+#[contract]
+pub struct WhitelistContract;
+
+#[contractimpl]
+impl WhitelistContract {
+    /// ✅ O(1) Map lookup — no linear scan.
+    pub fn is_allowed(env: Env, caller: Address) -> bool {
+        let map: Map<Address, bool> = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("wl"))
+            .unwrap_or(Map::new(&env));
+        map.contains_key(caller)
+    }
+}

--- a/test-contracts/linear-whitelist-scan-vulnerable/Cargo.toml
+++ b/test-contracts/linear-whitelist-scan-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-linear-whitelist-scan-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/linear-whitelist-scan-vulnerable/src/lib.rs
+++ b/test-contracts/linear-whitelist-scan-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+#[contract]
+pub struct WhitelistContract;
+
+#[contractimpl]
+impl WhitelistContract {
+    /// ❌ O(n) linear scan over storage-backed Vec — DoS risk.
+    pub fn is_allowed(env: Env, caller: Address) -> bool {
+        let list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("wl"))
+            .unwrap_or(Vec::new(&env));
+        list.iter().any(|a| a == caller)
+    }
+}

--- a/test-contracts/lock-period-truncation-safe/Cargo.toml
+++ b/test-contracts/lock-period-truncation-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-lock-period-truncation-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/lock-period-truncation-safe/src/lib.rs
+++ b/test-contracts/lock-period-truncation-safe/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct LockContract;
+
+#[contractimpl]
+impl LockContract {
+    /// ✅ Stores unlock timestamp as u64 — no truncation.
+    pub fn lock(env: Env, period: u64) {
+        let unlock: u64 = env.ledger().timestamp() + period;
+        env.storage().instance().set(&symbol_short!("unlock"), &unlock);
+    }
+}

--- a/test-contracts/lock-period-truncation-vulnerable/Cargo.toml
+++ b/test-contracts/lock-period-truncation-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-lock-period-truncation-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/lock-period-truncation-vulnerable/src/lib.rs
+++ b/test-contracts/lock-period-truncation-vulnerable/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct LockContract;
+
+#[contractimpl]
+impl LockContract {
+    /// ❌ Stores unlock timestamp as u32 — wraps after year 2106, bypassing the lock.
+    pub fn lock(env: Env, period: u64) {
+        let unlock: u32 = env.ledger().timestamp() + period;
+        env.storage().instance().set(&symbol_short!("unlock"), &unlock);
+    }
+}

--- a/test-contracts/nonce-increment-order-safe/Cargo.toml
+++ b/test-contracts/nonce-increment-order-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-nonce-increment-order-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/nonce-increment-order-safe/src/lib.rs
+++ b/test-contracts/nonce-increment-order-safe/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env};
+
+#[contract]
+pub struct NonceContract;
+
+#[contractimpl]
+impl NonceContract {
+    /// ✅ Nonce written BEFORE external call — no replay window.
+    pub fn execute(env: Env, token_id: Address, to: Address, amount: i128) {
+        let nonce: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("nonce"))
+            .unwrap_or(0);
+        // increment nonce first
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("nonce"), &(nonce + 1));
+        let client = token::Client::new(&env, &token_id);
+        client.transfer(&env.current_contract_address(), &to, &amount);
+    }
+}

--- a/test-contracts/nonce-increment-order-vulnerable/Cargo.toml
+++ b/test-contracts/nonce-increment-order-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-nonce-increment-order-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/nonce-increment-order-vulnerable/src/lib.rs
+++ b/test-contracts/nonce-increment-order-vulnerable/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env};
+
+#[contract]
+pub struct NonceContract;
+
+#[contractimpl]
+impl NonceContract {
+    /// ❌ Token transfer happens BEFORE nonce is written — replay risk.
+    pub fn execute(env: Env, token_id: Address, to: Address, amount: i128) {
+        let nonce: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("nonce"))
+            .unwrap_or(0);
+        // external call before nonce update
+        let client = token::Client::new(&env, &token_id);
+        client.transfer(&env.current_contract_address(), &to, &amount);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("nonce"), &(nonce + 1));
+    }
+}

--- a/test-contracts/uncapped-slippage-safe/Cargo.toml
+++ b/test-contracts/uncapped-slippage-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-uncapped-slippage-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/uncapped-slippage-safe/src/lib.rs
+++ b/test-contracts/uncapped-slippage-safe/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+const MAX_SLIPPAGE_BPS: u32 = 1000; // 10%
+
+#[contract]
+pub struct DexContract;
+
+#[contractimpl]
+impl DexContract {
+    /// ✅ Slippage capped at 10% before use.
+    pub fn swap(env: Env, amount: i128, slippage: u32) -> i128 {
+        assert!(slippage <= MAX_SLIPPAGE_BPS, "slippage exceeds maximum");
+        let out = amount - (amount * slippage as i128 / 10000);
+        env.storage().instance().set(&symbol_short!("last"), &out);
+        out
+    }
+}

--- a/test-contracts/uncapped-slippage-vulnerable/Cargo.toml
+++ b/test-contracts/uncapped-slippage-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-uncapped-slippage-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/uncapped-slippage-vulnerable/src/lib.rs
+++ b/test-contracts/uncapped-slippage-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct DexContract;
+
+#[contractimpl]
+impl DexContract {
+    /// ❌ No cap on slippage — caller can pass 10000 (100%), disabling price protection.
+    pub fn swap(env: Env, amount: i128, slippage: u32) -> i128 {
+        let out = amount - (amount * slippage as i128 / 10000);
+        env.storage().instance().set(&symbol_short!("last"), &out);
+        out
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks requested in issues #178–#181, plus fixes two pre-existing bugs in `lib.rs`.

---

## #178 — `lock-period-truncation` (Medium)

**Problem:** A contract that adds a lock/cooldown period to `env.ledger().timestamp()` and stores the result as `u32` will silently truncate the unlock timestamp after year 2106, bypassing the time-lock entirely.

**Detection:** Flags `BinOp::Add` expressions where one operand is `env.ledger().timestamp()` and the result is cast via `as u32` or stored in a `u32`-typed binding.

**Files:**
- `crates/checks/src/lock_period_truncation.rs`
- `test-contracts/lock-period-truncation-vulnerable/`
- `test-contracts/lock-period-truncation-safe/`

---

## #179 — `linear-whitelist-scan` (Medium)

**Problem:** A contract that stores a `Vec<Address>` whitelist in persistent storage and checks membership with `.iter().any(|a| a == caller)` has O(n) auth cost. An attacker who can append to the whitelist can DoS all privileged operations.

**Detection:** Flags `.iter().any(…)` calls inside `#[contractimpl]` functions that also read from storage (two-pass: first confirm a storage `get` exists, then flag any `.iter().any()`).

**Files:**
- `crates/checks/src/linear_whitelist_scan.rs`
- `test-contracts/linear-whitelist-scan-vulnerable/`
- `test-contracts/linear-whitelist-scan-safe/`

---

## #180 — `uncapped-slippage` (High)

**Problem:** A `swap`/`trade`/`exchange` function that accepts a `slippage`/`slippage_bps`/`max_slippage` parameter without asserting `slippage <= MAX` allows a caller to set 100% slippage, disabling price protection and enabling sandwich attacks.

**Detection:** Matches function names; collects slippage parameters; checks for a `BinOp::Le` guard in the AST or a `param <=` pattern in the source text (to catch `assert!(slippage <= MAX)` macros).

**Files:**
- `crates/checks/src/uncapped_slippage.rs`
- `test-contracts/uncapped-slippage-vulnerable/`
- `test-contracts/uncapped-slippage-safe/`

---

## #181 — `nonce-increment-order` (High)

**Problem:** A contract that reads a nonce from storage, performs an external call or token transfer, and only then writes the incremented nonce back to storage is vulnerable to replay attacks — a reentrant caller can reuse the same nonce.

**Detection:** Collects statement indices for nonce `set` calls (keyed by a `nonce`-containing key) and external calls (`invoke_contract`, `transfer`, `transfer_from`, `call`); flags if any external call index is less than the nonce `set` index.

**Files:**
- `crates/checks/src/nonce_increment_order.rs`
- `test-contracts/nonce-increment-order-vulnerable/`
- `test-contracts/nonce-increment-order-safe/`

---

## Pre-existing bug fixes

- Removed duplicate `pub mod uncapped_fee` declaration in `lib.rs`
- Added missing `pub mod ownership_transfer` + `pub use ownership_transfer::OwnershipTransferCheck` (the file existed but was never declared)

---

## Test results

```
test result: 286 passed; 29 failed (all pre-existing)
```

13 new tests added across the four checks — all pass. The 29 remaining failures are pre-existing and unrelated to this PR.

closes #178 
closes #179 
closes #180 
closes #181 