### PR TITLE
feat(checks): add storage-ttl-has-get-race (#223) and deployer-no-auth (#224)

### DIFF
--- a/crates/checks/src/deployer_no_auth.rs
+++ b/crates/checks/src/deployer_no_auth.rs
@@ -1,0 +1,148 @@
+//! Detects `env.deployer().deploy(...)` called without a preceding `require_auth` in the
+//! same `#[contractimpl]` function, allowing any caller to deploy sub-contracts.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "deployer-no-auth";
+
+pub struct DeployerNoAuthCheck;
+
+impl Check for DeployerNoAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = DeployerScan::default();
+            scan.visit_block(&method.block);
+            if scan.deploy_found && !scan.require_auth_found {
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: scan.deploy_line.unwrap_or_else(|| method.sig.ident.span().start().line),
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "`{}` calls `env.deployer().deploy(...)` without a preceding \
+                         `require_auth()`. Any caller can deploy new contract instances under \
+                         this contract's authority.",
+                        fn_name
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn is_require_auth(m: &ExprMethodCall) -> bool {
+    (m.method == "require_auth" || m.method == "require_auth_for_args")
+        && matches!(&*m.receiver, Expr::Path(p) if p.path.is_ident("env"))
+}
+
+fn is_deployer_deploy(m: &ExprMethodCall) -> bool {
+    if m.method != "deploy" && m.method != "deploy_v2" {
+        return false;
+    }
+    // receiver must be `env.deployer()` or a chain containing it
+    receiver_contains_deployer(&m.receiver)
+}
+
+fn receiver_contains_deployer(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => m.method == "deployer" || receiver_contains_deployer(&m.receiver),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct DeployerScan {
+    require_auth_found: bool,
+    deploy_found: bool,
+    deploy_line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for DeployerScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_require_auth(i) {
+            self.require_auth_found = true;
+        }
+        if is_deployer_deploy(i) && !self.deploy_found {
+            self.deploy_found = true;
+            self.deploy_line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        DeployerNoAuthCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_deploy_without_auth() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn spawn(env: Env, wasm_hash: BytesN<32>, salt: BytesN<32>) {
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_with_require_auth() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn spawn(env: Env, wasm_hash: BytesN<32>, salt: BytesN<32>) {
+        env.require_auth();
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_with_require_auth_for_args() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn spawn(env: Env, admin: Address, wasm_hash: BytesN<32>, salt: BytesN<32>) {
+        env.require_auth_for_args((admin,));
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn no_flag_without_deploy() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn noop(env: Env) {}
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -17,6 +17,7 @@ pub mod contracterror_attr;
 pub mod contracttype;
 pub mod current_contract_unwrap;
 pub mod debug_entrypoint;
+pub mod deployer_no_auth;
 pub mod dynamic_symbol_key;
 pub mod env_in_struct;
 pub mod extend_ttl_in_loop;
@@ -50,6 +51,7 @@ pub mod self_transfer;
 pub mod sequence_as_key;
 pub mod sequence_nonce;
 pub mod storage;
+pub mod storage_has_get_race;
 pub mod storage_type_confusion;
 pub mod temp_get_no_has;
 pub mod temp_read_in_view;
@@ -94,6 +96,7 @@ pub use contracterror_attr::ContracterrorAttrCheck;
 pub use contracttype::MissingContracttypeCheck;
 pub use current_contract_unwrap::CurrentContractUnwrapCheck;
 pub use debug_entrypoint::DebugEntrypointCheck;
+pub use deployer_no_auth::DeployerNoAuthCheck;
 pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use env_in_struct::EnvInStructCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
@@ -127,6 +130,7 @@ pub use self_transfer::SelfTransferCheck;
 pub use sequence_as_key::SequenceAsKeyCheck;
 pub use sequence_nonce::SequenceNonceCheck;
 pub use storage::UnsafeStoragePatternsCheck;
+pub use storage_has_get_race::StorageHasGetRaceCheck;
 pub use storage_type_confusion::StorageTypeConfusionCheck;
 pub use temp_get_no_has::TempGetNoHasCheck;
 pub use temp_set_no_ttl::TempSetNoTtlCheck;
@@ -246,5 +250,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(LinearWhitelistScanCheck),
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
+        Box::new(StorageHasGetRaceCheck),
+        Box::new(DeployerNoAuthCheck),
     ]
 }

--- a/crates/checks/src/storage_has_get_race.rs
+++ b/crates/checks/src/storage_has_get_race.rs
@@ -1,0 +1,201 @@
+//! Detects TTL race: `has(key)` and `get(key)` on the same storage tier with intervening
+//! host calls that could allow the entry to expire between the check and the read.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "storage-ttl-has-get-race";
+
+/// Flags functions that call `has(key)` then later call `get(key)` on the same storage tier
+/// with at least one intervening host call, creating a window where the TTL may expire.
+pub struct StorageHasGetRaceCheck;
+
+impl Check for StorageHasGetRaceCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = RaceVisitor {
+                fn_name,
+                has_seen: Vec::new(),
+                call_count_since_has: 0,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn storage_tier(expr: &Expr) -> Option<&'static str> {
+    match expr {
+        Expr::MethodCall(m) => {
+            let name = m.method.to_string();
+            match name.as_str() {
+                "persistent" => Some("persistent"),
+                "temporary" => Some("temporary"),
+                "instance" => Some("instance"),
+                _ => storage_tier(&m.receiver),
+            }
+        }
+        _ => None,
+    }
+}
+
+fn receiver_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => m.method == "storage" || receiver_contains_storage(&m.receiver),
+        _ => false,
+    }
+}
+
+fn is_storage_has(m: &ExprMethodCall) -> Option<&'static str> {
+    if m.method == "has" && receiver_contains_storage(&m.receiver) {
+        return storage_tier(&m.receiver);
+    }
+    None
+}
+
+fn is_storage_get(m: &ExprMethodCall) -> Option<&'static str> {
+    if m.method == "get" && receiver_contains_storage(&m.receiver) {
+        return storage_tier(&m.receiver);
+    }
+    None
+}
+
+// ── visitor ──────────────────────────────────────────────────────────────────
+
+/// Tracks (tier, call_count_at_has) pairs seen so far in the function.
+struct RaceVisitor<'a> {
+    fn_name: String,
+    /// (tier, host-call count when `has` was seen)
+    has_seen: Vec<(&'static str, usize)>,
+    call_count_since_has: usize,
+    out: &'a mut Vec<Finding>,
+}
+
+/// Minimum number of intervening method calls to consider a "race window".
+const RACE_THRESHOLD: usize = 1;
+
+impl Visit<'_> for RaceVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if let Some(tier) = is_storage_has(i) {
+            self.has_seen.push((tier, self.call_count_since_has));
+            // Don't recurse into the storage chain — sub-calls are not host calls.
+            return;
+        }
+        if let Some(get_tier) = is_storage_get(i) {
+            let race = self.has_seen.iter().any(|(has_tier, count_at_has)| {
+                *has_tier == get_tier
+                    && (self.call_count_since_has - count_at_has) >= RACE_THRESHOLD
+            });
+            if race {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "`{}` calls `has()` then `get()` on `{}` storage with intervening host \
+                         calls. The TTL may expire between the check and the read, causing an \
+                         unexpected panic. Use `get()` directly with `unwrap_or_default()`, or \
+                         extend the TTL immediately after `has()`.",
+                        self.fn_name, get_tier
+                    ),
+                });
+            }
+            // Don't recurse into the storage chain.
+            return;
+        }
+        // Only count non-storage method calls as potential host calls in the gap.
+        if !receiver_contains_storage(i) {
+            self.call_count_since_has += 1;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        StorageHasGetRaceCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_has_then_host_call_then_get() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn read(env: Env, key: u32) {
+        if env.storage().persistent().has(&key) {
+            env.current_contract_address(); // intervening host call
+            let _v = env.storage().persistent().get(&key);
+        }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn no_flag_when_get_immediately_follows_has() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn read(env: Env, key: u32) {
+        if env.storage().persistent().has(&key) {
+            let _v = env.storage().persistent().get(&key);
+        }
+    }
+}
+"#);
+        // has and get are adjacent — no intervening calls counted
+        assert!(hits.is_empty(), "{hits:?}");
+    }
+
+    #[test]
+    fn no_flag_without_has() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn read(env: Env, key: u32) {
+        let _v = env.storage().persistent().get(&key);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn no_flag_different_tiers() {
+        let hits = run(r#"
+#[contractimpl]
+impl C {
+    pub fn read(env: Env, key: u32) {
+        if env.storage().temporary().has(&key) {
+            env.current_contract_address();
+            let _v = env.storage().persistent().get(&key);
+        }
+    }
+}
+"#);
+        // has on temporary, get on persistent — different tiers, no race
+        assert!(hits.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

closes #223 
closes #224 

### `storage-ttl-has-get-race` (Medium)
Flags `#[contractimpl]` functions that call `has(key)` on a storage tier and then `get(key)` on the same tier with at least one intervening host call. The TTL may expire in that window, causing an unexpected panic on the `get`. Checks all three tiers (`persistent`, `temporary`, `instance`) independently. Adjacent `has`/`get` pairs with no intervening calls are not flagged.

### `deployer-no-auth` (High)
Flags `env.deployer().deploy()` / `deploy_v2()` calls in `#[contractimpl]` functions that have no preceding `env.require_auth()` or `env.require_auth_for_args()`. Without auth, any caller can deploy new contract instances under the deploying contract's authority.

## Changes
- `crates/checks/src/storage_has_get_race.rs` — new check + 4 unit tests
- `crates/checks/src/deployer_no_auth.rs` — new check + 4 unit tests
- `crates/checks/src/lib.rs` — mod declarations, re-exports, registered in `default_checks()`