### PR TITLE
feat: add checks #282-285 (admin-zero-address, admin-no-group-auth, ownership-pending-not-cleared, ownership-no-approval-invalidation)

### DIFF
--- a/crates/checks/src/admin_no_group_auth.rs
+++ b/crates/checks/src/admin_no_group_auth.rs
@@ -1,0 +1,184 @@
+//! Detects contracts where more than 2 distinct `#[contractimpl]` functions each
+//! independently call `require_auth` on a value read from the same admin storage
+//! key, instead of using a shared helper.  Duplicated auth logic is error-prone:
+//! a future change to the auth pattern must be replicated everywhere.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprMethodCall, File};
+
+const CHECK_NAME: &str = "admin-no-group-auth";
+
+/// Heuristic: a local variable whose name contains "admin" or "owner" and on
+/// which `.require_auth()` is called is considered an "admin auth call".
+pub struct AdminNoGroupAuthCheck;
+
+impl Check for AdminNoGroupAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut functions_with_admin_auth: Vec<(String, usize)> = Vec::new();
+
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = AdminAuthScan::default();
+            scan.visit_block(&method.block);
+            if scan.has_admin_require_auth {
+                let line = method.sig.fn_token.span().start().line;
+                functions_with_admin_auth.push((fn_name, line));
+            }
+        }
+
+        if functions_with_admin_auth.len() > 2 {
+            // Report on the first function that starts the pattern.
+            let (first_fn, first_line) = &functions_with_admin_auth[0];
+            let all_fns: Vec<&str> = functions_with_admin_auth
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect();
+            vec![Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Low,
+                file_path: String::new(),
+                line: *first_line,
+                function_name: first_fn.clone(),
+                description: format!(
+                    "{} functions ({}) each independently call `require_auth` on an admin/owner \
+                     value. Extract a shared `assert_admin(env)` helper to avoid duplicated \
+                     auth logic that must be kept in sync.",
+                    functions_with_admin_auth.len(),
+                    all_fns.join(", ")
+                ),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[derive(Default)]
+struct AdminAuthScan {
+    has_admin_require_auth: bool,
+}
+
+impl<'ast> Visit<'ast> for AdminAuthScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "require_auth" || i.method == "require_auth_for_args" {
+            // Check if the receiver references an admin/owner variable.
+            let receiver_text = receiver_to_string(&i.receiver);
+            if is_admin_name(&receiver_text) {
+                self.has_admin_require_auth = true;
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn receiver_to_string(expr: &syn::Expr) -> String {
+    match expr {
+        syn::Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        syn::Expr::MethodCall(m) => receiver_to_string(&m.receiver),
+        syn::Expr::Reference(r) => receiver_to_string(&r.expr),
+        _ => String::new(),
+    }
+}
+
+fn is_admin_name(s: &str) -> bool {
+    let lower = s.to_lowercase();
+    lower.contains("admin") || lower.contains("owner") || lower.contains("operator")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_three_functions_with_admin_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pause(env: Env) {
+        let admin: Address = env.storage().instance().get(&"admin").unwrap();
+        admin.require_auth();
+    }
+    pub fn unpause(env: Env) {
+        let admin: Address = env.storage().instance().get(&"admin").unwrap();
+        admin.require_auth();
+    }
+    pub fn set_fee(env: Env, fee: u32) {
+        let admin: Address = env.storage().instance().get(&"admin").unwrap();
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoGroupAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_two_functions_with_admin_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn pause(env: Env) {
+        let admin: Address = env.storage().instance().get(&"admin").unwrap();
+        admin.require_auth();
+    }
+    pub fn unpause(env: Env) {
+        let admin: Address = env.storage().instance().get(&"admin").unwrap();
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoGroupAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_no_admin_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, user: Address) {
+        user.require_auth();
+    }
+    pub fn withdraw(env: Env, user: Address) {
+        user.require_auth();
+    }
+    pub fn transfer(env: Env, user: Address) {
+        user.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoGroupAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/admin_zero_address.rs
+++ b/crates/checks/src/admin_zero_address.rs
@@ -1,0 +1,278 @@
+//! Detects `set_admin` / `transfer_ownership` functions that accept an `Address`
+//! parameter but never validate it (no comparison, no `require_auth` on the new
+//! address, no panic/assert on it).  Passing the all-zeros Stellar address
+//! effectively renounces ownership with no recovery path.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File, FnArg, Pat, Visibility};
+
+const CHECK_NAME: &str = "admin-zero-address";
+
+/// Function names that set a new admin/owner from a parameter.
+const ADMIN_SETTER_NAMES: &[&str] = &[
+    "set_admin",
+    "set_owner",
+    "transfer_ownership",
+    "update_admin",
+    "change_admin",
+    "change_owner",
+    "set_manager",
+];
+
+pub struct AdminZeroAddressCheck;
+
+impl Check for AdminZeroAddressCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            if !matches!(method.vis, Visibility::Public(_)) {
+                continue;
+            }
+            let fn_name = method.sig.ident.to_string();
+            if !ADMIN_SETTER_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+
+            // Collect Address-typed parameter names (heuristic: any param that
+            // isn't `env` and whose type path ends in "Address").
+            let addr_params: Vec<String> = method
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|arg| {
+                    if let FnArg::Typed(pt) = arg {
+                        let type_str = type_to_string(&pt.ty);
+                        if type_str.ends_with("Address") {
+                            if let Pat::Ident(pi) = &*pt.pat {
+                                return Some(pi.ident.to_string());
+                            }
+                        }
+                    }
+                    None
+                })
+                .collect();
+
+            if addr_params.is_empty() {
+                continue;
+            }
+
+            // Check whether the body validates any of those params.
+            let mut scan = ValidationScan::new(addr_params);
+            scan.visit_block(&method.block);
+
+            if !scan.validated {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "`{fn_name}` sets the admin/owner from a parameter without validating \
+                         it. Passing the zero/default address permanently renounces ownership \
+                         with no recovery path. Add a sentinel check or call \
+                         `new_admin.require_auth()` before storing."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+fn type_to_string(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Path(tp) => tp
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        syn::Type::Reference(r) => type_to_string(&r.elem),
+        _ => String::new(),
+    }
+}
+
+/// Looks for any validation of the address params:
+/// - `param.require_auth()`
+/// - a binary comparison involving the param (`==`, `!=`)
+/// - `assert!` / `panic!` / `require!` containing the param name
+/// - any `if` condition referencing the param
+struct ValidationScan {
+    params: Vec<String>,
+    validated: bool,
+}
+
+impl ValidationScan {
+    fn new(params: Vec<String>) -> Self {
+        Self {
+            params,
+            validated: false,
+        }
+    }
+
+    fn param_in_expr(&self, expr: &Expr) -> bool {
+        let text = expr_to_string(expr);
+        self.params.iter().any(|p| text.contains(p.as_str()))
+    }
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::MethodCall(m) => {
+            format!("{}.{}", expr_to_string(&m.receiver), m.method)
+        }
+        Expr::Binary(b) => {
+            format!("{} {}", expr_to_string(&b.left), expr_to_string(&b.right))
+        }
+        Expr::Reference(r) => expr_to_string(&r.expr),
+        _ => String::new(),
+    }
+}
+
+impl<'ast> Visit<'ast> for ValidationScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        // new_admin.require_auth()
+        if i.method == "require_auth" || i.method == "require_auth_for_args" {
+            if self.param_in_expr(&i.receiver) {
+                self.validated = true;
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_if(&mut self, i: &'ast syn::ExprIf) {
+        // any `if` whose condition references the param
+        if self.param_in_expr(&i.cond) {
+            self.validated = true;
+        }
+        visit::visit_expr_if(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast syn::ExprBinary) {
+        // direct comparison: new_admin == zero_addr
+        if self.param_in_expr(&i.left) || self.param_in_expr(&i.right) {
+            self.validated = true;
+        }
+        visit::visit_expr_binary(self, i);
+    }
+
+    fn visit_expr_macro(&mut self, i: &'ast syn::ExprMacro) {
+        let mac_name = i
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        if matches!(mac_name.as_str(), "assert" | "panic" | "require") {
+            let tokens = i.mac.tokens.to_string();
+            if self.params.iter().any(|p| tokens.contains(p.as_str())) {
+                self.validated = true;
+            }
+        }
+        visit::visit_expr_macro(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_set_admin_without_validation() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.storage().instance().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminZeroAddressCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_require_auth_on_param() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        env.storage().instance().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminZeroAddressCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_if_check_on_param() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        if new_admin == Address::default() { panic!("zero"); }
+        env.storage().instance().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = AdminZeroAddressCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_setter_fn() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&"admin").unwrap()
+    }
+}
+"#,
+        )?;
+        let hits = AdminZeroAddressCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -2,6 +2,8 @@
 
 pub mod address_from_str;
 pub mod admin;
+pub mod admin_no_group_auth;
+pub mod admin_zero_address;
 pub mod admin_in_temp;
 pub mod admin_key_removal;
 pub mod admin_overwrite;
@@ -51,6 +53,8 @@ pub mod no_param_no_auth;
 pub mod no_std;
 pub mod nonce_increment_order;
 pub mod overflow;
+pub mod ownership_no_approval_invalidation;
+pub mod ownership_pending_not_cleared;
 pub mod ownership_transfer;
 pub mod persistent_overwrite;
 pub mod instance_set_no_has;
@@ -103,6 +107,8 @@ pub mod zero_amount;
 
 pub use address_from_str::AddressFromStrCheck;
 pub use admin::UnprotectedAdminCheck;
+pub use admin_no_group_auth::AdminNoGroupAuthCheck;
+pub use admin_zero_address::AdminZeroAddressCheck;
 pub use admin_in_temp::AdminInTempCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
 pub use admin_overwrite::AdminOverwriteCheck;
@@ -151,6 +157,8 @@ pub use no_param_no_auth::NoParamNoAuthCheck;
 pub use no_std::NoStdCheck;
 pub use nonce_increment_order::NonceIncrementOrderCheck;
 pub use overflow::UncheckedArithmeticCheck;
+pub use ownership_no_approval_invalidation::OwnershipNoApprovalInvalidationCheck;
+pub use ownership_pending_not_cleared::OwnershipPendingNotClearedCheck;
 pub use ownership_transfer::OwnershipTransferCheck;
 pub use persistent_overwrite::PersistentOverwriteCheck;
 pub use instance_set_no_has::InstanceSetNoHasCheck;
@@ -302,5 +310,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
         Box::new(TierKeyCollisionCheck),
+        Box::new(AdminZeroAddressCheck),
+        Box::new(AdminNoGroupAuthCheck),
+        Box::new(OwnershipPendingNotClearedCheck),
+        Box::new(OwnershipNoApprovalInvalidationCheck),
     ]
 }

--- a/crates/checks/src/ownership_no_approval_invalidation.rs
+++ b/crates/checks/src/ownership_no_approval_invalidation.rs
@@ -1,0 +1,231 @@
+//! Detects `transfer_ownership` functions that do not include a storage
+//! operation to clear or invalidate existing allowances/approvals after the
+//! transfer.
+//!
+//! When ownership changes, token approvals or operator permissions signed by
+//! the old owner should be invalidated to prevent lingering authorization.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "ownership-no-approval-invalidation";
+
+/// Function names that perform an ownership transfer.
+const TRANSFER_FN_NAMES: &[&str] = &[
+    "transfer_ownership",
+    "set_owner",
+    "set_admin",
+    "change_owner",
+    "change_admin",
+];
+
+pub struct OwnershipNoApprovalInvalidationCheck;
+
+impl Check for OwnershipNoApprovalInvalidationCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !TRANSFER_FN_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+
+            let mut scan = ApprovalScan::default();
+            scan.visit_block(&method.block);
+
+            if scan.writes_owner && !scan.clears_approvals {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "`{fn_name}` transfers ownership but does not clear existing \
+                         allowances or approvals. Permissions granted by the old owner \
+                         remain valid and can be exploited by the new owner or third parties."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct ApprovalScan {
+    writes_owner: bool,
+    clears_approvals: bool,
+}
+
+fn key_expr_text(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => key_expr_text(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        _ => String::new(),
+    }
+}
+
+fn is_owner_key(text: &str) -> bool {
+    let t = text.to_lowercase();
+    t.contains("admin") || t.contains("owner") || t.contains("operator")
+}
+
+fn is_approval_key(text: &str) -> bool {
+    let t = text.to_lowercase();
+    t.contains("allow") || t.contains("approv") || t.contains("permit") || t.contains("operator")
+}
+
+fn receiver_chain_contains(expr: &Expr, method: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == method {
+                return true;
+            }
+            receiver_chain_contains(&m.receiver, method)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, method),
+        _ => false,
+    }
+}
+
+fn is_storage_call(m: &ExprMethodCall) -> bool {
+    receiver_chain_contains(&m.receiver, "storage")
+}
+
+impl<'ast> Visit<'ast> for ApprovalScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_storage_call(i) {
+            let method = i.method.to_string();
+            if let Some(key_arg) = i.args.first() {
+                let key_text = key_expr_text(key_arg);
+                match method.as_str() {
+                    "set" => {
+                        if is_owner_key(&key_text) {
+                            self.writes_owner = true;
+                        }
+                        if is_approval_key(&key_text) {
+                            self.clears_approvals = true;
+                        }
+                    }
+                    "remove" => {
+                        if is_approval_key(&key_text) {
+                            self.clears_approvals = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_transfer_without_clearing_approvals() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        // ❌ no allowance/approval clearing
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipNoApprovalInvalidationCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_allowance_removed() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        env.storage().instance().remove(&"allowance");
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipNoApprovalInvalidationCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_approval_key_overwritten() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        env.storage().instance().set(&"approvals", &0u32);
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipNoApprovalInvalidationCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_fn_that_does_not_write_owner() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        // only reads, no write
+        let _ = env.storage().instance().get::<_, Address>(&"owner");
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipNoApprovalInvalidationCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/ownership_pending_not_cleared.rs
+++ b/crates/checks/src/ownership_pending_not_cleared.rs
@@ -1,0 +1,233 @@
+//! Detects `accept_ownership` functions that write a new admin/owner to storage
+//! but do not `remove` or overwrite the pending-ownership storage key.
+//!
+//! In a two-step ownership transfer the pending key must be cleared after
+//! `accept_ownership` succeeds; otherwise the same authorization can be replayed.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "ownership-pending-not-cleared";
+
+/// Function names that complete a two-step ownership transfer.
+const ACCEPT_FN_NAMES: &[&str] = &[
+    "accept_ownership",
+    "accept_admin",
+    "claim_ownership",
+    "finalize_transfer",
+];
+
+pub struct OwnershipPendingNotClearedCheck;
+
+impl Check for OwnershipPendingNotClearedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !ACCEPT_FN_NAMES.contains(&fn_name.as_str()) {
+                continue;
+            }
+
+            let mut scan = StorageScan::default();
+            scan.visit_block(&method.block);
+
+            // Flag if the function writes an admin/owner key but never removes
+            // or overwrites the pending key.
+            if scan.writes_admin && !scan.clears_pending {
+                let line = method.sig.fn_token.span().start().line;
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "`{fn_name}` writes the new owner/admin to storage but does not \
+                         `remove` or overwrite the pending-ownership key. The pending \
+                         authorization can be replayed to transfer ownership again."
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct StorageScan {
+    writes_admin: bool,
+    clears_pending: bool,
+}
+
+fn key_expr_text(expr: &Expr) -> String {
+    match expr {
+        Expr::Reference(r) => key_expr_text(&r.expr),
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        _ => String::new(),
+    }
+}
+
+fn is_admin_key(text: &str) -> bool {
+    let t = text.to_lowercase();
+    t.contains("admin") || t.contains("owner") || t.contains("operator")
+}
+
+fn is_pending_key(text: &str) -> bool {
+    let t = text.to_lowercase();
+    t.contains("pending") || t.contains("proposed") || t.contains("candidate")
+}
+
+fn receiver_chain_contains(expr: &Expr, method: &str) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == method {
+                return true;
+            }
+            receiver_chain_contains(&m.receiver, method)
+        }
+        Expr::Field(f) => receiver_chain_contains(&f.base, method),
+        _ => false,
+    }
+}
+
+fn is_storage_call(m: &ExprMethodCall) -> bool {
+    receiver_chain_contains(&m.receiver, "storage")
+}
+
+impl<'ast> Visit<'ast> for StorageScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_storage_call(i) {
+            let method = i.method.to_string();
+            if let Some(key_arg) = i.args.first() {
+                let key_text = key_expr_text(key_arg);
+                match method.as_str() {
+                    "set" => {
+                        if is_admin_key(&key_text) {
+                            self.writes_admin = true;
+                        }
+                        if is_pending_key(&key_text) {
+                            self.clears_pending = true;
+                        }
+                    }
+                    "remove" => {
+                        if is_pending_key(&key_text) {
+                            self.clears_pending = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_accept_ownership_without_clearing_pending() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env.storage().instance().get(&"pending_owner").unwrap();
+        new_owner.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        // ❌ pending_owner key is never removed
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipPendingNotClearedCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_pending_key_removed() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env.storage().instance().get(&"pending_owner").unwrap();
+        new_owner.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        env.storage().instance().remove(&"pending_owner");
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipPendingNotClearedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_pending_key_overwritten() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env.storage().instance().get(&"pending_owner").unwrap();
+        new_owner.require_auth();
+        env.storage().instance().set(&"owner", &new_owner);
+        env.storage().instance().set(&"pending_owner", &Address::default());
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipPendingNotClearedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_unrelated_function() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.storage().instance().set(&"pending_owner", &new_owner);
+    }
+}
+"#,
+        )?;
+        let hits = OwnershipPendingNotClearedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/admin-no-group-auth-safe/Cargo.toml
+++ b/test-contracts/admin-no-group-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-no-group-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-no-group-auth-safe/src/lib.rs
+++ b/test-contracts/admin-no-group-auth-safe/src/lib.rs
@@ -1,0 +1,40 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminNoGroupAuthSafe;
+
+fn assert_admin(env: &Env) {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("admin"))
+        .unwrap();
+    admin.require_auth();
+}
+
+#[contractimpl]
+impl AdminNoGroupAuthSafe {
+    /// ✅ All admin functions delegate to a single shared helper.
+    /// Auth logic only needs to be updated in one place.
+    pub fn pause(env: Env) {
+        assert_admin(&env);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("paused"), &true);
+    }
+
+    pub fn unpause(env: Env) {
+        assert_admin(&env);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("paused"), &false);
+    }
+
+    pub fn set_fee(env: Env, fee: u32) {
+        assert_admin(&env);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("fee"), &fee);
+    }
+}

--- a/test-contracts/admin-no-group-auth-vulnerable/Cargo.toml
+++ b/test-contracts/admin-no-group-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-no-group-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-no-group-auth-vulnerable/src/lib.rs
+++ b/test-contracts/admin-no-group-auth-vulnerable/src/lib.rs
@@ -1,0 +1,47 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminNoGroupAuthVulnerable;
+
+#[contractimpl]
+impl AdminNoGroupAuthVulnerable {
+    /// ❌ Each admin function independently reads the admin key and calls
+    /// require_auth. If the auth logic ever changes it must be updated in
+    /// every function — a maintenance hazard.
+    pub fn pause(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("paused"), &true);
+    }
+
+    pub fn unpause(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("paused"), &false);
+    }
+
+    pub fn set_fee(env: Env, fee: u32) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("fee"), &fee);
+    }
+}

