### PR TITLE
feat: add 4 new checks — admin-no-remove, admin-stored-unused, admin-eq-instead-of-auth, vec-map-tuple-convert

### DIFF
--- a/crates/checks/src/admin_eq_instead_of_auth.rs
+++ b/crates/checks/src/admin_eq_instead_of_auth.rs
@@ -1,0 +1,224 @@
+//! Admin address read from storage and compared with `==` instead of calling
+//! `require_auth` — bypasses host-level signature verification.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprBinary, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "admin-eq-instead-of-auth";
+
+pub struct AdminEqInsteadOfAuthCheck;
+
+impl Check for AdminEqInsteadOfAuthCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = AdminEqScan {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+                has_require_auth: false,
+                admin_locals: Vec::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct AdminEqScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    has_require_auth: bool,
+    /// Local variable names that were assigned from an admin/owner storage read.
+    admin_locals: Vec<String>,
+}
+
+fn is_admin_storage_get(expr: &Expr) -> bool {
+    // Matches: env.storage().*.get(&admin_key)
+    match expr {
+        Expr::MethodCall(m) if m.method == "get" || m.method == "get_unchecked" => {
+            if let Some(key) = m.args.first() {
+                return is_admin_key_expr(key);
+            }
+            false
+        }
+        Expr::MethodCall(m) if m.method == "unwrap" || m.method == "unwrap_or_default" || m.method == "unwrap_or" => {
+            is_admin_storage_get(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn is_admin_key_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Reference(r) => is_admin_key_expr(&r.expr),
+        Expr::Path(p) => {
+            let s = p
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+                .to_lowercase();
+            s.contains("admin") || s.contains("owner")
+        }
+        Expr::Macro(m) => {
+            let tokens = m.mac.tokens.to_string().to_lowercase();
+            tokens.contains("admin") || tokens.contains("owner")
+        }
+        Expr::Lit(l) => {
+            if let syn::Lit::Str(s) = &l.lit {
+                let v = s.value().to_lowercase();
+                v.contains("admin") || v.contains("owner")
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn expr_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(p) if p.path.segments.len() == 1 => {
+            Some(p.path.segments[0].ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+impl<'ast> Visit<'ast> for AdminEqScan<'_> {
+    fn visit_local(&mut self, i: &'ast syn::Local) {
+        // let admin = env.storage()...get(&admin_key).unwrap();
+        if let Some(init) = &i.init {
+            if is_admin_storage_get(&init.expr) {
+                if let syn::Pat::Ident(p) = &i.pat {
+                    self.admin_locals.push(p.ident.to_string());
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "require_auth" || i.method == "require_auth_for_args" {
+            self.has_require_auth = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if !self.has_require_auth
+            && matches!(i.op, syn::BinOp::Eq(_) | syn::BinOp::Ne(_))
+        {
+            let left_id = expr_ident(&i.left);
+            let right_id = expr_ident(&i.right);
+            let involves_admin = [&left_id, &right_id].iter().any(|id| {
+                if let Some(name) = id {
+                    let lower = name.to_lowercase();
+                    lower.contains("admin")
+                        || lower.contains("owner")
+                        || self.admin_locals.contains(name)
+                } else {
+                    false
+                }
+            });
+            if involves_admin {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Function `{}` compares an admin/owner address with `==` instead of \
+                         calling `require_auth()`. This bypasses host-level signature \
+                         verification and can be spoofed.",
+                        self.fn_name
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_admin_eq_comparison() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn protected(env: Env, caller: Address) {
+        let admin: Address = env.storage().instance().get(&symbol_short!("admin")).unwrap();
+        if caller == admin {
+            // do privileged thing
+        }
+    }
+}
+"#,
+        )?;
+        let hits = AdminEqInsteadOfAuthCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "protected");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_require_auth_called() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn protected(env: Env) {
+        let admin: Address = env.storage().instance().get(&symbol_short!("admin")).unwrap();
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminEqInsteadOfAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_admin_comparison() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn check(env: Env, amount: u32) {
+        if amount == 0 {
+            panic!("zero");
+        }
+    }
+}
+"#,
+        )?;
+        let hits = AdminEqInsteadOfAuthCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/admin_no_remove.rs
+++ b/crates/checks/src/admin_no_remove.rs
@@ -1,0 +1,148 @@
+//! Contracts that have an `add_admin` function but no `remove_admin` or
+//! `revoke_admin` function create an ever-growing admin set with no revocation
+//! path.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::File;
+
+const CHECK_NAME: &str = "admin-no-remove";
+
+pub struct AdminNoRemoveCheck;
+
+impl Check for AdminNoRemoveCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut add_fn: Option<(String, usize)> = None;
+        let mut has_remove = false;
+
+        for method in contractimpl_functions(file) {
+            let name = method.sig.ident.to_string();
+            let lower = name.to_lowercase();
+            if lower.contains("add_admin") || lower.contains("add_operator") {
+                if add_fn.is_none() {
+                    let line = method.sig.fn_token.span().start().line;
+                    add_fn = Some((name, line));
+                }
+            }
+            if lower.contains("remove_admin")
+                || lower.contains("revoke_admin")
+                || lower.contains("remove_operator")
+                || lower.contains("revoke_operator")
+            {
+                has_remove = true;
+            }
+        }
+
+        if let Some((fn_name, line)) = add_fn {
+            if !has_remove {
+                return vec![Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Medium,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` adds an admin but no `remove_admin` or \
+                         `revoke_admin` function exists. A compromised admin key can never \
+                         be revoked."
+                    ),
+                }];
+            }
+        }
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_add_admin_without_remove() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn add_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoRemoveCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].function_name, "add_admin");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_remove_admin_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn add_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+    }
+    pub fn remove_admin(env: Env, admin: Address) {
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoRemoveCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_revoke_admin_present() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn add_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+    }
+    pub fn revoke_admin(env: Env, admin: Address) {
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminNoRemoveCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_contract_without_add_admin() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env) {}
+}
+"#,
+        )?;
+        let hits = AdminNoRemoveCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/admin_stored_unused.rs
+++ b/crates/checks/src/admin_stored_unused.rs
@@ -1,0 +1,225 @@
+//! Admin address stored in contract storage but never used in a `require_auth`
+//! call — the stored admin is cosmetic and provides no actual access control.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "admin-stored-unused";
+
+pub struct AdminStoredUnusedCheck;
+
+impl Check for AdminStoredUnusedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut stores_admin = false;
+        let mut has_admin_require_auth = false;
+
+        for method in contractimpl_functions(file) {
+            let mut scan = AdminUsageScan::default();
+            scan.visit_block(&method.block);
+            if scan.stores_admin {
+                stores_admin = true;
+            }
+            if scan.admin_require_auth {
+                has_admin_require_auth = true;
+            }
+        }
+
+        if stores_admin && !has_admin_require_auth {
+            // Find the first function that stores admin to report the line.
+            for method in contractimpl_functions(file) {
+                let mut scan = AdminUsageScan::default();
+                scan.visit_block(&method.block);
+                if scan.stores_admin {
+                    let fn_name = method.sig.ident.to_string();
+                    let line = method.sig.fn_token.span().start().line;
+                    return vec![Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Function `{fn_name}` stores an admin/owner address but no \
+                             function in this contract calls `require_auth` on the stored \
+                             admin. The stored admin has no actual authority."
+                        ),
+                    }];
+                }
+            }
+        }
+        vec![]
+    }
+}
+
+/// Detects `.set(admin_key, ...)` writes and `.require_auth()` calls on
+/// variables whose name contains "admin" or "owner".
+#[derive(Default)]
+struct AdminUsageScan {
+    stores_admin: bool,
+    admin_require_auth: bool,
+}
+
+fn is_admin_key(expr: &Expr) -> bool {
+    match expr {
+        Expr::Reference(r) => is_admin_key(&r.expr),
+        Expr::Path(p) => {
+            let s = p
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+                .to_lowercase();
+            s.contains("admin") || s.contains("owner")
+        }
+        Expr::Macro(m) => {
+            let s = m
+                .mac
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+                .to_lowercase();
+            // symbol_short!("admin") etc.
+            s.contains("symbol") || {
+                m.mac
+                    .tokens
+                    .to_string()
+                    .to_lowercase()
+                    .contains("admin")
+                    || m.mac.tokens.to_string().to_lowercase().contains("owner")
+            }
+        }
+        Expr::Lit(l) => {
+            if let syn::Lit::Str(s) = &l.lit {
+                let v = s.value().to_lowercase();
+                v.contains("admin") || v.contains("owner")
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn receiver_ident(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+        Expr::MethodCall(m) => receiver_ident(&m.receiver),
+        Expr::Reference(r) => receiver_ident(&r.expr),
+        _ => String::new(),
+    }
+}
+
+impl<'ast> Visit<'ast> for AdminUsageScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+
+        // Detect storage().*.set(&admin_key, value)
+        if method == "set" && i.args.len() >= 2 {
+            if let Some(key_arg) = i.args.first() {
+                if is_admin_key(key_arg) {
+                    self.stores_admin = true;
+                }
+            }
+        }
+
+        // Detect admin_var.require_auth() where var name contains admin/owner
+        if method == "require_auth" || method == "require_auth_for_args" {
+            let recv = receiver_ident(&i.receiver).to_lowercase();
+            if recv.contains("admin") || recv.contains("owner") {
+                self.admin_require_auth = true;
+            }
+        }
+
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_admin_stored_but_never_used_in_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+    }
+    pub fn do_thing(env: Env) {
+        env.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminStoredUnusedCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_admin_used_in_require_auth() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+    }
+    pub fn protected(env: Env) {
+        let admin: Address = env.storage().instance().get(&symbol_short!("admin")).unwrap();
+        admin.require_auth();
+    }
+}
+"#,
+        )?;
+        let hits = AdminStoredUnusedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_contract_without_admin_storage() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn set_value(env: Env, v: u32) {
+        env.storage().instance().set(&symbol_short!("val"), &v);
+    }
+}
+"#,
+        )?;
+        let hits = AdminStoredUnusedCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -3,7 +3,10 @@
 pub mod address_cmp_instead_of_auth;
 pub mod address_from_str;
 pub mod admin;
+pub mod admin_eq_instead_of_auth;
 pub mod admin_no_group_auth;
+pub mod admin_no_remove;
+pub mod admin_stored_unused;
 pub mod admin_zero_address;
 pub mod admin_in_temp;
 pub mod admin_key_removal;
@@ -110,6 +113,7 @@ pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
 mod util;
 pub mod vec_get_unwrap;
+pub mod vec_map_tuple_convert;
 pub mod vec_mutate_in_loop;
 pub mod vec_push_in_loop;
 pub mod vesting_cliff;
@@ -123,7 +127,10 @@ pub mod zero_transfer_event;
 pub use address_cmp_instead_of_auth::AddressCmpInsteadOfAuthCheck;
 pub use address_from_str::AddressFromStrCheck;
 pub use admin::UnprotectedAdminCheck;
+pub use admin_eq_instead_of_auth::AdminEqInsteadOfAuthCheck;
 pub use admin_no_group_auth::AdminNoGroupAuthCheck;
+pub use admin_no_remove::AdminNoRemoveCheck;
+pub use admin_stored_unused::AdminStoredUnusedCheck;
 pub use admin_zero_address::AdminZeroAddressCheck;
 pub use admin_in_temp::AdminInTempCheck;
 pub use admin_key_removal::AdminKeyRemovalCheck;
@@ -228,6 +235,7 @@ pub use uncapped_slippage::UncappedSlippageCheck;
 pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vec_mutate_in_loop::VecMutateInLoopCheck;
+pub use vec_map_tuple_convert::VecMapTupleConvertCheck;
 pub use vec_push_in_loop::VecPushInLoopCheck;
 pub use vesting_cliff::VestingCliffCheck;
 pub use weak_randomness::WeakRandomnessCheck;
@@ -349,6 +357,10 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TierKeyCollisionCheck),
         Box::new(AdminZeroAddressCheck),
         Box::new(AdminNoGroupAuthCheck),
+        Box::new(AdminNoRemoveCheck),
+        Box::new(AdminStoredUnusedCheck),
+        Box::new(AdminEqInsteadOfAuthCheck),
+        Box::new(VecMapTupleConvertCheck),
         Box::new(OwnershipPendingNotClearedCheck),
         Box::new(OwnershipNoApprovalInvalidationCheck),
     ]

--- a/crates/checks/src/vec_map_tuple_convert.rs
+++ b/crates/checks/src/vec_map_tuple_convert.rs
@@ -1,0 +1,222 @@
+//! Unnecessary conversion of a Soroban `Map` to `Vec<(Symbol, Val)>` via
+//! `.to_vec()` or `.into_vec()` when direct `Map` operations should be used.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "vec-map-tuple-convert";
+
+pub struct VecMapTupleConvertCheck;
+
+impl Check for VecMapTupleConvertCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = MapToVecScan {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+                map_locals: Vec::new(),
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct MapToVecScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+    /// Local variable names that are typed or named as Map.
+    map_locals: Vec<String>,
+}
+
+fn is_map_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(p) => {
+            let s = p
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+                .to_lowercase();
+            s.contains("map")
+        }
+        Expr::MethodCall(m) => {
+            // map.clone(), map.get(...), etc.
+            is_map_expr(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn type_is_map(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(p) => {
+            if let Some(seg) = p.path.segments.last() {
+                seg.ident == "Map"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+impl<'ast> Visit<'ast> for MapToVecScan<'_> {
+    fn visit_local(&mut self, i: &'ast syn::Local) {
+        // Track `let map: Map<...> = ...` or `let map = ...` where name contains "map"
+        let is_map_typed = if let syn::Pat::Type(pt) = &i.pat {
+            type_is_map(&pt.ty)
+        } else {
+            false
+        };
+        let ident = match &i.pat {
+            syn::Pat::Ident(p) => Some(p.ident.to_string()),
+            syn::Pat::Type(pt) => {
+                if let syn::Pat::Ident(p) = &*pt.pat {
+                    Some(p.ident.to_string())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(name) = ident {
+            let lower = name.to_lowercase();
+            if is_map_typed || lower.contains("map") {
+                self.map_locals.push(name);
+            }
+        }
+        visit::visit_local(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+        if method == "to_vec" || method == "into_vec" {
+            // Check if receiver is a Map variable or Map-typed expression
+            let receiver_is_map = is_map_expr(&i.receiver) || {
+                if let Expr::Path(p) = &*i.receiver {
+                    if let Some(seg) = p.path.segments.last() {
+                        self.map_locals.contains(&seg.ident.to_string())
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+            if receiver_is_map {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Function `{}` calls `.{method}()` on a Map, converting it to a \
+                         Vec of tuples. Use direct Map operations (`.get()`, `.set()`, \
+                         `.keys()`) instead to avoid unnecessary compute overhead.",
+                        self.fn_name
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_map_to_vec() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Map, Symbol, Val, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, map: Map<Symbol, Val>) {
+        let v = map.to_vec();
+    }
+}
+"#,
+        )?;
+        let hits = VecMapTupleConvertCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].function_name, "process");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_map_into_vec() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Map, Symbol, Val, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, my_map: Map<Symbol, Val>) {
+        let v = my_map.into_vec();
+    }
+}
+"#,
+        )?;
+        let hits = VecMapTupleConvertCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_using_map_get() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Map, Symbol, Val, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, map: Map<Symbol, Val>, key: Symbol) {
+        let _ = map.get(key);
+    }
+}
+"#,
+        )?;
+        let hits = VecMapTupleConvertCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_vec_to_vec() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Vec, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, items: Vec<u32>) {
+        let v = items.to_vec();
+    }
+}
+"#,
+        )?;
+        let hits = VecMapTupleConvertCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/admin-eq-instead-of-auth-safe/Cargo.toml
+++ b/test-contracts/admin-eq-instead-of-auth-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-eq-instead-of-auth-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-eq-instead-of-auth-safe/src/lib.rs
+++ b/test-contracts/admin-eq-instead-of-auth-safe/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminEqInsteadOfAuthSafe;
+
+#[contractimpl]
+impl AdminEqInsteadOfAuthSafe {
+    pub fn init(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
+    }
+
+    /// ✅ Uses require_auth on the stored admin — proper host-level verification.
+    pub fn protected(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("val"), &1u32);
+    }
+}

--- a/test-contracts/admin-eq-instead-of-auth-vulnerable/Cargo.toml
+++ b/test-contracts/admin-eq-instead-of-auth-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-eq-instead-of-auth-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-eq-instead-of-auth-vulnerable/src/lib.rs
+++ b/test-contracts/admin-eq-instead-of-auth-vulnerable/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminEqInsteadOfAuthVulnerable;
+
+#[contractimpl]
+impl AdminEqInsteadOfAuthVulnerable {
+    pub fn init(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
+    }
+
+    /// ❌ Compares caller == admin with == instead of require_auth.
+    /// Bypasses host-level signature verification.
+    pub fn protected(env: Env, caller: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        if caller == admin {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("val"), &1u32);
+        }
+    }
+}

--- a/test-contracts/admin-no-remove-safe/Cargo.toml
+++ b/test-contracts/admin-no-remove-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-no-remove-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-no-remove-safe/src/lib.rs
+++ b/test-contracts/admin-no-remove-safe/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminNoRemoveSafe;
+
+#[contractimpl]
+impl AdminNoRemoveSafe {
+    /// ✅ Admins can be added and removed.
+    pub fn add_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &new_admin);
+    }
+
+    pub fn remove_admin(env: Env, admin: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        let _ = admin;
+        env.storage().instance().remove(&symbol_short!("admin"));
+    }
+}

--- a/test-contracts/admin-no-remove-vulnerable/Cargo.toml
+++ b/test-contracts/admin-no-remove-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-no-remove-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-no-remove-vulnerable/src/lib.rs
+++ b/test-contracts/admin-no-remove-vulnerable/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminNoRemoveVulnerable;
+
+#[contractimpl]
+impl AdminNoRemoveVulnerable {
+    /// ❌ Admins can be added but never removed — a compromised key is permanent.
+    pub fn add_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        current.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &new_admin);
+    }
+}

--- a/test-contracts/admin-stored-unused-safe/Cargo.toml
+++ b/test-contracts/admin-stored-unused-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-stored-unused-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-stored-unused-safe/src/lib.rs
+++ b/test-contracts/admin-stored-unused-safe/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminStoredUnusedSafe;
+
+#[contractimpl]
+impl AdminStoredUnusedSafe {
+    pub fn init(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
+    }
+
+    /// ✅ Admin is read from storage and used in require_auth.
+    pub fn do_thing(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("val"), &42u32);
+    }
+}

--- a/test-contracts/admin-stored-unused-vulnerable/Cargo.toml
+++ b/test-contracts/admin-stored-unused-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-admin-stored-unused-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/admin-stored-unused-vulnerable/src/lib.rs
+++ b/test-contracts/admin-stored-unused-vulnerable/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct AdminStoredUnusedVulnerable;
+
+#[contractimpl]
+impl AdminStoredUnusedVulnerable {
+    /// ❌ Admin is stored but never used in require_auth — cosmetic only.
+    pub fn init(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
+    }
+
+    pub fn do_thing(env: Env) {
+        // No admin check — anyone can call this
+        env.storage()
+            .instance()
+            .set(&symbol_short!("val"), &42u32);
+    }
+}

--- a/test-contracts/vec-map-tuple-convert-safe/Cargo.toml
+++ b/test-contracts/vec-map-tuple-convert-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-vec-map-tuple-convert-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/vec-map-tuple-convert-safe/src/lib.rs
+++ b/test-contracts/vec-map-tuple-convert-safe/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Val};
+
+#[contract]
+pub struct VecMapTupleConvertSafe;
+
+#[contractimpl]
+impl VecMapTupleConvertSafe {
+    /// ✅ Uses direct Map operations instead of converting to Vec.
+    pub fn process(env: Env, map: Map<Symbol, Val>, key: Symbol) -> Option<Val> {
+        map.get(key)
+    }
+}

--- a/test-contracts/vec-map-tuple-convert-vulnerable/Cargo.toml
+++ b/test-contracts/vec-map-tuple-convert-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-vec-map-tuple-convert-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/vec-map-tuple-convert-vulnerable/src/lib.rs
+++ b/test-contracts/vec-map-tuple-convert-vulnerable/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Val};
+
+#[contract]
+pub struct VecMapTupleConvertVulnerable;
+
+#[contractimpl]
+impl VecMapTupleConvertVulnerable {
+    /// ❌ Converts Map to Vec<(Symbol, Val)> unnecessarily — wastes compute.
+    pub fn process(env: Env, map: Map<Symbol, Val>) -> u32 {
+        let v = map.to_vec();
+        v.len()
+    }
+}


### PR DESCRIPTION
## Summary

Implements four new static analysis checks requested in issues #269, #286, #287, and #288.

---

### #286 — `admin-no-remove` (Severity: Medium)

**Problem:** Contracts that expose an `add_admin` function with no corresponding `remove_admin` or `revoke_admin` create an ever-growing admin set. A compromised admin key can never be revoked.

**Detection:** Flags `#[contractimpl]` contracts that have an `add_admin` (or `add_operator`) function but no `remove_admin` / `revoke_admin` counterpart.

**Files:**
- `crates/checks/src/admin_no_remove.rs`
- `test-contracts/admin-no-remove-vulnerable/`
- `test-contracts/admin-no-remove-safe/`

---

### #287 — `admin-stored-unused` (Severity: High)

**Problem:** If a contract stores an admin address via `storage().set(&admin_key, ...)` but no function ever calls `require_auth()` on the stored value, the admin is cosmetic — it provides no actual access control.

**Detection:** Flags files where an admin/owner key is written to storage but the stored value is never passed to `require_auth` or `require_auth_for_args`.

**Files:**
- `crates/checks/src/admin_stored_unused.rs`
- `test-contracts/admin-stored-unused-vulnerable/`
- `test-contracts/admin-stored-unused-safe/`

---

### #288 — `admin-eq-instead-of-auth` (Severity: High)

**Problem:** Reading an admin address from storage and comparing a parameter against it with `==` bypasses Soroban's host-level signature verification. An attacker can pass any address that matches the stored value without proving they control it.

**Detection:** Flags `==` / `!=` comparisons involving a variable read from an admin/owner storage key where `require_auth` is not called.

**Files:**
- `crates/checks/src/admin_eq_instead_of_auth.rs`
- `test-contracts/admin-eq-instead-of-auth-vulnerable/`
- `test-contracts/admin-eq-instead-of-auth-safe/`

---

### #269 — `vec-map-tuple-convert` (Severity: Low)

**Problem:** Calling `.to_vec()` or `.into_vec()` on a Soroban `Map` converts it to `Vec<(Symbol, Val)>` tuples, wasting compute budget. Direct `Map` operations (`.get()`, `.set()`, `.keys()`) should be used instead.

**Detection:** Flags `.to_vec()` / `.into_vec()` calls on variables typed as `Map` or whose name contains "map".

**Files:**
- `crates/checks/src/vec_map_tuple_convert.rs`
- `test-contracts/vec-map-tuple-convert-vulnerable/`
- `test-contracts/vec-map-tuple-convert-safe/`

---

## What was tested

Each check includes inline unit tests covering:
- Vulnerable pattern → finding reported with correct severity
- Safe pattern → no findings
- Edge cases (no admin, non-admin comparisons, etc.)

All 4 checks are registered in `default_checks()` in `crates/checks/src/lib.rs`.

Closes #286, closes #287, closes #288, closes #269