### PR TITLE
feat: add catch-unwind detector (#247)

### DIFF
--- a/crates/checks/src/catch_unwind.rs
+++ b/crates/checks/src/catch_unwind.rs
@@ -1,0 +1,196 @@
+//! Detects `std::panic::catch_unwind` usage in Soroban contracts.
+//!
+//! `catch_unwind` is undefined behavior in WASM targets and will abort the transaction.
+//! It should never be used in Soroban contracts.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, File};
+
+const CHECK_NAME: &str = "catch-unwind";
+
+/// Flags `std::panic::catch_unwind`, `::std::panic::catch_unwind`, and `catch_unwind`
+/// function calls inside `#[contractimpl]` function bodies.
+pub struct CatchUnwindCheck;
+
+impl Check for CatchUnwindCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = CatchUnwindScan {
+                fn_name,
+                out: &mut out,
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct CatchUnwindScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for CatchUnwindScan<'_> {
+    fn visit_expr_call(&mut self, i: &'ast ExprCall) {
+        if is_catch_unwind_call(i) {
+            let line = i.span().start().line;
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Method `{}` uses `catch_unwind`. This is undefined behavior in WASM \
+                     targets and will abort the transaction. It should never be used in \
+                     Soroban contracts.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+fn is_catch_unwind_call(call: &ExprCall) -> bool {
+    let Expr::Path(p) = &*call.func else {
+        return false;
+    };
+
+    let segs = &p.path.segments;
+
+    // Match: catch_unwind
+    if segs.len() == 1 && segs[0].ident == "catch_unwind" {
+        return true;
+    }
+
+    // Match: std::panic::catch_unwind
+    if segs.len() == 3
+        && segs[0].ident == "std"
+        && segs[1].ident == "panic"
+        && segs[2].ident == "catch_unwind"
+    {
+        return true;
+    }
+
+    // Match: ::std::panic::catch_unwind
+    if segs.len() == 3
+        && segs[0].ident == "std"
+        && segs[1].ident == "panic"
+        && segs[2].ident == "catch_unwind"
+    {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn detects_catch_unwind_direct() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn risky_op(env: Env) {
+        let _ = catch_unwind(|| {
+            // Some code
+        });
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = CatchUnwindCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+        assert_eq!(findings[0].function_name, "risky_op");
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_std_panic_catch_unwind() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn risky_op(env: Env) {
+        let result = std::panic::catch_unwind(|| {
+            // Some code
+        });
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = CatchUnwindCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+        assert_eq!(findings[0].function_name, "risky_op");
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_absolute_std_panic_catch_unwind() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn risky_op(env: Env) {
+        ::std::panic::catch_unwind(|| {});
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = CatchUnwindCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+        assert_eq!(findings[0].severity, Severity::High);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_outside_contractimpl() -> Result<(), syn::Error> {
+        let code = r#"
+pub fn regular_fn() {
+    let _ = catch_unwind(|| {});
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = CatchUnwindCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_unrelated_calls() -> Result<(), syn::Error> {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn safe_op(env: Env) {
+        let _ = some_function(|| {});
+    }
+}
+        "#;
+        let file = parse_file(code)?;
+        let check = CatchUnwindCheck;
+        let findings = check.run(&file, code);
+        assert_eq!(findings.len(), 0);
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -20,6 +20,7 @@ pub mod balance_negative_check;
 pub mod balance_overflow;
 pub mod broken_pause;
 pub mod bump_to_ttl;
+pub mod catch_unwind;
 pub mod burn_auth;
 pub mod bytes_not_bytesn;
 pub mod bytes_oversized;
@@ -140,6 +141,7 @@ pub use balance_negative_check::BalanceNegativeCheck;
 pub use balance_overflow::BalanceOverflowCheck;
 pub use broken_pause::BrokenPauseCheck;
 pub use bump_to_ttl::BumpToTtlCheck;
+pub use catch_unwind::CatchUnwindCheck;
 pub use burn_auth::BurnAuthCheck;
 pub use bytes_not_bytesn::BytesNotBytesNCheck;
 pub use bytes_oversized::BytesOversizedCheck;
@@ -281,6 +283,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(UnsafeStoragePatternsCheck),
         Box::new(InstanceDomainMixingCheck),
         Box::new(PanicUsageCheck),
+        Box::new(CatchUnwindCheck),
         Box::new(PartialWriteOnErrorCheck),
         Box::new(MissingContracttypeCheck),
         Box::new(UnboundedStorageCheck),

--- a/test-contracts/catch_unwind-safe/Cargo.toml
+++ b/test-contracts/catch_unwind-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-catch-unwind-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/catch_unwind-safe/src/lib.rs
+++ b/test-contracts/catch_unwind-safe/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct CatchUnwindSafe;
+
+#[derive(Debug)]
+pub enum Error {
+    OperationFailed,
+    InvalidInput,
+}
+
+#[contractimpl]
+impl CatchUnwindSafe {
+    /// Uses Result return type instead of catch_unwind — safe approach.
+    pub fn safe_operation(env: Env) -> Result<bool, Error> {
+        // Perform operation that returns Result
+        validate_input()?;
+        Ok(true)
+    }
+
+    /// Explicitly handles errors with Result instead of relying on panic handling.
+    pub fn safe_with_result(env: Env) -> Result<u32, Error> {
+        // Use Result for error handling instead of catch_unwind
+        let value = compute_safely()?;
+        Ok(value)
+    }
+
+    /// Uses conditional logic instead of relying on panic safety — safe approach.
+    pub fn safe_conditional(env: Env) -> Result<(), Error> {
+        if !is_valid() {
+            return Err(Error::InvalidInput);
+        }
+        Ok(())
+    }
+
+    /// Properly propagates errors using ? operator instead of catching panics.
+    pub fn safe_with_propagation(env: Env) -> Result<String, Error> {
+        let result = perform_operation()?;
+        Ok(result)
+    }
+}
+
+fn validate_input() -> Result<(), Error> {
+    Ok(())
+}
+
+fn compute_safely() -> Result<u32, Error> {
+    Ok(42)
+}
+
+fn is_valid() -> bool {
+    true
+}
+
+fn perform_operation() -> Result<String, Error> {
+    Ok("success".to_string())
+}

--- a/test-contracts/catch_unwind-vulnerable/Cargo.toml
+++ b/test-contracts/catch_unwind-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-catch-unwind-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/catch_unwind-vulnerable/src/lib.rs
+++ b/test-contracts/catch_unwind-vulnerable/src/lib.rs
@@ -1,0 +1,47 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct CatchUnwindVulnerable;
+
+#[contractimpl]
+impl CatchUnwindVulnerable {
+    /// Uses catch_unwind directly — should trigger `catch-unwind` (High).
+    /// catch_unwind is undefined behavior in WASM targets and will abort the transaction.
+    pub fn risky_with_direct(env: Env) -> bool {
+        let result = catch_unwind(|| {
+            // Some code that might panic
+            true
+        });
+        result.is_ok()
+    }
+
+    /// Uses std::panic::catch_unwind — should trigger `catch-unwind` (High).
+    pub fn risky_with_std_panic(env: Env) -> bool {
+        let result = std::panic::catch_unwind(|| {
+            // Some code that might panic
+            42
+        });
+        result.is_ok()
+    }
+
+    /// Uses absolute path ::std::panic::catch_unwind — should trigger `catch-unwind` (High).
+    pub fn risky_with_absolute_path(env: Env) -> bool {
+        let result = ::std::panic::catch_unwind(|| {
+            // Some code that might panic
+            "hello"
+        });
+        result.is_ok()
+    }
+
+    /// Multiple catch_unwind calls — should trigger multiple findings (High).
+    pub fn multiple_catches(env: Env) {
+        let _ = catch_unwind(|| {
+            // First catch
+        });
+
+        let _ = std::panic::catch_unwind(|| {
+            // Second catch
+        });
+    }
+}


### PR DESCRIPTION
  - Implement CatchUnwindCheck in crates/checks/src/catch_unwind.rs
  - Flags std::panic::catch_unwind, ::std::panic::catch_unwind, and bare catch_unwind inside #[contractimpl] functions (Severity: High)
  - Register check in default_checks()
  - Add test-contracts/catch_unwind-vulnerable and catch_unwind-safe
  - Add 5 unit tests
  - gh pr create \
    --repo Veritas-Vaults-Network/Soroban-Guard-Core \
    --title "feat: add catch-unwind detector (#247)" \
    --body "## Summary
  Closes #247
  
  Adds a static analysis check that flags \`std::panic::catch_unwind\` usage inside \`#[contractimpl]\` functions. This is undefined behavior in WASM targets and will abort the
  Soroban transaction.
  
  ## Changes
  - \`crates/checks/src/catch_unwind.rs\` — new \`CatchUnwindCheck\` (Severity: High)
  - \`crates/checks/src/lib.rs\` — registered in \`default_checks()\`
  - \`test-contracts/catch_unwind-vulnerable/\` — triggers the check
  - \`test-contracts/catch_unwind-safe/\` — passes the check
  
  ## Test coverage
  5 unit tests: bare \`catch_unwind\`, \`std::panic::catch_unwind\`, \`::std::panic::catch_unwind\`, outside-contractimpl (no flag), unrelated calls (no flag)." \
    --base main \
    --head debbieAmoni:feat/catch-unwind-check
  
  Or just open the PR manually at:
  https://github.com/Veritas-Vaults-Network/Soroban-Guard-Core/compare/main...debbieAmoni:feat/catch-unwind-check
  
  