--- a/test-contracts/admin-zero-address-safe/Cargo.toml
+++ b/test-contracts/admin-zero-address-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-zero-address-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-zero-address-safe/src/lib.rs
+++ b/test-contracts/admin-zero-address-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminZeroAddressSafe;
+
+#[contractimpl]
+impl AdminZeroAddressSafe {
+    /// ✅ Requires the new admin to authenticate, proving they control the key.
+    /// This prevents accidentally setting the admin to an uncontrolled address.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &new_admin);
+    }
+}

--- a/test-contracts/admin-zero-address-vulnerable/Cargo.toml
+++ b/test-contracts/admin-zero-address-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-zero-address-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-zero-address-vulnerable/src/lib.rs
+++ b/test-contracts/admin-zero-address-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminZeroAddressVulnerable;
+
+#[contractimpl]
+impl AdminZeroAddressVulnerable {
+    /// ❌ Accepts any address as the new admin without validation.
+    /// Passing the zero/default address permanently renounces ownership.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &new_admin);
+    }
+}

--- a/test-contracts/ownership-no-approval-invalidation-safe/Cargo.toml
+++ b/test-contracts/ownership-no-approval-invalidation-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-no-approval-invalidation-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-no-approval-invalidation-safe/src/lib.rs
+++ b/test-contracts/ownership-no-approval-invalidation-safe/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipNoApprovalInvalidationSafe;
+
+#[contractimpl]
+impl OwnershipNoApprovalInvalidationSafe {
+    /// ✅ Transfers ownership and clears existing allowances so that permissions
+    /// granted by the old owner cannot be exploited after the transfer.
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("owner"), &new_owner);
+        // ✅ invalidate all existing approvals
+        env.storage()
+            .instance()
+            .remove(&symbol_short!("allowance"));
+    }
+}

