### PR TITLE
feat: add checks decimals-mismatch, zero-transfer-event, ownership-immediate, renounce-no-backup

### DIFF
--- a/crates/checks/src/decimals_mismatch.rs
+++ b/crates/checks/src/decimals_mismatch.rs
@@ -1,0 +1,194 @@
+//! Detects `decimals()` returning a hardcoded literal while other functions in the
+//! same contract use hardcoded divisor/multiplier literals inconsistent with it.
+//!
+//! Off-chain clients rely on `decimals()` to scale balances. If the declared value
+//! disagrees with the scaling constants used in arithmetic, displayed balances will
+//! be wrong.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprLit, File, Lit, ReturnType, Stmt};
+
+const CHECK_NAME: &str = "decimals-mismatch";
+
+pub struct DecimalsMismatchCheck;
+
+impl Check for DecimalsMismatchCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        let methods: Vec<_> = contractimpl_functions(file).collect();
+
+        // Find `decimals()` returning a literal integer.
+        let declared = methods.iter().find_map(|m| {
+            if m.sig.ident != "decimals" {
+                return None;
+            }
+            // Only consider functions with no meaningful parameters (just Env).
+            let param_count = m.sig.inputs.len();
+            if param_count > 1 {
+                return None;
+            }
+            extract_single_literal_return(&m.block)
+        });
+
+        let declared_decimals = match declared {
+            Some(d) => d,
+            None => return out,
+        };
+
+        // Collect all power-of-10 literals used in other functions as divisors/multipliers.
+        for method in &methods {
+            if method.sig.ident == "decimals" {
+                continue;
+            }
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = LiteralScan::default();
+            scan.visit_block(&method.block);
+
+            for (line, lit_val) in scan.power_of_10_literals {
+                // Compute implied decimals from the literal (e.g. 1_000_000 → 6).
+                if let Some(implied) = implied_decimals(lit_val) {
+                    if implied != declared_decimals {
+                        out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::Low,
+                            file_path: String::new(),
+                            line,
+                            function_name: fn_name.clone(),
+                            description: format!(
+                                "Function `{fn_name}` uses a scaling constant `{lit_val}` \
+                                 implying {implied} decimals, but `decimals()` returns \
+                                 {declared_decimals}. Off-chain clients will misread balances."
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Extract the single integer literal returned by a simple function body.
+/// Handles `{ 7 }`, `{ return 7; }`, and `-> u32 { 7u32 }`.
+fn extract_single_literal_return(block: &syn::Block) -> Option<u64> {
+    // Tail expression: `{ 7 }`
+    if let Some(Expr::Lit(ExprLit { lit: Lit::Int(i), .. })) = block.stmts.iter().find_map(|s| {
+        if let Stmt::Expr(e, _) = s {
+            Some(e)
+        } else {
+            None
+        }
+    }) {
+        return i.base10_parse::<u64>().ok();
+    }
+    // `return 7;`
+    for stmt in &block.stmts {
+        if let Stmt::Expr(Expr::Return(r), _) = stmt {
+            if let Some(Expr::Lit(ExprLit { lit: Lit::Int(i), .. })) = r.expr.as_deref() {
+                return i.base10_parse::<u64>().ok();
+            }
+        }
+    }
+    None
+}
+
+/// Return the number of decimal places implied by a power-of-10 literal.
+fn implied_decimals(val: u64) -> Option<u64> {
+    if val == 0 {
+        return None;
+    }
+    let mut v = val;
+    let mut exp = 0u64;
+    while v % 10 == 0 {
+        v /= 10;
+        exp += 1;
+    }
+    if v == 1 && exp > 0 {
+        Some(exp)
+    } else {
+        None
+    }
+}
+
+#[derive(Default)]
+struct LiteralScan {
+    /// (line, value) for each power-of-10 integer literal found.
+    power_of_10_literals: Vec<(usize, u64)>,
+}
+
+impl<'ast> Visit<'ast> for LiteralScan {
+    fn visit_expr_lit(&mut self, i: &'ast ExprLit) {
+        if let Lit::Int(n) = &i.lit {
+            if let Ok(val) = n.base10_parse::<u64>() {
+                if implied_decimals(val).is_some() {
+                    self.power_of_10_literals.push((i.span().start().line, val));
+                }
+            }
+        }
+        visit::visit_expr_lit(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_mismatch_between_decimals_and_divisor() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn decimals(_env: Env) -> u32 { 7 }
+    pub fn balance(env: Env, addr: Address) -> i128 {
+        let raw: i128 = env.storage().instance().get(&addr).unwrap_or(0);
+        raw / 1_000_000  // implies 6 decimals, but decimals() says 7
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = DecimalsMismatchCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_when_consistent() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn decimals(_env: Env) -> u32 { 7 }
+    pub fn balance(env: Env, addr: Address) -> i128 {
+        let raw: i128 = env.storage().instance().get(&addr).unwrap_or(0);
+        raw / 10_000_000  // implies 7 decimals — matches
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = DecimalsMismatchCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn no_decimals_fn_no_finding() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn balance(env: Env, addr: Address) -> i128 {
+        let raw: i128 = env.storage().instance().get(&addr).unwrap_or(0);
+        raw / 1_000_000
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = DecimalsMismatchCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -76,6 +76,10 @@ pub mod weak_randomness;
 pub mod withdraw_auth;
 pub mod wrapping_balance_op;
 pub mod zero_amount;
+pub mod decimals_mismatch;
+pub mod zero_transfer_event;
+pub mod ownership_immediate;
+pub mod renounce_no_backup;
 
 pub use admin::UnprotectedAdminCheck;
 pub use admin_in_temp::AdminInTempCheck;
@@ -150,6 +154,10 @@ pub use weak_randomness::WeakRandomnessCheck;
 pub use withdraw_auth::WithdrawAuthCheck;
 pub use wrapping_balance_op::WrappingBalanceOpCheck;
 pub use zero_amount::ZeroAmountCheck;
+pub use decimals_mismatch::DecimalsMismatchCheck;
+pub use zero_transfer_event::ZeroTransferEventCheck;
+pub use ownership_immediate::OwnershipImmediateCheck;
+pub use renounce_no_backup::RenounceNoBackupCheck;
 
 use serde::Serialize;
 use syn::File;
@@ -246,5 +254,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(LinearWhitelistScanCheck),
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
+        Box::new(DecimalsMismatchCheck),
+        Box::new(ZeroTransferEventCheck),
+        Box::new(OwnershipImmediateCheck),
+        Box::new(RenounceNoBackupCheck),
     ]
 }

--- a/crates/checks/src/ownership_immediate.rs
+++ b/crates/checks/src/ownership_immediate.rs
@@ -1,0 +1,203 @@
+//! Detects immediate single-step ownership transfer without a two-step
+//! propose/accept pattern.
+//!
+//! Directly writing a new admin/owner address in one step is risky: if the
+//! supplied address is wrong, ownership is permanently lost. The safe pattern
+//! is propose + accept (two-step handoff).
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "ownership-immediate";
+
+/// Names that indicate a direct ownership-transfer function.
+const TRANSFER_FN_NAMES: &[&str] = &[
+    "set_admin",
+    "set_owner",
+    "transfer_ownership",
+    "change_admin",
+    "change_owner",
+    "update_admin",
+    "update_owner",
+];
+
+/// Names that indicate a safe two-step acceptance function exists.
+const ACCEPT_FN_NAMES: &[&str] = &[
+    "accept_ownership",
+    "accept_admin",
+    "confirm_admin",
+    "confirm_ownership",
+    "claim_ownership",
+    "claim_admin",
+];
+
+pub struct OwnershipImmediateCheck;
+
+impl Check for OwnershipImmediateCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let methods: Vec<_> = contractimpl_functions(file).collect();
+
+        // Check whether a safe accept function exists anywhere in the impl block.
+        let has_accept_fn = methods
+            .iter()
+            .any(|m| ACCEPT_FN_NAMES.contains(&m.sig.ident.to_string().as_str()));
+
+        if has_accept_fn {
+            return vec![];
+        }
+
+        let mut out = Vec::new();
+        for method in &methods {
+            let fn_name = method.sig.ident.to_string();
+            if !TRANSFER_FN_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+
+            // Check if the body writes directly to an admin/owner storage key.
+            let mut scan = AdminWriteScan::default();
+            scan.visit_block(&method.block);
+
+            if scan.writes_admin_key {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` transfers ownership in a single step without a \
+                         corresponding `accept_ownership` / `accept_admin` function. \
+                         If the new address is wrong, ownership is permanently lost. \
+                         Use a two-step propose-then-accept pattern."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn is_admin_key(expr: &Expr) -> bool {
+    let text = expr_to_string(expr).to_lowercase();
+    text.contains("admin") || text.contains("owner")
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => expr_to_string(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .tokens
+            .to_string()
+            .trim_matches('"')
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+fn receiver_has(expr: &Expr, method: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => m.method == method || receiver_has(&m.receiver, method),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct AdminWriteScan {
+    writes_admin_key: bool,
+}
+
+impl<'ast> Visit<'ast> for AdminWriteScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Detect storage().{instance,persistent}().set(admin_key, value)
+        if i.method == "set"
+            && receiver_has(&i.receiver, "storage")
+            && i.args.len() >= 2
+        {
+            if let Some(key_arg) = i.args.first() {
+                if is_admin_key(key_arg) {
+                    self.writes_admin_key = true;
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_single_step_set_admin() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = OwnershipImmediateCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn passes_when_accept_fn_exists() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("pending"), &new_admin);
+    }
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env.storage().instance().get(&symbol_short!("pending")).unwrap();
+        pending.require_auth();
+        env.storage().instance().set(&symbol_short!("admin"), &pending);
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = OwnershipImmediateCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_functions() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        env.storage().instance().set(&to, &amount);
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = OwnershipImmediateCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/renounce_no_backup.rs
+++ b/crates/checks/src/renounce_no_backup.rs
@@ -1,0 +1,195 @@
+//! Detects `renounce_ownership` / `renounce_admin` functions that remove the
+//! admin key without verifying a backup or fallback admin mechanism exists.
+//!
+//! Calling `storage().remove(admin_key)` or setting the admin to `None` without
+//! any alternative authorization path permanently locks the contract.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "renounce-no-backup";
+
+/// Function names that indicate an ownership-renouncement operation.
+const RENOUNCE_FN_NAMES: &[&str] = &[
+    "renounce_ownership",
+    "renounce_admin",
+    "revoke_ownership",
+    "revoke_admin",
+];
+
+pub struct RenounceNoBackupCheck;
+
+impl Check for RenounceNoBackupCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !RENOUNCE_FN_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+
+            let mut scan = RenounceScan::default();
+            scan.visit_block(&method.block);
+
+            // Flag if the function removes/clears the admin key without setting a backup.
+            if scan.removes_admin && !scan.sets_backup {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` removes or clears the admin key without \
+                         setting a backup or fallback admin. This permanently locks the \
+                         contract with no recovery path."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn is_admin_key(expr: &Expr) -> bool {
+    let text = expr_to_string(expr).to_lowercase();
+    text.contains("admin") || text.contains("owner")
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => expr_to_string(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m.mac.tokens.to_string().trim_matches('"').to_string(),
+        _ => String::new(),
+    }
+}
+
+fn receiver_has(expr: &Expr, method: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => m.method == method || receiver_has(&m.receiver, method),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+struct RenounceScan {
+    removes_admin: bool,
+    sets_backup: bool,
+}
+
+impl<'ast> Visit<'ast> for RenounceScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+
+        // Detect storage().{instance,persistent}().remove(admin_key)
+        if method == "remove" && receiver_has(&i.receiver, "storage") {
+            if let Some(key_arg) = i.args.first() {
+                if is_admin_key(key_arg) {
+                    self.removes_admin = true;
+                }
+            }
+        }
+
+        // Detect storage().{instance,persistent}().set(admin_key, backup_value)
+        // as a backup mechanism (e.g. setting a multisig or DAO address).
+        if method == "set" && receiver_has(&i.receiver, "storage") {
+            if let Some(key_arg) = i.args.first() {
+                if is_admin_key(key_arg) {
+                    self.sets_backup = true;
+                }
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_renounce_without_backup() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn renounce_ownership(env: Env) {
+        env.require_auth();
+        env.storage().instance().remove(&symbol_short!("admin"));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = RenounceNoBackupCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[0].function_name, "renounce_ownership");
+    }
+
+    #[test]
+    fn passes_when_backup_set_before_remove() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn renounce_ownership(env: Env, backup: Address) {
+        env.require_auth();
+        env.storage().instance().set(&symbol_short!("admin"), &backup);
+        env.storage().instance().remove(&symbol_short!("owner"));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = RenounceNoBackupCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_renounce_functions() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn clear_data(env: Env) {
+        env.storage().instance().remove(&symbol_short!("admin"));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = RenounceNoBackupCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn flags_renounce_admin_variant() {
+        let code = r#"
+#[contractimpl]
+impl C {
+    pub fn renounce_admin(env: Env) {
+        env.storage().persistent().remove(&symbol_short!("admin"));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = RenounceNoBackupCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+    }
+}

--- a/crates/checks/src/zero_transfer_event.rs
+++ b/crates/checks/src/zero_transfer_event.rs
@@ -1,0 +1,193 @@
+//! Detects `transfer` functions that emit events without first checking `amount > 0`.
+//!
+//! A zero-amount transfer serves no financial purpose but still emits an event,
+//! spamming the event log and potentially confusing off-chain indexers.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprMethodCall, File, FnArg, Pat, PatType};
+
+const CHECK_NAME: &str = "zero-transfer-event";
+
+pub struct ZeroTransferEventCheck;
+
+impl Check for ZeroTransferEventCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if fn_name != "transfer" {
+                continue;
+            }
+
+            // Must have an `amount` parameter.
+            let has_amount = method.sig.inputs.iter().any(|arg| {
+                if let FnArg::Typed(PatType { pat, .. }) = arg {
+                    if let Pat::Ident(id) = &**pat {
+                        return id.ident == "amount";
+                    }
+                }
+                false
+            });
+            if !has_amount {
+                continue;
+            }
+
+            let mut scan = TransferScan::default();
+            scan.visit_block(&method.block);
+
+            // Flag if events are emitted but amount is never checked against 0.
+            if scan.emits_event && !scan.checks_amount_zero {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` emits an event but does not check `amount > 0` \
+                         before doing so. Zero-amount transfers spam the event log with \
+                         economically meaningless entries."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct TransferScan {
+    emits_event: bool,
+    checks_amount_zero: bool,
+}
+
+impl<'ast> Visit<'ast> for TransferScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // Detect event emission: env.events().publish(...) or similar.
+        let method = i.method.to_string();
+        if matches!(method.as_str(), "publish" | "emit") {
+            self.emits_event = true;
+        }
+        // Also detect chained: .events().publish(...)
+        if method == "publish" || method == "emit" {
+            self.emits_event = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        let left_amount = expr_is_ident(&i.left, "amount");
+        let right_zero = expr_is_zero(&i.right);
+        let left_zero = expr_is_zero(&i.left);
+        let right_amount = expr_is_ident(&i.right, "amount");
+
+        if (left_amount && right_zero) || (left_zero && right_amount) {
+            match i.op {
+                BinOp::Gt(_)
+                | BinOp::Ge(_)
+                | BinOp::Lt(_)
+                | BinOp::Le(_)
+                | BinOp::Ne(_)
+                | BinOp::Eq(_) => {
+                    self.checks_amount_zero = true;
+                }
+                _ => {}
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+fn expr_is_ident(expr: &Expr, name: &str) -> bool {
+    if let Expr::Path(p) = expr {
+        p.path.is_ident(name)
+    } else {
+        false
+    }
+}
+
+fn expr_is_zero(expr: &Expr) -> bool {
+    if let Expr::Lit(l) = expr {
+        if let syn::Lit::Int(i) = &l.lit {
+            return i.base10_parse::<i64>().map(|n| n == 0).unwrap_or(false);
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_transfer_with_event_no_zero_check() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        env.events().publish((symbol_short!("transfer"),), (from, to, amount));
+        env.storage().instance().set(&to, &amount);
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = ZeroTransferEventCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_when_amount_checked_before_event() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        if amount <= 0 { panic!("zero"); }
+        env.events().publish((symbol_short!("transfer"),), (from, to, amount));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = ZeroTransferEventCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn passes_when_no_event_emitted() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        env.storage().instance().set(&to, &amount);
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = ZeroTransferEventCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_transfer_functions() {
+        let code = r#"
+#[contractimpl]
+impl Token {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        env.events().publish((symbol_short!("mint"),), (to, amount));
+    }
+}
+"#;
+        let file = parse_file(code).unwrap();
+        let findings = ZeroTransferEventCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/test-contracts/decimals-mismatch-safe/Cargo.toml
+++ b/test-contracts/decimals-mismatch-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-decimals-mismatch-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/decimals-mismatch-safe/src/lib.rs
+++ b/test-contracts/decimals-mismatch-safe/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct DecimalsMismatchSafe;
+
+#[contractimpl]
+impl DecimalsMismatchSafe {
+    /// ✅ Declares 7 decimals and consistently uses 10_000_000 (10^7) as the
+    /// scaling constant — off-chain clients will display balances correctly.
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn balance(env: Env, addr: Address) -> i128 {
+        let raw: i128 = env.storage().instance().get(&addr).unwrap_or(0);
+        raw / 10_000_000 // consistent with 7 decimals
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let scaled = amount * 10_000_000; // consistent 7-decimal scaling
+        env.storage().instance().set(&to, &scaled);
+        let _ = from;
+    }
+}

--- a/test-contracts/decimals-mismatch-vulnerable/Cargo.toml
+++ b/test-contracts/decimals-mismatch-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-decimals-mismatch-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/decimals-mismatch-vulnerable/src/lib.rs
+++ b/test-contracts/decimals-mismatch-vulnerable/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct DecimalsMismatchVulnerable;
+
+#[contractimpl]
+impl DecimalsMismatchVulnerable {
+    /// ❌ Declares 7 decimals but uses 1_000_000 (6 decimals) as the scaling
+    /// constant — off-chain clients will display balances 10× too large.
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn balance(env: Env, addr: Address) -> i128 {
+        let raw: i128 = env.storage().instance().get(&addr).unwrap_or(0);
+        raw / 1_000_000 // implies 6 decimals, but decimals() says 7
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let scaled = amount * 1_000_000; // 6-decimal scaling
+        env.storage().instance().set(&to, &scaled);
+        let _ = from;
+    }
+}

--- a/test-contracts/ownership-immediate-safe/Cargo.toml
+++ b/test-contracts/ownership-immediate-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-immediate-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-immediate-safe/src/lib.rs
+++ b/test-contracts/ownership-immediate-safe/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipImmediateSafe;
+
+#[contractimpl]
+impl OwnershipImmediateSafe {
+    /// ✅ Step 1: propose a new admin (stores in pending slot, does not transfer yet).
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pending"), &new_admin);
+    }
+
+    /// ✅ Step 2: the pending admin must accept — two-step handoff prevents
+    /// accidental permanent loss of ownership.
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("pending"))
+            .unwrap();
+        pending.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &pending);
+        env.storage()
+            .instance()
+            .remove(&symbol_short!("pending"));
+    }
+}

--- a/test-contracts/ownership-immediate-vulnerable/Cargo.toml
+++ b/test-contracts/ownership-immediate-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-immediate-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-immediate-vulnerable/src/lib.rs
+++ b/test-contracts/ownership-immediate-vulnerable/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipImmediateVulnerable;
+
+#[contractimpl]
+impl OwnershipImmediateVulnerable {
+    /// ❌ Transfers ownership in a single step — if `new_admin` is wrong,
+    /// ownership is permanently lost with no recovery path.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        // Direct single-step write — no two-step propose/accept pattern
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &new_admin);
+    }
+}

--- a/test-contracts/renounce-no-backup-safe/Cargo.toml
+++ b/test-contracts/renounce-no-backup-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-renounce-no-backup-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/renounce-no-backup-safe/src/lib.rs
+++ b/test-contracts/renounce-no-backup-safe/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct RenounceNoBackupSafe;
+
+#[contractimpl]
+impl RenounceNoBackupSafe {
+    /// ✅ Transfers admin to a backup address before renouncing the current
+    /// admin key — the contract always retains an authorized admin.
+    pub fn renounce_ownership(env: Env, backup: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        // Set backup first, then remove the old key
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &backup);
+    }
+}

--- a/test-contracts/renounce-no-backup-vulnerable/Cargo.toml
+++ b/test-contracts/renounce-no-backup-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-renounce-no-backup-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/renounce-no-backup-vulnerable/src/lib.rs
+++ b/test-contracts/renounce-no-backup-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct RenounceNoBackupVulnerable;
+
+#[contractimpl]
+impl RenounceNoBackupVulnerable {
+    /// ❌ Removes the admin key with no backup — the contract is permanently
+    /// locked after this call with no recovery path.
+    pub fn renounce_ownership(env: Env) {
+        env.storage()
+            .instance()
+            .remove(&symbol_short!("admin"));
+    }
+}

--- a/test-contracts/zero-transfer-event-safe/Cargo.toml
+++ b/test-contracts/zero-transfer-event-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-zero-transfer-event-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/zero-transfer-event-safe/src/lib.rs
+++ b/test-contracts/zero-transfer-event-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct ZeroTransferEventSafe;
+
+#[contractimpl]
+impl ZeroTransferEventSafe {
+    /// ✅ Rejects zero-amount transfers before emitting any event.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        env.events()
+            .publish((symbol_short!("transfer"),), (from.clone(), to.clone(), amount));
+        env.storage().instance().set(&to, &amount);
+        let _ = from;
+    }
+}

--- a/test-contracts/zero-transfer-event-vulnerable/Cargo.toml
+++ b/test-contracts/zero-transfer-event-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-zero-transfer-event-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/zero-transfer-event-vulnerable/src/lib.rs
+++ b/test-contracts/zero-transfer-event-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct ZeroTransferEventVulnerable;
+
+#[contractimpl]
+impl ZeroTransferEventVulnerable {
+    /// ❌ Emits a transfer event without checking amount > 0.
+    /// Zero-amount transfers spam the event log with meaningless entries.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        // No zero-amount guard — event is emitted even for amount == 0
+        env.events()
+            .publish((symbol_short!("transfer"),), (from, to, amount));
+        env.storage().instance().set(&to, &amount);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks resolving issues #278, #279, #280, and #281.

---

## Issue #278 — `decimals-mismatch` (Low)

**Problem:** `decimals()` returns a hardcoded literal but other functions in the same contract use scaling constants (divisors/multipliers) that imply a different number of decimal places. Off-chain clients rely on `decimals()` to scale balances — a mismatch causes displayed values to be wrong by an order of magnitude.

**Detection:** Finds `decimals()` returning a literal integer, then scans all other functions for power-of-10 literals. If any literal implies a different decimal count, a Low finding is emitted.

**Files:**
- `crates/checks/src/decimals_mismatch.rs`
- `test-contracts/decimals-mismatch-vulnerable/` — declares 7 decimals but uses `1_000_000` (6 decimals) as scaling constant
- `test-contracts/decimals-mismatch-safe/` — consistently uses `10_000_000` (7 decimals) everywhere

---

## Issue #279 — `zero-transfer-event` (Low)

**Problem:** A `transfer(from, to, amount)` function that emits an event without first checking `amount > 0` allows zero-amount transfers to spam the event log with economically meaningless entries, confusing off-chain indexers.

**Detection:** Flags `transfer` functions with an `amount` parameter that call `.publish()` or `.emit()` without any binary comparison of `amount` against `0`.

**Files:**
- `crates/checks/src/zero_transfer_event.rs`
- `test-contracts/zero-transfer-event-vulnerable/` — emits event with no zero-amount guard
- `test-contracts/zero-transfer-event-safe/` — rejects `amount <= 0` before emitting

---

## Issue #280 — `ownership-immediate` (Medium)

**Problem:** Directly writing a new admin/owner address in a single step (e.g. `set_admin(new_admin)`) is risky — if the supplied address is wrong or a typo, ownership is permanently lost with no recovery. The safe pattern is a two-step propose-then-accept handoff.

**Detection:** Flags functions named `set_admin`, `set_owner`, `transfer_ownership`, etc. that write directly to an admin/owner storage key, when no corresponding `accept_ownership` / `accept_admin` / `confirm_admin` function exists in the same impl block.

**Files:**
- `crates/checks/src/ownership_immediate.rs`
- `test-contracts/ownership-immediate-vulnerable/` — single-step `set_admin` with no accept function
- `test-contracts/ownership-immediate-safe/` — two-step `set_admin` + `accept_admin`

---

## Issue #281 — `renounce-no-backup` (High)

**Problem:** `renounce_ownership` or `renounce_admin` that calls `storage().remove(admin_key)` without first setting a backup admin permanently locks the contract — no function can ever be called that requires admin authorization again.

**Detection:** Flags functions named `renounce_ownership`, `renounce_admin`, `revoke_ownership`, or `revoke_admin` that call `storage().remove()` on an admin/owner key without also calling `storage().set()` on an admin/owner key in the same body.

**Files:**
- `crates/checks/src/renounce_no_backup.rs`
- `test-contracts/renounce-no-backup-vulnerable/` — removes admin key with no backup
- `test-contracts/renounce-no-backup-safe/` — sets backup admin before renouncing

---

## Changes

- `crates/checks/src/lib.rs` — module declarations, `pub use` exports, registered in `default_checks()`
- 4 new check files with unit tests
- 8 new test contracts (4 vulnerable + 4 safe)

closes #278
closes #279
closes #280
closes #281 