### PR TITLE
Add new Soroban Guard checks for invoke_contract and deploy issues wi…

### DIFF
--- a/crates/checks/src/deploy_salt_predictable.rs
+++ b/crates/checks/src/deploy_salt_predictable.rs
@@ -1,0 +1,180 @@
+//! Flags `env.deployer().deploy()` calls with predictable salt derived from ledger data.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Pat, PatType, Stmt};
+
+const CHECK_NAME: &str = "deploy-salt-predictable";
+
+pub struct DeploySaltPredictableCheck;
+
+impl Check for DeploySaltPredictableCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = DeploySaltPredictableVisitor {
+                fn_name,
+                ledger_vars: Vec::new(),
+                out: &mut out,
+            };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn is_ledger_rand(expr: &Expr) -> bool {
+    let Expr::MethodCall(outer) = expr else {
+        return false;
+    };
+    if !matches!(outer.method.to_string().as_str(), "timestamp" | "sequence") {
+        return false;
+    }
+    let Expr::MethodCall(inner) = &*outer.receiver else {
+        return false;
+    };
+    inner.method == "ledger"
+}
+
+fn expr_contains_ledger_rand(expr: &Expr, ledger_vars: &[String]) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if is_ledger_rand(expr) {
+                return true;
+            }
+            expr_contains_ledger_rand(&m.receiver, ledger_vars)
+                || m.args.iter().any(|arg| expr_contains_ledger_rand(arg, ledger_vars))
+        }
+        Expr::Path(path) => path
+            .path
+            .get_ident()
+            .map_or(false, |id| ledger_vars.contains(&id.to_string())),
+        Expr::Reference(r) => expr_contains_ledger_rand(&r.expr, ledger_vars),
+        Expr::Paren(p) => expr_contains_ledger_rand(&p.expr, ledger_vars),
+        _ => false,
+    }
+}
+
+fn is_deploy_call(m: &ExprMethodCall) -> bool {
+    if m.method != "deploy" {
+        return false;
+    }
+    matches!(&*m.receiver, Expr::MethodCall(inner) if inner.method == "deployer")
+}
+
+struct DeploySaltPredictableVisitor<'a> {
+    fn_name: String,
+    ledger_vars: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for DeploySaltPredictableVisitor<'_> {
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        if let Stmt::Local(local) = i {
+            if let Some((_, init_expr)) = &local.init {
+                if expr_contains_ledger_rand(&init_expr.expr, &self.ledger_vars) {
+                    if let Pat::Ident(pi) = &local.pat {
+                        self.ledger_vars.push(pi.ident.to_string());
+                    }
+                }
+            }
+        }
+        visit::visit_stmt(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_deploy_call(i) {
+            if let Some(salt_arg) = i.args.iter().nth(1) {
+                if expr_contains_ledger_rand(salt_arg, &self.ledger_vars) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` deploys a contract with a salt derived from `env.ledger().sequence()` or `env.ledger().timestamp()`. This allows deployment front-running.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        DeploySaltPredictableCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_ledger_sequence_salt_direct() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        env.deployer().deploy(wasm_hash, env.ledger().sequence());
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn flags_ledger_timestamp_salt_via_var() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let salt = env.ledger().timestamp();
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn passes_constant_salt() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let salt = ();
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/deploy_unverified.rs
+++ b/crates/checks/src/deploy_unverified.rs
@@ -1,0 +1,159 @@
+//! Flags `env.deployer().deploy()` return values that are used without `env.is_contract()` verification.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashSet;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Pat, Stmt};
+
+const CHECK_NAME: &str = "deploy-unverified";
+
+pub struct DeployUnverifiedCheck;
+
+impl Check for DeployUnverifiedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = DeployUnverifiedVisitor {
+                fn_name,
+                deploy_vars: Vec::new(),
+                verified: HashSet::new(),
+                out: &mut out,
+            };
+            visitor.visit_block(&method.block);
+            for (var_name, line) in visitor.deploy_vars {
+                if !visitor.verified.contains(&var_name) {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line,
+                        function_name: visitor.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` deploys a sub-contract and uses the returned address "
+                            "without verifying that it exists via `env.is_contract(...)`.",
+                            visitor.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+fn is_deploy_call(m: &ExprMethodCall) -> bool {
+    if m.method != "deploy" {
+        return false;
+    }
+    matches!(&*m.receiver, Expr::MethodCall(inner) if inner.method == "deployer")
+}
+
+fn is_is_contract_call(m: &ExprMethodCall) -> bool {
+    if m.method != "is_contract" {
+        return false;
+    }
+    matches!(&*m.receiver, Expr::Path(p) if p.path.is_ident("env"))
+}
+
+fn expr_ident_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident().map(|id| id.to_string()),
+        Expr::Reference(r) => expr_ident_name(&r.expr),
+        Expr::Paren(p) => expr_ident_name(&p.expr),
+        _ => None,
+    }
+}
+
+struct DeployUnverifiedVisitor<'a> {
+    fn_name: String,
+    deploy_vars: Vec<(String, usize)>,
+    verified: HashSet<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for DeployUnverifiedVisitor<'_> {
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        if let Stmt::Local(local) = i {
+            if let Some((_, init_expr)) = &local.init {
+                if let Expr::MethodCall(m) = &*init_expr.expr {
+                    if is_deploy_call(m) {
+                        if let Pat::Ident(pi) = &local.pat {
+                            self.deploy_vars.push((pi.ident.to_string(), m.span().start().line));
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_stmt(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_is_contract_call(i) {
+            if let Some(arg) = i.args.first() {
+                if let Some(name) = expr_ident_name(arg) {
+                    self.verified.insert(name);
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        DeployUnverifiedCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_deploy_without_is_contract() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Bytes, Env, Symbol};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let addr = env.deployer().deploy(wasm_hash, ());
+        env.storage().persistent().set(&Symbol::new(&env, "addr"), &addr);
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_when_is_contract_called() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Bytes, Env, Symbol};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let addr = env.deployer().deploy(wasm_hash, ());
+        if env.is_contract(&addr) {
+            env.storage().persistent().set(&Symbol::new(&env, "addr"), &addr);
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/invoke_func_from_input.rs
+++ b/crates/checks/src/invoke_func_from_input.rs
@@ -1,0 +1,230 @@
+//! Detects `invoke_contract` calls where the function name symbol is derived from user input.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashSet;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMacro, ExprMethodCall, File, FnArg, Pat, PatType, Stmt};
+
+const CHECK_NAME: &str = "invoke-func-from-input";
+
+pub struct InvokeFuncFromInputCheck;
+
+impl Check for InvokeFuncFromInputCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let params = parameter_names(&method.sig.inputs);
+            if params.is_empty() {
+                continue;
+            }
+            let mut v = InvokeFuncFromInputVisitor {
+                fn_name: method.sig.ident.to_string(),
+                params: &params,
+                symbol_vars: Vec::new(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn parameter_names(inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>) -> HashSet<String> {
+    inputs
+        .iter()
+        .filter_map(|arg| {
+            if let FnArg::Typed(PatType { pat, .. }) = arg {
+                if let Pat::Ident(pi) = pat.as_ref() {
+                    let name = pi.ident.to_string();
+                    if name != "env" {
+                        return Some(name);
+                    }
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn expr_uses_param(expr: &Expr, params: &HashSet<String>) -> bool {
+    match expr {
+        Expr::Path(p) => p.path.get_ident().map_or(false, |id| params.contains(&id.to_string())),
+        Expr::Reference(r) => expr_uses_param(&r.expr, params),
+        Expr::Paren(p) => expr_uses_param(&p.expr, params),
+        Expr::MethodCall(m) => expr_uses_param(&m.receiver, params)
+            || m.args.iter().any(|arg| expr_uses_param(arg, params)),
+        Expr::Call(c) => expr_uses_param(&c.func, params)
+            || c.args.iter().any(|arg| expr_uses_param(arg, params)),
+        Expr::Field(f) => expr_uses_param(&f.base, params),
+        Expr::Macro(m) => macro_contains_param(m, params),
+        Expr::Tuple(t) => t.elems.iter().any(|e| expr_uses_param(e, params)),
+        Expr::Array(a) => a.elems.iter().any(|e| expr_uses_param(e, params)),
+        Expr::Binary(b) => {
+            expr_uses_param(&b.left, params) || expr_uses_param(&b.right, params)
+        }
+        Expr::Unary(u) => expr_uses_param(&u.expr, params),
+        Expr::Cast(c) => expr_uses_param(&c.expr, params),
+        Expr::AddrOf(a) => expr_uses_param(&a.expr, params),
+        Expr::Try(t) => expr_uses_param(&t.expr, params),
+        Expr::Match(m) => expr_uses_param(&m.expr, params),
+        _ => false,
+    }
+}
+
+fn macro_contains_param(mac: &ExprMacro, params: &HashSet<String>) -> bool {
+    let tokens = mac.mac.tokens.to_string();
+    params.iter().any(|param| tokens.contains(param))
+}
+
+fn is_symbol_short_with_param(expr: &Expr, params: &HashSet<String>) -> bool {
+    match expr {
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "symbol_short")
+            && macro_contains_param(m, params),
+        Expr::Reference(r) => is_symbol_short_with_param(&r.expr, params),
+        Expr::Paren(p) => is_symbol_short_with_param(&p.expr, params),
+        _ => false,
+    }
+}
+
+fn is_symbol_from_str_with_param(expr: &Expr, params: &HashSet<String>) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    let Expr::Path(func) = &*call.func else {
+        return false;
+    };
+    if func.path.segments.last().is_some_and(|s| s.ident == "from_str") {
+        if let Some(arg) = call.args.iter().nth(1) {
+            return expr_uses_param(arg, params);
+        }
+    }
+    false
+}
+
+fn is_user_input_symbol(expr: &Expr, params: &HashSet<String>) -> bool {
+    is_symbol_short_with_param(expr, params) || is_symbol_from_str_with_param(expr, params)
+}
+
+fn expr_ident_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident().map(|id| id.to_string()),
+        Expr::Reference(r) => expr_ident_name(&r.expr),
+        Expr::Paren(p) => expr_ident_name(&p.expr),
+        _ => None,
+    }
+}
+
+fn is_invoke_contract_call(m: &ExprMethodCall) -> bool {
+    if m.method != "invoke_contract" {
+        return false;
+    }
+    matches!(&*m.receiver, Expr::Path(p) if p.path.is_ident("env"))
+}
+
+struct InvokeFuncFromInputVisitor<'a> {
+    fn_name: String,
+    params: &'a HashSet<String>,
+    symbol_vars: Vec<String>,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for InvokeFuncFromInputVisitor<'_> {
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        if let Stmt::Local(local) = i {
+            if let Some((_, init_expr)) = &local.init {
+                if is_user_input_symbol(&init_expr.expr, self.params) {
+                    if let Pat::Ident(pi) = &local.pat {
+                        self.symbol_vars.push(pi.ident.to_string());
+                    }
+                }
+            }
+        }
+        visit::visit_stmt(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_invoke_contract_call(i) {
+            if let Some(sym_arg) = i.args.iter().nth(1) {
+                let uses_param = is_user_input_symbol(sym_arg, self.params);
+                let uses_tracked_var = expr_ident_name(sym_arg)
+                    .map_or(false, |name| self.symbol_vars.contains(&name));
+                if uses_param || uses_tracked_var {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` invokes a contract with a function name Symbol derived from user input. This allows callers to invoke arbitrary functions on the target contract.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        InvokeFuncFromInputCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_user_input_symbol_for_invoke_contract() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn call(env: Env, contract: Address, user_func: String) {
+        let func_name = Symbol::from_str(&env, &user_func);
+        env.invoke_contract(&contract, &func_name, &());
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn passes_when_function_name_is_constant() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn call(env: Env, contract: Address) {
+        let func_name = Symbol::short("get");
+        env.invoke_contract(&contract, &func_name, &());
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/invoke_result_untrusted.rs
+++ b/crates/checks/src/invoke_result_untrusted.rs
@@ -1,0 +1,219 @@
+//! Detects untrusted casts or conversions of `env.invoke_contract()` return values.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprIf, ExprMatch, ExprMethodCall, File, Stmt};
+
+const CHECK_NAME: &str = "invoke-result-untrusted";
+
+pub struct InvokeResultUntrustedCheck;
+
+impl Check for InvokeResultUntrustedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = InvokeResultUntrustedVisitor {
+                fn_name,
+                invoke_bindings: Vec::new(),
+                out: &mut out,
+                safe_context: false,
+            };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn is_invoke_contract_call(m: &ExprMethodCall) -> bool {
+    m.method == "invoke_contract"
+        && matches!(&*m.receiver, Expr::Path(p) if p.path.is_ident("env"))
+}
+
+fn is_cast_method(m: &ExprMethodCall) -> bool {
+    matches!(
+        m.method.to_string().as_str(),
+        "try_into_val" | "from_val" | "try_from_val"
+    )
+}
+
+fn expr_contains_invoke_contract(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if is_invoke_contract_call(m) {
+                return true;
+            }
+            expr_contains_invoke_contract(&m.receiver)
+                || m.args.iter().any(expr_contains_invoke_contract)
+        }
+        Expr::Reference(r) => expr_contains_invoke_contract(&r.expr),
+        Expr::Paren(p) => expr_contains_invoke_contract(&p.expr),
+        _ => false,
+    }
+}
+
+fn expr_ident_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(path) => path.path.get_ident().map(|id| id.to_string()),
+        Expr::Reference(r) => expr_ident_name(&r.expr),
+        Expr::Paren(p) => expr_ident_name(&p.expr),
+        _ => None,
+    }
+}
+
+struct InvokeResultUntrustedVisitor<'a> {
+    fn_name: String,
+    invoke_bindings: Vec<String>,
+    out: &'a mut Vec<Finding>,
+    safe_context: bool,
+}
+
+impl<'ast> Visit<'ast> for InvokeResultUntrustedVisitor<'_> {
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        if let Stmt::Local(local) = i {
+            if let Some((_, init_expr)) = &local.init {
+                let mut expr = &init_expr.expr;
+                if let Expr::MethodCall(cast_call) = expr {
+                    if is_cast_method(cast_call)
+                        && expr_contains_invoke_contract(&cast_call.receiver)
+                    {
+                        if let syn::Pat::Ident(pi) = &local.pat {
+                            self.invoke_bindings.push(pi.ident.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_stmt(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_cast_method(i) && !self.safe_context {
+            let receiver_contains_invoke = expr_contains_invoke_contract(&i.receiver);
+            let receiver_is_invoke_binding = expr_ident_name(&i.receiver)
+                .map_or(false, |name| self.invoke_bindings.contains(&name));
+            if receiver_contains_invoke || receiver_is_invoke_binding {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Method `{}` converts the result of `invoke_contract` with `{}` without validating the returned schema. Validate the result before converting or use a `match`/`if let` guard.",
+                        self.fn_name,
+                        i.method
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_match(&mut self, i: &'ast ExprMatch) {
+        let prev = self.safe_context;
+        self.safe_context = true;
+        self.visit_expr(&i.expr);
+        self.safe_context = prev;
+        for arm in &i.arms {
+            self.visit_pat(&arm.pat);
+            if let Some((_, guard)) = &arm.guard {
+                self.visit_expr(guard);
+            }
+            self.visit_block(&arm.body);
+        }
+    }
+
+    fn visit_expr_if(&mut self, i: &'ast ExprIf) {
+        if let Expr::Let(expr_let) = &*i.cond {
+            let prev = self.safe_context;
+            self.safe_context = true;
+            self.visit_expr(&expr_let.expr);
+            self.safe_context = prev;
+            self.visit_pat(&expr_let.pat);
+            self.visit_block(&i.then_branch);
+            if let Some((_, else_branch)) = &i.else_branch {
+                self.visit_expr(else_branch);
+            }
+        } else {
+            visit::visit_expr_if(self, i);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        InvokeResultUntrustedCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_inline_try_into_val() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn call(env: Env, contract: Address) -> i128 {
+        env.invoke_contract::<Val>(&contract, &Symbol::short("get"), &())
+            .try_into_val(&env)
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_bound_try_into_val() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn call(env: Env, contract: Address) -> i128 {
+        let result = env.invoke_contract::<Val>(&contract, &Symbol::short("get"), &());
+        result.try_into_val(&env)
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn passes_when_match_used() {
+        let hits = run(r#"
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn call(env: Env, contract: Address) -> Option<i128> {
+        let result: Val = env.invoke_contract(&contract, &Symbol::short("get"), &());
+        match result.try_into_val(&env) {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -29,6 +29,10 @@ pub mod instance_vec_growth;
 pub mod linear_whitelist_scan;
 pub mod lock_period_truncation;
 pub mod invoke_unchecked_cast;
+pub mod invoke_func_from_input;
+pub mod invoke_result_untrusted;
+pub mod deploy_salt_predictable;
+pub mod deploy_unverified;
 pub mod map_key_explosion;
 pub mod map_user_key_bloat;
 pub mod migration_guard;
@@ -104,6 +108,10 @@ pub use instance_remove_critical::InstanceRemoveCriticalCheck;
 pub use instance_ttl::InstanceTtlCheck;
 pub use instance_vec_growth::InstanceVecGrowthCheck;
 pub use invoke_unchecked_cast::InvokeUncheckedCastCheck;
+pub use invoke_func_from_input::InvokeFuncFromInputCheck;
+pub use invoke_result_untrusted::InvokeResultUntrustedCheck;
+pub use deploy_salt_predictable::DeploySaltPredictableCheck;
+pub use deploy_unverified::DeployUnverifiedCheck;
 pub use linear_whitelist_scan::LinearWhitelistScanCheck;
 pub use lock_period_truncation::LockPeriodTruncationCheck;
 pub use map_key_explosion::MapKeyExplosionCheck;
@@ -228,6 +236,10 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(HashAsStorageKeyCheck),
         Box::new(UnauthAddressInStructCheck),
         Box::new(InvokeUncheckedCastCheck),
+        Box::new(InvokeFuncFromInputCheck),
+        Box::new(InvokeResultUntrustedCheck),
+        Box::new(DeploySaltPredictableCheck),
+        Box::new(DeployUnverifiedCheck),
         Box::new(NegativeDepositCheck),
         Box::new(NoParamNoAuthCheck),
         Box::new(StorageTypeConfusionCheck),

--- a/test-contracts/deploy-salt-predictable-safe/Cargo.toml
+++ b/test-contracts/deploy-salt-predictable-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-salt-predictable-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-salt-predictable-safe/src/lib.rs
+++ b/test-contracts/deploy-salt-predictable-safe/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct SafeDeploySaltPredictable;
+
+#[contractimpl]
+impl SafeDeploySaltPredictable {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        env.deployer().deploy(wasm_hash, ());
+    }
+}

--- a/test-contracts/deploy-salt-predictable-vulnerable/Cargo.toml
+++ b/test-contracts/deploy-salt-predictable-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-salt-predictable-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-salt-predictable-vulnerable/src/lib.rs
+++ b/test-contracts/deploy-salt-predictable-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct VulnerableDeploySaltPredictable;
+
+#[contractimpl]
+impl VulnerableDeploySaltPredictable {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let salt = env.ledger().sequence();
+        env.deployer().deploy(wasm_hash, salt);
+    }
+}

--- a/test-contracts/deploy-unverified-safe/Cargo.toml
+++ b/test-contracts/deploy-unverified-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-unverified-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-unverified-safe/src/lib.rs
+++ b/test-contracts/deploy-unverified-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env, Symbol};
+
+#[contract]
+pub struct SafeDeployUnverified;
+
+#[contractimpl]
+impl SafeDeployUnverified {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let addr = env.deployer().deploy(wasm_hash, ());
+        if env.is_contract(&addr) {
+            env.storage().persistent().set(&Symbol::new(&env, "addr"), &addr);
+        }
+    }
+}

--- a/test-contracts/deploy-unverified-vulnerable/Cargo.toml
+++ b/test-contracts/deploy-unverified-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-deploy-unverified-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/deploy-unverified-vulnerable/src/lib.rs
+++ b/test-contracts/deploy-unverified-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env, Symbol};
+
+#[contract]
+pub struct VulnerableDeployUnverified;
+
+#[contractimpl]
+impl VulnerableDeployUnverified {
+    pub fn deploy(env: Env, wasm_hash: Bytes) {
+        let addr = env.deployer().deploy(wasm_hash, ());
+        env.storage().persistent().set(&Symbol::new(&env, "addr"), &addr);
+    }
+}

--- a/test-contracts/invoke-func-from-input-safe/Cargo.toml
+++ b/test-contracts/invoke-func-from-input-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-func-from-input-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-func-from-input-safe/src/lib.rs
+++ b/test-contracts/invoke-func-from-input-safe/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct SafeInvokeFuncFromInput;
+
+#[contractimpl]
+impl SafeInvokeFuncFromInput {
+    pub fn call(env: Env, contract: Address) {
+        let func_name = Symbol::short("get");
+        env.invoke_contract(&contract, &func_name, &());
+    }
+}

--- a/test-contracts/invoke-func-from-input-vulnerable/Cargo.toml
+++ b/test-contracts/invoke-func-from-input-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-func-from-input-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-func-from-input-vulnerable/src/lib.rs
+++ b/test-contracts/invoke-func-from-input-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct VulnerableInvokeFuncFromInput;
+
+#[contractimpl]
+impl VulnerableInvokeFuncFromInput {
+    pub fn call(env: Env, contract: Address, user_func: String) {
+        let func_name = Symbol::from_str(&env, &user_func);
+        env.invoke_contract(&contract, &func_name, &());
+    }
+}

--- a/test-contracts/invoke-result-untrusted-safe/Cargo.toml
+++ b/test-contracts/invoke-result-untrusted-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-result-untrusted-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-result-untrusted-safe/src/lib.rs
+++ b/test-contracts/invoke-result-untrusted-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val};
+
+#[contract]
+pub struct SafeInvokeResultUntrusted;
+
+#[contractimpl]
+impl SafeInvokeResultUntrusted {
+    pub fn call(env: Env, contract: Address) -> Option<i128> {
+        let result: Val = env.invoke_contract(&contract, &Symbol::short("get"), &());
+        match result.try_into_val(&env) {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+}

--- a/test-contracts/invoke-result-untrusted-vulnerable/Cargo.toml
+++ b/test-contracts/invoke-result-untrusted-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-invoke-result-untrusted-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/invoke-result-untrusted-vulnerable/src/lib.rs
+++ b/test-contracts/invoke-result-untrusted-vulnerable/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val};
+
+#[contract]
+pub struct VulnerableInvokeResultUntrusted;
+
+#[contractimpl]
+impl VulnerableInvokeResultUntrusted {
+    pub fn call(env: Env, contract: Address) -> i128 {
+        env.invoke_contract::<Val>(&contract, &Symbol::short("get"), &())
+            .try_into_val(&env)
+    }
+}


### PR DESCRIPTION
…th fixtures
closes #225 
closes #226 
closes #227
closes #228 

New Security Checks
invoke-func-from-input: Flags arbitrary contract method invocations where the function name originates from user-controlled input.

invoke-result-untrusted: Flags untrusted casting of contract return values (via try_into_val, from_val, or try_from_val) without prior schema validation.

deploy-salt-predictable: Flags deployments using predictable salts derived from ledger sequence or timestamp to prevent front-running.

deploy-unverified: Flags the immediate use of deployed addresses without an explicit env.is_contract(...) success verification.