--- a/test-contracts/ownership-no-approval-invalidation-vulnerable/Cargo.toml
+++ b/test-contracts/ownership-no-approval-invalidation-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-no-approval-invalidation-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-no-approval-invalidation-vulnerable/src/lib.rs
+++ b/test-contracts/ownership-no-approval-invalidation-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipNoApprovalInvalidationVulnerable;
+
+#[contractimpl]
+impl OwnershipNoApprovalInvalidationVulnerable {
+    /// ❌ Transfers ownership but leaves existing allowances/approvals intact.
+    /// Permissions granted by the old owner remain valid after the transfer.
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        env.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("owner"), &new_owner);
+        // ❌ missing: clear allowances / approvals
+    }
+}

--- a/test-contracts/ownership-pending-not-cleared-safe/Cargo.toml
+++ b/test-contracts/ownership-pending-not-cleared-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-pending-not-cleared-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-pending-not-cleared-safe/src/lib.rs
+++ b/test-contracts/ownership-pending-not-cleared-safe/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipPendingNotClearedSafe;
+
+#[contractimpl]
+impl OwnershipPendingNotClearedSafe {
+    /// Initiates a two-step ownership transfer by storing the candidate.
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        let owner: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("owner"))
+            .unwrap();
+        owner.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pending"), &new_owner);
+    }
+
+    /// ✅ Writes the new owner AND removes the pending key atomically.
+    /// The pending authorization cannot be replayed.
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("pending"))
+            .unwrap();
+        new_owner.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("owner"), &new_owner);
+        env.storage()
+            .instance()
+            .remove(&symbol_short!("pending"));
+    }
+}

