### PR TITLE
feat: add ttl-no-set check (#220)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -60,6 +60,7 @@ pub mod token_burn_auth;
 pub mod token_transfer_unchecked;
 pub mod transfer_to_self;
 pub mod ttl_arg_order;
+pub mod ttl_no_set;
 pub mod unauth_address_in_struct;
 pub mod uncapped_slippage;
 pub mod unauth_fee_setter;
@@ -136,6 +137,7 @@ pub use token_burn_auth::TokenBurnAuthCheck;
 pub use token_transfer_unchecked::TokenTransferUncheckedCheck;
 pub use transfer_to_self::TransferToSelfCheck;
 pub use ttl_arg_order::TtlArgOrderCheck;
+pub use ttl_no_set::TtlNoSetCheck;
 pub use unauth_address_in_struct::UnauthAddressInStructCheck;
 pub use uncapped_slippage::UncappedSlippageCheck;
 pub use unauth_fee_setter::UnauthFeeSetterCheck;
@@ -246,5 +248,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(LinearWhitelistScanCheck),
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
+        Box::new(TtlNoSetCheck),
     ]
 }

--- a/crates/checks/src/ttl_no_set.rs
+++ b/crates/checks/src/ttl_no_set.rs
@@ -1,0 +1,185 @@
+//! Flags `extend_ttl(key, min, max)` calls where `key` is never passed to `set` anywhere
+//! in the same contract file (phantom TTL extension — dead code or wrong key).
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "ttl-no-set";
+
+pub struct TtlNoSetCheck;
+
+impl Check for TtlNoSetCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        // Collect all keys passed to `set` across the whole file.
+        let mut set_collector = KeyCollector { method: "set", keys: Vec::new() };
+        set_collector.visit_file(file);
+        let set_keys: Vec<String> = set_collector.keys;
+
+        // Collect all (key, line, fn_name) passed to `extend_ttl` (3-arg form).
+        let mut ttl_collector = TtlExtendCollector { entries: Vec::new() };
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            ttl_collector.current_fn = fn_name;
+            ttl_collector.visit_block(&method.block);
+        }
+
+        // Flag extend_ttl keys that never appear in any set call.
+        ttl_collector
+            .entries
+            .into_iter()
+            .filter(|(key, _, _)| !set_keys.contains(key))
+            .map(|(key, line, fn_name)| Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Low,
+                file_path: String::new(),
+                line,
+                function_name: fn_name,
+                description: format!(
+                    "extend_ttl called for key `{key}` which is never written via `set` \
+                     in this contract. This may be dead code or a wrong key."
+                ),
+            })
+            .collect()
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => m.method == "storage" || receiver_chain_contains_storage(&m.receiver),
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+/// Extract a simple string representation of an expression used as a storage key.
+fn key_repr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Reference(r) => key_repr(&r.expr),
+        Expr::Path(p) => Some(p.path.segments.last()?.ident.to_string()),
+        Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(s), .. }) => Some(s.value()),
+        Expr::Macro(m) => Some(m.mac.path.segments.last()?.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// Visits the whole file and collects key representations for a given method name.
+struct KeyCollector {
+    method: &'static str,
+    keys: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for KeyCollector {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == self.method
+            && receiver_chain_contains_storage(&i.receiver)
+            && !i.args.is_empty()
+        {
+            if let Some(k) = key_repr(&i.args[0]) {
+                self.keys.push(k);
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+/// Collects (key, line, fn_name) for 3-arg extend_ttl calls inside contractimpl functions.
+struct TtlExtendCollector {
+    current_fn: String,
+    entries: Vec<(String, usize, String)>,
+}
+
+impl<'ast> Visit<'ast> for TtlExtendCollector {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "extend_ttl"
+            && receiver_chain_contains_storage(&i.receiver)
+            && i.args.len() == 3
+        {
+            if let Some(k) = key_repr(&i.args[0]) {
+                self.entries.push((k, i.span().start().line, self.current_fn.clone()));
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        TtlNoSetCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_extend_ttl_without_set() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        // extend_ttl for KEY but KEY is never set anywhere
+        env.storage().persistent().extend_ttl(&KEY, 100, 1000);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_when_key_is_set() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, v: u32) {
+        env.storage().persistent().set(&KEY, &v);
+        env.storage().persistent().extend_ttl(&KEY, 100, 1000);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_two_arg_extend_ttl() {
+        // 2-arg form (instance/temporary) — not flagged by this check
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        env.storage().instance().extend_ttl(100, 1000);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_set_in_different_function() {
+        let hits = run(r#"
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, v: u32) {
+        env.storage().persistent().set(&KEY, &v);
+    }
+    pub fn refresh(env: Env) {
+        env.storage().persistent().extend_ttl(&KEY, 100, 1000);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/test-contracts/ttl-no-set-safe/Cargo.toml
+++ b/test-contracts/ttl-no-set-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-no-set-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-no-set-safe/src/lib.rs
+++ b/test-contracts/ttl-no-set-safe/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct SafeContract;
+
+const DATA_KEY: soroban_sdk::Symbol = symbol_short!("data");
+
+#[contractimpl]
+impl SafeContract {
+    pub fn store(env: Env, val: u32) {
+        // ✅ DATA_KEY is written via set before extend_ttl
+        env.storage().persistent().set(&DATA_KEY, &val);
+        env.storage().persistent().extend_ttl(DATA_KEY, 10000, 17280);
+    }
+
+    pub fn refresh(env: Env) {
+        // ✅ DATA_KEY is set elsewhere in the contract
+        env.storage().persistent().extend_ttl(DATA_KEY, 10000, 17280);
+    }
+}

--- a/test-contracts/ttl-no-set-vulnerable/Cargo.toml
+++ b/test-contracts/ttl-no-set-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-no-set-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-no-set-vulnerable/src/lib.rs
+++ b/test-contracts/ttl-no-set-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct VulnerableContract;
+
+const DATA_KEY: soroban_sdk::Symbol = symbol_short!("data");
+const GHOST_KEY: soroban_sdk::Symbol = symbol_short!("ghost");
+
+#[contractimpl]
+impl VulnerableContract {
+    pub fn store(env: Env, val: u32) {
+        env.storage().persistent().set(&DATA_KEY, &val);
+        env.storage().persistent().extend_ttl(DATA_KEY, 10000, 17280);
+    }
+
+    pub fn refresh(env: Env) {
+        // ❌ GHOST_KEY is never written via set — phantom extension
+        env.storage().persistent().extend_ttl(GHOST_KEY, 10000, 17280);
+    }
+}


### PR DESCRIPTION
- Flags extend_ttl(key, min, max) where key is never written via set in the contract
- Severity: Low
- Collects set keys across whole file, cross-references with extend_ttl keys
- Adds test contracts: ttl-no-set-vulnerable, ttl-no-set-safe
- Registers TtlNoSetCheck in default_checks()

closes #220 