### PR TITLE
feat(escrow): add cancel_funding and investor refund path

### DIFF
--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -1,0 +1,150 @@
+# Escrow Lifecycle
+
+This document describes the complete state machine for the LiquiFact escrow contract, including the `Cancelled` state and investor refund path added in [#242](https://github.com/Liquifact/Liquifact-contracts/issues/242).
+
+---
+
+## Status codes
+
+| Code | Name        | Description                                                  |
+|------|-------------|--------------------------------------------------------------|
+| `0`  | Funding     | Accepting investor contributions; target not yet reached.    |
+| `1`  | Active      | Funding target met; escrow obligations are live.             |
+| `2`  | Completed   | All escrow obligations fulfilled.                            |
+| `3`  | Legal Hold  | Frozen by a compliance action; most transitions blocked.     |
+| `4`  | Cancelled   | Funding failed; investors may claim refunds.                 |
+
+---
+
+## State machine
+
+```
+                    ┌─────────────────────────────────────────────────┐
+                    │                                                 │
+  initialize()      ▼                                                 │
+  ──────────►  0 (Funding) ──── admin cancel_funding() ──────► 4 (Cancelled)
+                    │                                                 │
+                    │  (target reached, off-chain trigger)            │  investor refund()
+                    ▼                                                 ▼
+               1 (Active)                                  InvestorContribution → 0
+                    │
+                    │  (obligations fulfilled)
+                    ▼
+               2 (Completed)
+```
+
+Legal hold (`status = 3`) can be set from any non-terminal state by a compliance action and blocks `cancel_funding`.
+
+---
+
+## Entrypoints
+
+### `initialize(admin, funding_token, funding_target)`
+
+Sets up the escrow. Can only be called once. Sets status to `0`.
+
+- `admin` — address authorised to call `cancel_funding`.
+- `funding_token` — SEP-41 token contract address used for contributions and refunds.
+- `funding_target` — minimum total contribution (in stroops) to transition to Active.
+
+### `contribute(investor, amount)`
+
+Records an investor contribution during the Funding phase.
+
+- Requires `investor` authorisation.
+- Transfers `amount` from `investor` to the contract.
+- Accumulates `DataKey::InvestorContribution(investor)` and `DataKey::FundedAmount`.
+- Panics if status ≠ `0` or `amount ≤ 0`.
+
+### `cancel_funding()`
+
+Transitions status from `0` (Funding) to `4` (Cancelled).
+
+- Requires `admin` authorisation.
+- Panics if status ≠ `0` or legal hold is active.
+- Emits `FundingCancelled { admin, funded_amount }`.
+
+### `refund(investor)`
+
+Returns an investor's contribution after cancellation.
+
+- Requires `investor` authorisation.
+- Panics if status ≠ `4` or `InvestorContribution(investor) == 0`.
+- Zeroes `InvestorContribution(investor)` **before** the token transfer (prevents double-spend).
+- Transfers exactly the recorded contribution via `external_calls::transfer_funding_token_with_balance_checks`.
+- Emits `Refunded { investor, amount }`.
+
+---
+
+## Events
+
+### `FundingCancelled`
+
+Emitted by `cancel_funding`.
+
+| Field           | Type      | Description                              |
+|-----------------|-----------|------------------------------------------|
+| `admin`         | `Address` | Admin that triggered the cancellation.   |
+| `funded_amount` | `i128`    | Total contributions at time of cancel.   |
+
+### `Refunded`
+
+Emitted by `refund`.
+
+| Field      | Type      | Description                              |
+|------------|-----------|------------------------------------------|
+| `investor` | `Address` | Investor who received the refund.        |
+| `amount`   | `i128`    | Amount returned (in stroops).            |
+
+---
+
+## Storage layout
+
+| Key                              | Tier       | Type      | Description                          |
+|----------------------------------|------------|-----------|--------------------------------------|
+| `DataKey::Admin`                 | Instance   | `Address` | Contract administrator.              |
+| `DataKey::FundingToken`          | Instance   | `Address` | SEP-41 token address.                |
+| `DataKey::FundingTarget`         | Instance   | `i128`    | Minimum funding goal.                |
+| `DataKey::FundedAmount`          | Instance   | `i128`    | Running total of contributions.      |
+| `DataKey::Status`                | Instance   | `u32`     | Current lifecycle status code.       |
+| `DataKey::LegalHold`             | Instance   | `bool`    | Compliance freeze flag.              |
+| `DataKey::InvestorContribution(addr)` | Persistent | `i128` | Per-investor contribution amount. |
+
+Instance storage is extended on `initialize` and should be bumped by callers on active use. Persistent `InvestorContribution` entries are extended on each `contribute` call.
+
+---
+
+## Security invariants
+
+| Invariant | Enforcement |
+|-----------|-------------|
+| Only admin can cancel | `admin.require_auth()` at top of `cancel_funding` |
+| Only investor can refund | `investor.require_auth()` at top of `refund` |
+| No double-refund | Contribution zeroed before transfer; second call panics on `amount == 0` check |
+| No refund outside Cancelled state | Status assertion at top of `refund` |
+| No cancel outside Funding state | Status assertion at top of `cancel_funding` |
+| Legal hold blocks cancel | `legal_hold` assertion in `cancel_funding` |
+| Balance-delta check on every transfer | `transfer_funding_token_with_balance_checks` asserts `balance_after - balance_before == amount` |
+| Overflow-safe arithmetic | `checked_add` / `checked_sub` throughout; `overflow-checks = true` in release profile |
+| Total refunded ≤ funded_amount | Each refund ≤ individual contribution; sum of contributions == `funded_amount` |
+
+---
+
+## Example flow
+
+```
+# Funding phase
+initialize(admin, USDC, 1_000_000)
+contribute(alice, 600_000)   # alice's contribution recorded
+contribute(bob,   400_000)   # funded_amount == 1_000_000
+
+# Admin decides to cancel (target not reached in time, or other reason)
+cancel_funding()             # status → 4, FundingCancelled emitted
+
+# Investors reclaim principal
+refund(alice)                # 600_000 USDC returned, Refunded emitted
+refund(bob)                  # 400_000 USDC returned, Refunded emitted
+
+# Second refund attempt is rejected
+refund(alice)                # panics: "no contribution to refund"
+```

--- a/escrow/Cargo.toml
+++ b/escrow/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "liquifact-escrow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/escrow/src/external_calls.rs
+++ b/escrow/src/external_calls.rs
@@ -1,0 +1,49 @@
+//! External contract call helpers.
+//!
+//! All token transfers go through this module so that balance-delta checks are
+//! applied consistently and cannot be bypassed by callers.
+
+use soroban_sdk::{token, Address, Env};
+
+/// Transfer `amount` of `token` from `from` to `to`, asserting that the
+/// recipient's balance increases by exactly `amount` (balance-delta check).
+///
+/// # Panics
+/// - If `amount` is not positive.
+/// - If the recipient's post-transfer balance does not equal `pre + amount`
+///   (guards against fee-on-transfer tokens or re-entrancy that drains the
+///   contract mid-call).
+///
+/// # Security notes
+/// - The balance snapshot is taken **before** the transfer call.
+/// - The assertion is evaluated **after** the transfer returns.
+/// - Because Soroban's execution model is single-threaded and re-entrant calls
+///   within the same transaction are serialised, this check is sufficient to
+///   detect unexpected balance changes caused by malicious token contracts.
+pub fn transfer_funding_token_with_balance_checks(
+    env: &Env,
+    token: &Address,
+    from: &Address,
+    to: &Address,
+    amount: i128,
+) {
+    assert!(amount > 0, "transfer amount must be positive");
+
+    let client = token::Client::new(env, token);
+
+    let balance_before: i128 = client.balance(to);
+
+    client.transfer(from, to, &amount);
+
+    let balance_after: i128 = client.balance(to);
+
+    // Checked arithmetic: balance_after - balance_before must equal amount.
+    let delta = balance_after
+        .checked_sub(balance_before)
+        .expect("balance underflow after transfer");
+
+    assert_eq!(
+        delta, amount,
+        "balance delta mismatch: expected {amount}, got {delta}"
+    );
+}

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1,0 +1,322 @@
+//! LiquiFact Escrow Contract
+//!
+//! # State machine
+//!
+//! ```text
+//! 0 (Funding) ──admin cancel_funding──► 4 (Cancelled)
+//!      │                                      │
+//!      │ (target reached)              investor refund
+//!      ▼                                      ▼
+//!   1 (Active)                         contribution → 0
+//! ```
+//!
+//! Status codes:
+//! - `0` — Funding: accepting contributions, target not yet reached
+//! - `1` — Active: funding target met, escrow is live
+//! - `2` — Completed: escrow obligations fulfilled
+//! - `3` — Legal hold: frozen by compliance action
+//! - `4` — Cancelled: funding failed; investors may claim refunds
+
+#![no_std]
+
+use soroban_sdk::{contract, contractevent, contractimpl, contracttype, token, Address, Env};
+
+mod external_calls;
+
+#[cfg(test)]
+mod tests {
+    mod funding;
+}
+
+// ── Status constants ──────────────────────────────────────────────────────────
+
+const STATUS_FUNDING: u32 = 0;
+const STATUS_CANCELLED: u32 = 4;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+/// Persistent storage keys for the escrow contract.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Address of the contract administrator.
+    Admin,
+    /// Address of the SEP-41 funding token.
+    FundingToken,
+    /// Funding target (in token stroops).
+    FundingTarget,
+    /// Total amount funded so far.
+    FundedAmount,
+    /// Current lifecycle status (u32).
+    Status,
+    /// Legal hold flag (bool).
+    LegalHold,
+    /// Per-investor contribution amount.
+    InvestorContribution(Address),
+}
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+/// Emitted when an admin cancels a funding-phase escrow.
+#[contractevent]
+pub struct FundingCancelled {
+    pub admin: Address,
+    pub funded_amount: i128,
+}
+
+/// Emitted when an investor successfully claims a refund.
+#[contractevent]
+pub struct Refunded {
+    pub investor: Address,
+    pub amount: i128,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct EscrowContract;
+
+#[contractimpl]
+impl EscrowContract {
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /// Initialise the escrow.
+    ///
+    /// Must be called once by the deployer. Sets status to `0` (Funding).
+    ///
+    /// # Arguments
+    /// * `admin`          – Address that may call `cancel_funding`.
+    /// * `funding_token`  – SEP-41 token contract address.
+    /// * `funding_target` – Minimum amount (in stroops) to reach Active status.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        funding_token: Address,
+        funding_target: i128,
+    ) {
+        // Prevent re-initialisation.
+        if env.storage().instance().has(&DataKey::Status) {
+            panic!("already initialised");
+        }
+        assert!(funding_target > 0, "funding_target must be positive");
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingToken, &funding_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingTarget, &funding_target);
+        env.storage()
+            .instance()
+            .set(&DataKey::FundedAmount, &0_i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::Status, &STATUS_FUNDING);
+        env.storage()
+            .instance()
+            .set(&DataKey::LegalHold, &false);
+
+        env.storage()
+            .instance()
+            .extend_ttl(17_280, 17_280 * 30);
+    }
+
+    // ── Admin: cancel funding ─────────────────────────────────────────────────
+
+    /// Transition the escrow from `Funding` (0) to `Cancelled` (4).
+    ///
+    /// # Access control
+    /// Requires `admin` authorisation.
+    ///
+    /// # Preconditions
+    /// - Status must be `0` (Funding).
+    /// - Legal hold must not be active.
+    ///
+    /// # Effects
+    /// - Sets status to `4` (Cancelled).
+    /// - Emits [`FundingCancelled`].
+    pub fn cancel_funding(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialised");
+        admin.require_auth();
+
+        let legal_hold: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::LegalHold)
+            .unwrap_or(false);
+        assert!(!legal_hold, "escrow is under legal hold");
+
+        let status: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Status)
+            .expect("not initialised");
+        assert_eq!(status, STATUS_FUNDING, "can only cancel during Funding phase");
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Status, &STATUS_CANCELLED);
+
+        let funded_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FundedAmount)
+            .unwrap_or(0);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("cancelled"),),
+            FundingCancelled {
+                admin,
+                funded_amount,
+            },
+        );
+    }
+
+    // ── Investor: refund ──────────────────────────────────────────────────────
+
+    /// Return an investor's contribution after a cancellation.
+    ///
+    /// # Access control
+    /// Requires `investor` authorisation.
+    ///
+    /// # Preconditions
+    /// - Status must be `4` (Cancelled).
+    /// - `investor` must have a non-zero recorded contribution.
+    ///
+    /// # Effects
+    /// - Zeroes `InvestorContribution(investor)` (prevents double-refund).
+    /// - Transfers exactly the recorded contribution back to `investor` via
+    ///   [`external_calls::transfer_funding_token_with_balance_checks`].
+    /// - Emits [`Refunded`].
+    pub fn refund(env: Env, investor: Address) {
+        investor.require_auth();
+
+        let status: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Status)
+            .expect("not initialised");
+        assert_eq!(status, STATUS_CANCELLED, "refunds only available after cancellation");
+
+        let contribution_key = DataKey::InvestorContribution(investor.clone());
+        let amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&contribution_key)
+            .unwrap_or(0);
+        assert!(amount > 0, "no contribution to refund");
+
+        // Zero out before transfer — prevents re-entrancy / double-spend.
+        env.storage()
+            .persistent()
+            .set(&contribution_key, &0_i128);
+
+        let funding_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::FundingToken)
+            .expect("not initialised");
+
+        external_calls::transfer_funding_token_with_balance_checks(
+            &env,
+            &funding_token,
+            &env.current_contract_address(),
+            &investor,
+            amount,
+        );
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("refunded"),),
+            Refunded {
+                investor,
+                amount,
+            },
+        );
+    }
+
+    // ── Investor: contribute ──────────────────────────────────────────────────
+
+    /// Record an investor contribution during the Funding phase.
+    ///
+    /// Transfers `amount` from `investor` to this contract and records it.
+    ///
+    /// # Preconditions
+    /// - Status must be `0` (Funding).
+    /// - `amount` must be positive.
+    pub fn contribute(env: Env, investor: Address, amount: i128) {
+        investor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let status: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Status)
+            .expect("not initialised");
+        assert_eq!(status, STATUS_FUNDING, "contributions only accepted during Funding phase");
+
+        let funding_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::FundingToken)
+            .expect("not initialised");
+
+        let token_client = token::Client::new(&env, &funding_token);
+        token_client.transfer(&investor, &env.current_contract_address(), &amount);
+
+        let contribution_key = DataKey::InvestorContribution(investor.clone());
+        let prev: i128 = env
+            .storage()
+            .persistent()
+            .get(&contribution_key)
+            .unwrap_or(0);
+        let new_contribution = prev.checked_add(amount).expect("contribution overflow");
+        env.storage()
+            .persistent()
+            .set(&contribution_key, &new_contribution);
+
+        let prev_funded: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FundedAmount)
+            .unwrap_or(0);
+        let new_funded = prev_funded.checked_add(amount).expect("funded_amount overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::FundedAmount, &new_funded);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&contribution_key, 17_280, 17_280 * 30);
+    }
+
+    // ── View helpers ──────────────────────────────────────────────────────────
+
+    /// Returns the current lifecycle status code.
+    pub fn status(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Status)
+            .unwrap_or(STATUS_FUNDING)
+    }
+
+    /// Returns the recorded contribution for `investor`, or `0`.
+    pub fn contribution(env: Env, investor: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorContribution(investor))
+            .unwrap_or(0)
+    }
+
+    /// Returns the total funded amount.
+    pub fn funded_amount(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::FundedAmount)
+            .unwrap_or(0)
+    }
+}

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -1,0 +1,355 @@
+//! Tests for `cancel_funding` and `refund` entrypoints.
+//!
+//! Coverage:
+//! - Happy-path cancel + single refund
+//! - Happy-path cancel + multiple investors refund independently
+//! - Double-refund is a no-op (panics on second call)
+//! - Refund in wrong state (Funding, Active) panics
+//! - cancel_funding in wrong state (Active) panics
+//! - cancel_funding under legal hold panics
+//! - Unauthorised cancel_funding panics
+//! - Unauthorised refund panics
+//! - Zero-contribution refund panics
+//! - Contribution overflow guard
+//! - Contribute in wrong state (Cancelled) panics
+//! - funded_amount invariant: total refunded ≤ funded_amount
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
+    token, Address, Env, IntoVal,
+};
+
+use crate::{DataKey, EscrowContract, EscrowContractClient};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+struct TestEnv {
+    env: Env,
+    contract: Address,
+    client: EscrowContractClient<'static>,
+    token: Address,
+    admin: Address,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+
+        // Deploy a standard SEP-41 token for testing.
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+        let contract = env.register(EscrowContract, ());
+        // SAFETY: the client lifetime is tied to `env` which lives in the struct.
+        let client = EscrowContractClient::new(&env, &contract);
+
+        client.initialize(&admin, &token, &1_000_000_i128);
+
+        TestEnv {
+            env,
+            contract,
+            client,
+            token,
+            admin,
+        }
+    }
+
+    /// Mint `amount` tokens to `addr`.
+    fn mint(&self, addr: &Address, amount: i128) {
+        let token_client = token::StellarAssetClient::new(&self.env, &self.token);
+        token_client.mint(addr, &amount);
+    }
+
+    /// Contribute `amount` from `investor`.
+    fn contribute(&self, investor: &Address, amount: i128) {
+        self.mint(investor, amount);
+        self.client.contribute(investor, &amount);
+    }
+}
+
+// ── cancel_funding ────────────────────────────────────────────────────────────
+
+#[test]
+fn cancel_funding_transitions_status_to_4() {
+    let t = TestEnv::new();
+    assert_eq!(t.client.status(), 0);
+    t.client.cancel_funding();
+    assert_eq!(t.client.status(), 4);
+}
+
+#[test]
+fn cancel_funding_emits_event() {
+    let t = TestEnv::new();
+    t.contribute(&Address::generate(&t.env), 500_000);
+    t.client.cancel_funding();
+
+    let events = t.env.events().all();
+    let has_cancelled = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|v| v == soroban_sdk::symbol_short!("cancelled").into_val(&t.env))
+    });
+    assert!(has_cancelled, "FundingCancelled event not emitted");
+}
+
+#[test]
+#[should_panic(expected = "can only cancel during Funding phase")]
+fn cancel_funding_fails_when_not_in_funding_state() {
+    let t = TestEnv::new();
+    // Manually set status to Active (1).
+    t.env
+        .as_contract(&t.contract, || {
+            t.env
+                .storage()
+                .instance()
+                .set(&DataKey::Status, &1_u32);
+        });
+    t.client.cancel_funding();
+}
+
+#[test]
+#[should_panic(expected = "can only cancel during Funding phase")]
+fn cancel_funding_is_idempotent_guard() {
+    let t = TestEnv::new();
+    t.client.cancel_funding();
+    // Second call must panic — already in state 4.
+    t.client.cancel_funding();
+}
+
+#[test]
+#[should_panic(expected = "escrow is under legal hold")]
+fn cancel_funding_blocked_under_legal_hold() {
+    let t = TestEnv::new();
+    t.env.as_contract(&t.contract, || {
+        t.env
+            .storage()
+            .instance()
+            .set(&DataKey::LegalHold, &true);
+    });
+    t.client.cancel_funding();
+}
+
+#[test]
+#[should_panic]
+fn cancel_funding_requires_admin_auth() {
+    let env = Env::default();
+    // Do NOT mock auths — auth will fail.
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let contract = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract);
+    client.initialize(&admin, &token, &1_000_000_i128);
+    client.cancel_funding(); // should panic: missing auth
+}
+
+// ── refund ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn refund_returns_exact_contribution() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 300_000);
+
+    t.client.cancel_funding();
+
+    let token_client = token::Client::new(&t.env, &t.token);
+    let before = token_client.balance(&investor);
+    t.client.refund(&investor);
+    let after = token_client.balance(&investor);
+
+    assert_eq!(after - before, 300_000);
+}
+
+#[test]
+fn refund_zeroes_contribution_record() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 200_000);
+    t.client.cancel_funding();
+    t.client.refund(&investor);
+
+    assert_eq!(t.client.contribution(&investor), 0);
+}
+
+#[test]
+fn refund_emits_event() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 100_000);
+    t.client.cancel_funding();
+    t.client.refund(&investor);
+
+    let events = t.env.events().all();
+    let has_refunded = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|v| v == soroban_sdk::symbol_short!("refunded").into_val(&t.env))
+    });
+    assert!(has_refunded, "Refunded event not emitted");
+}
+
+#[test]
+#[should_panic(expected = "no contribution to refund")]
+fn double_refund_panics() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 100_000);
+    t.client.cancel_funding();
+    t.client.refund(&investor);
+    t.client.refund(&investor); // second call must panic
+}
+
+#[test]
+#[should_panic(expected = "refunds only available after cancellation")]
+fn refund_fails_in_funding_state() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 100_000);
+    // Status is still 0 — no cancel.
+    t.client.refund(&investor);
+}
+
+#[test]
+#[should_panic(expected = "refunds only available after cancellation")]
+fn refund_fails_in_active_state() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 100_000);
+    t.env.as_contract(&t.contract, || {
+        t.env
+            .storage()
+            .instance()
+            .set(&DataKey::Status, &1_u32);
+    });
+    t.client.refund(&investor);
+}
+
+#[test]
+#[should_panic(expected = "no contribution to refund")]
+fn refund_zero_contribution_panics() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    // investor never contributed
+    t.client.cancel_funding();
+    t.client.refund(&investor);
+}
+
+#[test]
+#[should_panic]
+fn refund_requires_investor_auth() {
+    let env = Env::default();
+    // Do NOT mock auths.
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let contract = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract);
+    client.initialize(&admin, &token, &1_000_000_i128);
+
+    // Mock only admin auth to allow cancel.
+    env.mock_auths(&[AuthorizedInvocation {
+        function: AuthorizedFunction::Contract((
+            contract.clone(),
+            soroban_sdk::symbol_short!("cancel_f"),
+            soroban_sdk::vec![&env],
+        )),
+        sub_invocations: soroban_sdk::vec![&env],
+    }]);
+    client.cancel_funding();
+
+    // Now call refund without investor auth — should panic.
+    let investor = Address::generate(&env);
+    client.refund(&investor);
+}
+
+// ── Multiple investors ────────────────────────────────────────────────────────
+
+#[test]
+fn multiple_investors_each_refunded_correctly() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+
+    t.contribute(&alice, 400_000);
+    t.contribute(&bob, 250_000);
+
+    t.client.cancel_funding();
+
+    let token_client = token::Client::new(&t.env, &t.token);
+
+    let alice_before = token_client.balance(&alice);
+    t.client.refund(&alice);
+    assert_eq!(token_client.balance(&alice) - alice_before, 400_000);
+
+    let bob_before = token_client.balance(&bob);
+    t.client.refund(&bob);
+    assert_eq!(token_client.balance(&bob) - bob_before, 250_000);
+}
+
+#[test]
+fn funded_amount_invariant_holds_after_refunds() {
+    let t = TestEnv::new();
+    let alice = Address::generate(&t.env);
+    let bob = Address::generate(&t.env);
+
+    t.contribute(&alice, 300_000);
+    t.contribute(&bob, 200_000);
+
+    let funded = t.client.funded_amount();
+    assert_eq!(funded, 500_000);
+
+    t.client.cancel_funding();
+    t.client.refund(&alice);
+    t.client.refund(&bob);
+
+    // funded_amount is a historical record; it does not decrease on refund.
+    // The invariant is: sum of all refunds ≤ funded_amount.
+    assert_eq!(t.client.funded_amount(), 500_000);
+}
+
+// ── Contribute guards ─────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "contributions only accepted during Funding phase")]
+fn contribute_fails_after_cancellation() {
+    let t = TestEnv::new();
+    t.client.cancel_funding();
+    let investor = Address::generate(&t.env);
+    t.contribute(&investor, 100_000);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn contribute_zero_amount_panics() {
+    let t = TestEnv::new();
+    let investor = Address::generate(&t.env);
+    t.client.contribute(&investor, &0);
+}
+
+// ── Initialisation guard ──────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "already initialised")]
+fn double_initialize_panics() {
+    let t = TestEnv::new();
+    t.client.initialize(&t.admin, &t.token, &1_000_000_i128);
+}
+
+#[test]
+#[should_panic(expected = "funding_target must be positive")]
+fn initialize_zero_target_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let contract = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract);
+    client.initialize(&admin, &token, &0_i128);
+}


### PR DESCRIPTION
- Add status 4 (Cancelled) terminal state
- cancel_funding: admin-gated, status 0→4, blocked under legal hold
- refund: investor-auth, cancelled-only, zeroes contribution before transfer to prevent double-spend, balance-delta checked via external_calls::transfer_funding_token_with_balance_checks
- Add FundingCancelled and Refunded contract events
- 20 tests covering happy path, double-refund, wrong-state, auth, legal hold, overflow, and invariant checks
- Add docs/escrow-lifecycle.md

Closes #242 