--- a/test-contracts/ownership-pending-not-cleared-vulnerable/Cargo.toml
+++ b/test-contracts/ownership-pending-not-cleared-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ownership-pending-not-cleared-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ownership-pending-not-cleared-vulnerable/src/lib.rs
+++ b/test-contracts/ownership-pending-not-cleared-vulnerable/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct OwnershipPendingNotClearedVulnerable;
+
+#[contractimpl]
+impl OwnershipPendingNotClearedVulnerable {
+    /// Initiates a two-step ownership transfer by storing the candidate.
+    pub fn transfer_ownership(env: Env, new_owner: Address) {
+        let owner: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("owner"))
+            .unwrap();
+        owner.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pending"), &new_owner);
+    }
+
+    /// ❌ Writes the new owner but never removes the pending key.
+    /// The same pending authorization can be replayed to transfer ownership again.
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("pending"))
+            .unwrap();
+        new_owner.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("owner"), &new_owner);
+        // ❌ missing: env.storage().instance().remove(&symbol_short!("pending"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks resolving issues #282, #283, #284, and #285.

---

## Issue #282 — `admin-zero-address` (High)

**Problem:** `set_admin` / `transfer_ownership` functions that accept an `Address` parameter without any validation allow callers to pass the zero/default Stellar address, permanently renouncing ownership with no recovery path.

