### PR TITLE
feat: add checks for issues #205-#208

### DIFF
--- a/crates/checks/src/address_from_str.rs
+++ b/crates/checks/src/address_from_str.rs
@@ -1,0 +1,190 @@
+//! `Address::from_str` called with a user-supplied parameter (panic risk / DoS).
+//!
+//! `Address::from_str(&env, input)` panics if `input` is not a valid Stellar address.
+//! Calling it on unvalidated user input allows any caller to trigger a contract panic
+//! by passing an invalid string, causing a denial of service.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, File, Pat, PatIdent};
+
+const CHECK_NAME: &str = "address-from-str";
+
+fn param_names(method: &syn::ImplItemFn) -> Vec<String> {
+    method
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| {
+            if let syn::FnArg::Typed(pt) = arg {
+                if let Pat::Ident(PatIdent { ident, .. }) = &*pt.pat {
+                    return Some(ident.to_string());
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn expr_is_param(expr: &Expr, params: &[String]) -> bool {
+    let inner = match expr {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Path(p) => p
+            .path
+            .get_ident()
+            .is_some_and(|id| params.contains(&id.to_string())),
+        _ => false,
+    }
+}
+
+/// True if the call is `Address::from_str(&env, <param>)` where `<param>` is a
+/// function parameter (i.e., user-controlled input).
+fn is_address_from_str_with_param(call: &ExprCall, params: &[String]) -> bool {
+    let Expr::Path(p) = &*call.func else {
+        return false;
+    };
+    let segs = &p.path.segments;
+    if !(segs.len() == 2 && segs[0].ident == "Address" && segs[1].ident == "from_str") {
+        return false;
+    }
+    if call.args.len() < 2 {
+        return false;
+    }
+    expr_is_param(&call.args[1], params)
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    params: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    fn visit_expr_call(&mut self, i: &ExprCall) {
+        if is_address_from_str_with_param(i, &self.params) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`Address::from_str` in `{}` is called with a user-supplied parameter. \
+                     Passing an invalid Stellar address string causes a panic, enabling \
+                     denial-of-service. Validate the input or accept an `Address` parameter \
+                     directly instead of a raw string.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+pub struct AddressFromStrCheck;
+
+impl Check for AddressFromStrCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let params = param_names(method);
+            let mut v = Visitor {
+                fn_name,
+                params,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_address_from_str_with_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env, String};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn resolve(env: Env, input: String) -> Address {
+        Address::from_str(&env, &input)
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AddressFromStrCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_literal_string() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn resolve(env: Env) -> Address {
+        Address::from_str(&env, "GABC...")
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AddressFromStrCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_address_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn resolve(_env: Env, addr: Address) -> Address {
+        addr
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AddressFromStrCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_contractimpl() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{Address, Env, String};
+pub struct C;
+impl C {
+    pub fn resolve(env: Env, input: String) -> Address {
+        Address::from_str(&env, &input)
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = AddressFromStrCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/bytes_oversized.rs
+++ b/crates/checks/src/bytes_oversized.rs
@@ -1,0 +1,213 @@
+//! `Bytes::from_slice` called with a user-controlled slice whose length is not validated.
+//!
+//! If `data` comes from a function parameter without a prior length check, callers can
+//! pass arbitrarily large buffers, exceeding ledger entry size limits or corrupting
+//! fixed-size slot layouts.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprMethodCall, File, Pat, PatIdent};
+
+const CHECK_NAME: &str = "bytes-oversized";
+
+/// Collect the names of all parameters in the function signature.
+fn param_names(method: &syn::ImplItemFn) -> Vec<String> {
+    method
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| {
+            if let syn::FnArg::Typed(pt) = arg {
+                if let Pat::Ident(PatIdent { ident, .. }) = &*pt.pat {
+                    return Some(ident.to_string());
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+/// True if the expression (or a reference to it) is one of the tracked parameter names.
+fn expr_is_param(expr: &Expr, params: &[String]) -> bool {
+    let inner = match expr {
+        Expr::Reference(r) => &*r.expr,
+        other => other,
+    };
+    match inner {
+        Expr::Path(p) => p
+            .path
+            .get_ident()
+            .is_some_and(|id| params.contains(&id.to_string())),
+        _ => false,
+    }
+}
+
+/// True if the call is `Bytes::from_slice(&env, <param>)` where `<param>` is a
+/// function parameter (i.e., user-controlled).
+fn is_bytes_from_slice_with_param(call: &ExprCall, params: &[String]) -> bool {
+    let Expr::Path(p) = &*call.func else {
+        return false;
+    };
+    let segs = &p.path.segments;
+    if !(segs.len() == 2 && segs[0].ident == "Bytes" && segs[1].ident == "from_slice") {
+        return false;
+    }
+    // args: (&env, data)
+    if call.args.len() < 2 {
+        return false;
+    }
+    expr_is_param(&call.args[1], params)
+}
+
+/// Also catch the method-call form: `Bytes::from_slice` is sometimes written as
+/// a free function, but also check `.from_slice(...)` on a path receiver.
+fn is_method_from_slice_with_param(call: &ExprMethodCall, params: &[String]) -> bool {
+    if call.method != "from_slice" {
+        return false;
+    }
+    // receiver should be `Bytes` path
+    let Expr::Path(p) = &*call.receiver else {
+        return false;
+    };
+    if !p.path.get_ident().is_some_and(|id| id == "Bytes") {
+        return false;
+    }
+    call.args.iter().any(|a| expr_is_param(a, params))
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    params: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    fn visit_expr_call(&mut self, i: &ExprCall) {
+        if is_bytes_from_slice_with_param(i, &self.params) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`Bytes::from_slice` in `{}` receives a user-controlled slice without \
+                     a prior length check. Callers can supply oversized buffers that exceed \
+                     ledger entry limits or corrupt fixed-size slot layouts. Validate \
+                     `data.len()` before constructing the `Bytes` value.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_call(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if is_method_from_slice_with_param(i, &self.params) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`Bytes::from_slice` in `{}` receives a user-controlled slice without \
+                     a prior length check. Callers can supply oversized buffers that exceed \
+                     ledger entry limits or corrupt fixed-size slot layouts. Validate \
+                     `data.len()` before constructing the `Bytes` value.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+pub struct BytesOversizedCheck;
+
+impl Check for BytesOversizedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let params = param_names(method);
+            let mut v = Visitor {
+                fn_name,
+                params,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_bytes_from_slice_with_param() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, data: &[u8]) {
+        let b = Bytes::from_slice(&env, data);
+        env.storage().instance().set(&1u32, &b);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesOversizedCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_literal_slice() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Bytes, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env) {
+        let b = Bytes::from_slice(&env, &[1u8, 2, 3]);
+        env.storage().instance().set(&1u32, &b);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesOversizedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_contractimpl() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{Bytes, Env};
+pub struct C;
+impl C {
+    pub fn store(env: Env, data: &[u8]) {
+        let _ = Bytes::from_slice(&env, data);
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = BytesOversizedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/i128_to_u64.rs
+++ b/crates/checks/src/i128_to_u64.rs
@@ -1,0 +1,159 @@
+//! `i128` (or `u128`) cast to `u64` without overflow/range checking.
+//!
+//! `value as u64` silently truncates if `value > u64::MAX` or is negative.
+//! In token contracts this can cause amounts to wrap to unexpected values.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCast, File, Type};
+
+const CHECK_NAME: &str = "i128-to-u64-cast";
+
+fn type_is_u64(ty: &Type) -> bool {
+    matches!(ty, Type::Path(p) if p.path.is_ident("u64"))
+}
+
+fn expr_type_is_wide_int(expr: &Expr) -> bool {
+    // We can't resolve types statically, so we look for common patterns:
+    // casts from i128/u128 literals or from expressions typed as i128/u128.
+    // The most reliable signal is a nested cast: `(x as i128) as u64`.
+    match expr {
+        Expr::Cast(inner) => {
+            matches!(&*inner.ty, Type::Path(p) if p.path.is_ident("i128") || p.path.is_ident("u128"))
+        }
+        // Also flag any `as u64` where the source is a path (variable) — conservative
+        // but catches the common `amount as u64` pattern in token contracts.
+        Expr::Path(_) => true,
+        Expr::MethodCall(_) => true,
+        _ => false,
+    }
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    fn visit_expr_cast(&mut self, i: &ExprCast) {
+        if type_is_u64(&i.ty) && expr_type_is_wide_int(&i.expr) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`as u64` cast in `{}` may silently truncate an `i128`/`u128` value \
+                     that exceeds `u64::MAX` or is negative. Use `u64::try_from(value)` \
+                     and handle the error, or validate the range before casting.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_cast(self, i);
+    }
+}
+
+pub struct I128ToU64Check;
+
+impl Check for I128ToU64Check {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = Visitor {
+                fn_name,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_variable_as_u64() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn convert(_env: Env, amount: i128) -> u64 {
+        amount as u64
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = I128ToU64Check.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_nested_i128_cast_as_u64() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn convert(_env: Env, x: u32) -> u64 {
+        (x as i128) as u64
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = I128ToU64Check.run(&file, "");
+        // outer cast is flagged
+        assert!(!hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_try_from() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn convert(_env: Env, amount: i128) -> Option<u64> {
+        u64::try_from(amount).ok()
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = I128ToU64Check.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_contractimpl() -> Result<(), syn::Error> {
+        let src = r#"
+pub struct C;
+impl C {
+    pub fn convert(amount: i128) -> u64 {
+        amount as u64
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = I128ToU64Check.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -1,5 +1,6 @@
 //! Vulnerability detectors for Soroban smart contracts.
 
+pub mod address_from_str;
 pub mod admin;
 pub mod admin_in_temp;
 pub mod admin_key_removal;
@@ -13,6 +14,7 @@ pub mod balance_overflow;
 pub mod broken_pause;
 pub mod burn_auth;
 pub mod bytes_not_bytesn;
+pub mod bytes_oversized;
 pub mod contracterror_attr;
 pub mod contracttype;
 pub mod current_contract_unwrap;
@@ -22,6 +24,7 @@ pub mod env_in_struct;
 pub mod extend_ttl_in_loop;
 pub mod float_arithmetic;
 pub mod hash_as_storage_key;
+pub mod i128_to_u64;
 pub mod instance_domain_mixing;
 pub mod instance_remove_critical;
 pub mod instance_ttl;
@@ -45,6 +48,7 @@ pub mod unlimited_allowance;
 pub mod panic_usage;
 pub mod partial_write_on_error;
 pub mod reentrancy;
+pub mod runtime_symbol;
 pub mod secp256k1_unchecked;
 pub mod self_transfer;
 pub mod sequence_as_key;
@@ -77,6 +81,7 @@ pub mod withdraw_auth;
 pub mod wrapping_balance_op;
 pub mod zero_amount;
 
+pub use address_from_str::AddressFromStrCheck;
 pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
@@ -90,6 +95,7 @@ pub use balance_overflow::BalanceOverflowCheck;
 pub use broken_pause::BrokenPauseCheck;
 pub use burn_auth::BurnAuthCheck;
 pub use bytes_not_bytesn::BytesNotBytesNCheck;
+pub use bytes_oversized::BytesOversizedCheck;
 pub use contracterror_attr::ContracterrorAttrCheck;
 pub use contracttype::MissingContracttypeCheck;
 pub use current_contract_unwrap::CurrentContractUnwrapCheck;
@@ -99,6 +105,7 @@ pub use env_in_struct::EnvInStructCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
 pub use hash_as_storage_key::HashAsStorageKeyCheck;
+pub use i128_to_u64::I128ToU64Check;
 pub use instance_domain_mixing::InstanceDomainMixingCheck;
 pub use instance_remove_critical::InstanceRemoveCriticalCheck;
 pub use instance_ttl::InstanceTtlCheck;
@@ -122,6 +129,7 @@ pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use panic_usage::PanicUsageCheck;
 pub use partial_write_on_error::PartialWriteOnErrorCheck;
 pub use reentrancy::ReentrancyCheck;
+pub use runtime_symbol::RuntimeSymbolCheck;
 pub use secp256k1_unchecked::Secp256k1UncheckedCheck;
 pub use self_transfer::SelfTransferCheck;
 pub use sequence_as_key::SequenceAsKeyCheck;
@@ -246,5 +254,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(LinearWhitelistScanCheck),
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
+        Box::new(RuntimeSymbolCheck),
+        Box::new(BytesOversizedCheck),
+        Box::new(I128ToU64Check),
+        Box::new(AddressFromStrCheck),
     ]
 }

--- a/crates/checks/src/runtime_symbol.rs
+++ b/crates/checks/src/runtime_symbol.rs
@@ -1,0 +1,130 @@
+//! `Symbol::from_str` used at runtime instead of the `symbol_short!` compile-time macro.
+//!
+//! `symbol_short!` validates the string at compile time and produces a zero-cost constant.
+//! `Symbol::from_str(&env, name)` defers validation to runtime, so misspelled symbols
+//! are only caught when the contract executes on-chain.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, File};
+
+const CHECK_NAME: &str = "runtime-symbol";
+
+fn is_symbol_from_str(call: &ExprCall) -> bool {
+    let Expr::Path(p) = &*call.func else {
+        return false;
+    };
+    let segs = &p.path.segments;
+    segs.len() == 2 && segs[0].ident == "Symbol" && segs[1].ident == "from_str"
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for Visitor<'_> {
+    fn visit_expr_call(&mut self, i: &ExprCall) {
+        if is_symbol_from_str(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Low,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`Symbol::from_str` used at runtime in `{}`. \
+                     For compile-time constant strings (≤9 chars) prefer `symbol_short!` \
+                     which validates the value at compile time and has zero runtime cost.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+pub struct RuntimeSymbolCheck;
+
+impl Check for RuntimeSymbolCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = Visitor {
+                fn_name,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_symbol_from_str() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn get_key(env: Env) -> Symbol {
+        Symbol::from_str(&env, "counter")
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = RuntimeSymbolCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_symbol_short() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn get_key(_env: Env) -> Symbol {
+        symbol_short!("counter")
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = RuntimeSymbolCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_outside_contractimpl() -> Result<(), syn::Error> {
+        let src = r#"
+use soroban_sdk::{Env, Symbol};
+pub struct C;
+impl C {
+    pub fn get_key(env: Env) -> Symbol {
+        Symbol::from_str(&env, "counter")
+    }
+}
+"#;
+        let file = parse_file(src)?;
+        let hits = RuntimeSymbolCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/address-from-str-safe/Cargo.toml
+++ b/test-contracts/address-from-str-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-address-from-str-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/address-from-str-safe/src/lib.rs
+++ b/test-contracts/address-from-str-safe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AddressFromStrSafe;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("owner");
+
+#[contractimpl]
+impl AddressFromStrSafe {
+    /// Safe: accepts a typed Address parameter — the SDK validates it before
+    /// the function is called, so no runtime panic is possible.
+    pub fn set_owner(env: Env, owner: Address) {
+        env.storage().instance().set(&KEY, &owner);
+    }
+
+    pub fn get_owner(env: Env) -> Address {
+        env.storage().instance().get(&KEY).unwrap()
+    }
+}

--- a/test-contracts/address-from-str-vulnerable/Cargo.toml
+++ b/test-contracts/address-from-str-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-address-from-str-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/address-from-str-vulnerable/src/lib.rs
+++ b/test-contracts/address-from-str-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String};
+
+#[contract]
+pub struct AddressFromStrVulnerable;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("owner");
+
+#[contractimpl]
+impl AddressFromStrVulnerable {
+    /// BUG: Address::from_str panics on invalid input.
+    /// Any caller can trigger a contract panic by passing a malformed address string,
+    /// causing a denial of service.
+    pub fn set_owner(env: Env, raw_addr: String) {
+        let owner = Address::from_str(&env, &raw_addr); // ❌ panics on invalid input
+        env.storage().instance().set(&KEY, &owner);
+    }
+}

--- a/test-contracts/bytes-oversized-safe/Cargo.toml
+++ b/test-contracts/bytes-oversized-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-bytes-oversized-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/bytes-oversized-safe/src/lib.rs
+++ b/test-contracts/bytes-oversized-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, Env};
+
+#[contract]
+pub struct BytesOversizedSafe;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("blob");
+const MAX_LEN: u32 = 128;
+
+#[contractimpl]
+impl BytesOversizedSafe {
+    /// Safe: length is validated before constructing the Bytes value.
+    pub fn store(env: Env, data: Bytes) {
+        assert!(data.len() <= MAX_LEN, "data exceeds maximum allowed size");
+        env.storage().persistent().set(&KEY, &data);
+    }
+}

--- a/test-contracts/bytes-oversized-vulnerable/Cargo.toml
+++ b/test-contracts/bytes-oversized-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-bytes-oversized-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/bytes-oversized-vulnerable/src/lib.rs
+++ b/test-contracts/bytes-oversized-vulnerable/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, Env};
+
+#[contract]
+pub struct BytesOversizedVulnerable;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("blob");
+
+#[contractimpl]
+impl BytesOversizedVulnerable {
+    /// BUG: `data` is user-controlled and its length is never checked.
+    /// A caller can pass a slice that exceeds the ledger entry size limit,
+    /// causing the storage write to fail or corrupt slot layouts.
+    pub fn store(env: Env, data: &[u8]) {
+        // No length validation — user controls how large `data` is.
+        let b = Bytes::from_slice(&env, data); // ❌ oversized input not rejected
+        env.storage().persistent().set(&KEY, &b);
+    }
+}

--- a/test-contracts/i128-to-u64-safe/Cargo.toml
+++ b/test-contracts/i128-to-u64-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-i128-to-u64-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/i128-to-u64-safe/src/lib.rs
+++ b/test-contracts/i128-to-u64-safe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct I128ToU64Safe;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl I128ToU64Safe {
+    /// Safe: uses try_from to detect overflow/negative values before converting.
+    pub fn deposit(env: Env, amount: i128) {
+        let stored = u64::try_from(amount).expect("amount out of u64 range");
+        env.storage().instance().set(&KEY, &stored);
+    }
+
+    pub fn get_balance(env: Env) -> u64 {
+        env.storage().instance().get(&KEY).unwrap_or(0u64)
+    }
+}

--- a/test-contracts/i128-to-u64-vulnerable/Cargo.toml
+++ b/test-contracts/i128-to-u64-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-i128-to-u64-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/i128-to-u64-vulnerable/src/lib.rs
+++ b/test-contracts/i128-to-u64-vulnerable/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct I128ToU64Vulnerable;
+
+const KEY: soroban_sdk::Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl I128ToU64Vulnerable {
+    /// BUG: `amount as u64` silently truncates if amount > u64::MAX or is negative.
+    /// Token amounts in Soroban are i128; casting without a range check can wrap
+    /// to an unexpected value.
+    pub fn deposit(env: Env, amount: i128) {
+        let stored: u64 = amount as u64; // ❌ silent truncation
+        env.storage().instance().set(&KEY, &stored);
+    }
+
+    pub fn get_balance(env: Env) -> u64 {
+        env.storage().instance().get(&KEY).unwrap_or(0u64)
+    }
+}

--- a/test-contracts/runtime-symbol-safe/Cargo.toml
+++ b/test-contracts/runtime-symbol-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-runtime-symbol-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/runtime-symbol-safe/src/lib.rs
+++ b/test-contracts/runtime-symbol-safe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct RuntimeSymbolSafe;
+
+/// Safe: compile-time constant — validated at compile time, zero runtime cost.
+const KEY: Symbol = symbol_short!("counter");
+
+#[contractimpl]
+impl RuntimeSymbolSafe {
+    pub fn get_key(_env: Env) -> Symbol {
+        KEY
+    }
+
+    pub fn increment(env: Env) {
+        let n: u32 = env.storage().instance().get(&KEY).unwrap_or(0);
+        env.storage().instance().set(&KEY, &(n + 1));
+    }
+}

--- a/test-contracts/runtime-symbol-vulnerable/Cargo.toml
+++ b/test-contracts/runtime-symbol-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-runtime-symbol-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/runtime-symbol-vulnerable/src/lib.rs
+++ b/test-contracts/runtime-symbol-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct RuntimeSymbolVulnerable;
+
+const KEY: Symbol = symbol_short!("count");
+
+#[contractimpl]
+impl RuntimeSymbolVulnerable {
+    /// BUG: Symbol::from_str defers validation to runtime.
+    /// A misspelled name is only caught when the contract executes on-chain.
+    pub fn get_key(env: Env) -> Symbol {
+        Symbol::from_str(&env, "counter")
+    }
+
+    pub fn increment(env: Env) {
+        let n: u32 = env.storage().instance().get(&KEY).unwrap_or(0);
+        env.storage().instance().set(&KEY, &(n + 1));
+    }
+}


### PR DESCRIPTION
Closes #205 
 
runtime-symbol (Low): flags Symbol::from_str used at runtime instead of the symbol_short! compile-time macro

Closes #206 

  bytes-oversized (Medium): flags Bytes::from_slice called with a user-controlled slice whose length is not validated before use

Closes  #207

 i128-to-u64-cast (Medium): flags i128/u128 values cast to u64 with 'as u64', which silently truncates on overflow or negative input

Closes #208

 address-from-str (Medium): flags Address::from_str called with a user-supplied parameter, which panics on invalid input (DoS risk)