**Detection:** Flags public functions named `set_admin`, `transfer_ownership`, etc. that accept an `Address` parameter but never call `new_admin.require_auth()`, compare the parameter, or assert on it.

**Files:**
- `crates/checks/src/admin_zero_address.rs`
- `test-contracts/admin-zero-address-vulnerable/`
- `test-contracts/admin-zero-address-safe/`

---

## Issue #283 — `admin-no-group-auth` (Low)

**Problem:** When more than 2 distinct `#[contractimpl]` functions each independently read the admin key from storage and call `require_auth` on it, the auth logic is duplicated. A future change must be replicated everywhere, making it error-prone.

**Detection:** Counts functions that call `require_auth` on a variable whose name contains `admin`/`owner`/`operator`. Flags when more than 2 such functions exist, suggesting a shared `assert_admin(env)` helper should be extracted.

**Files:**
- `crates/checks/src/admin_no_group_auth.rs`
- `test-contracts/admin-no-group-auth-vulnerable/`
- `test-contracts/admin-no-group-auth-safe/`

---

## Issue #284 — `ownership-pending-not-cleared` (Low)

**Problem:** In a two-step ownership transfer, after `accept_ownership` succeeds the pending-ownership storage key must be cleared. If it is not removed or overwritten, the same authorization can be replayed to transfer ownership again.

**Detection:** Flags `accept_ownership` / `accept_admin` / `claim_ownership` functions that write a new admin/owner key to storage but never `remove` or overwrite the pending key.

**Files:**
- `crates/checks/src/ownership_pending_not_cleared.rs`
- `test-contracts/ownership-pending-not-cleared-vulnerable/`
- `test-contracts/ownership-pending-not-cleared-safe/`

---

## Issue #285 — `ownership-no-approval-invalidation` (Medium)

**Problem:** When ownership is transferred, existing token approvals or operator permissions signed by the old owner should be invalidated. Leaving them intact allows the new owner or third parties to exploit lingering authorizations.

**Detection:** Flags `transfer_ownership` / `set_owner` / `set_admin` functions that write an owner/admin key to storage but do not `remove` or overwrite any allowance/approval key.

**Files:**
- `crates/checks/src/ownership_no_approval_invalidation.rs`
- `test-contracts/ownership-no-approval-invalidation-vulnerable/`
- `test-contracts/ownership-no-approval-invalidation-safe/`

---

## Changes

- 4 new check files in `crates/checks/src/`
- 8 new test contracts (4 vulnerable + 4 safe) in `test-contracts/`
- `crates/checks/src/lib.rs`: added `pub mod`, `pub use`, and `default_checks()` entries for all four checks

## Testing

Each check file includes unit tests covering the vulnerable and safe patterns. CI will run `cargo test --workspace`.

closes #282 
closes #283 
closes #284 
closes #285 