### PR TITLE
feat(checks): add result-err-ignored check (#245)

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -73,6 +73,7 @@ pub mod persistent_for_temp;
 pub mod persistent_overwrite;
 pub mod redundant_auth_args;
 pub mod reentrancy;
+pub mod result_err_ignored;
 pub mod renounce_no_backup;
 pub mod runtime_symbol;
 pub mod secp256k1_unchecked;
@@ -194,6 +195,7 @@ pub use persistent_for_temp::PersistentForTempCheck;
 pub use persistent_overwrite::PersistentOverwriteCheck;
 pub use redundant_auth_args::RedundantAuthArgsCheck;
 pub use reentrancy::ReentrancyCheck;
+pub use result_err_ignored::ResultErrIgnoredCheck;
 pub use renounce_no_backup::RenounceNoBackupCheck;
 pub use runtime_symbol::RuntimeSymbolCheck;
 pub use secp256k1_unchecked::Secp256k1UncheckedCheck;
@@ -295,6 +297,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(FloatArithmeticCheck),
         Box::new(WeakRandomnessCheck),
         Box::new(ReentrancyCheck),
+        Box::new(ResultErrIgnoredCheck),
         Box::new(TokenTransferUncheckedCheck),
         Box::new(ContracterrorAttrCheck),
         Box::new(TokenBurnAuthCheck),

--- a/crates/checks/src/result_err_ignored.rs
+++ b/crates/checks/src/result_err_ignored.rs
@@ -1,0 +1,171 @@
+//! Flags `if let Ok(_) = expr { ... }` without an `else` branch in `#[contractimpl]` functions.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprIf, File, Pat, PatTupleStruct};
+
+const CHECK_NAME: &str = "result-err-ignored";
+
+pub struct ResultErrIgnoredCheck;
+
+impl Check for ResultErrIgnoredCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = Visitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+/// Returns true if the pattern is `Ok(...)`.
+fn pat_is_ok(pat: &Pat) -> bool {
+    if let Pat::TupleStruct(PatTupleStruct { path, .. }) = pat {
+        path.segments.last().is_some_and(|s| s.ident == "Ok")
+    } else {
+        false
+    }
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for Visitor<'_> {
+    fn visit_expr_if(&mut self, i: &'ast ExprIf) {
+        // Check for `if let Ok(...) = expr` with no else branch
+        if i.else_branch.is_none() {
+            if let syn::Expr::Let(expr_let) = &*i.cond {
+                if pat_is_ok(&expr_let.pat) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "`if let Ok(...)` in `{}` has no `else` branch — errors are \
+                             silently ignored. Use `match`, `?`, or an explicit `else` to \
+                             handle the `Err` variant.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        // Recurse into nested expressions
+        visit::visit_expr_if(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).expect("parse");
+        ResultErrIgnoredCheck.run(&file, src)
+    }
+
+    #[test]
+    fn flags_if_let_ok_no_else() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env) {
+        if let Ok(val) = some_op() {
+            env.storage().instance().set(&"k", &val);
+        }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "transfer");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+    }
+
+    #[test]
+    fn passes_if_let_ok_with_else() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env) {
+        if let Ok(val) = some_op() {
+            env.storage().instance().set(&"k", &val);
+        } else {
+            panic!("error");
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_match_on_result() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn transfer(env: Env) {
+        match some_op() {
+            Ok(val) => { let _ = val; }
+            Err(_) => {}
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() {
+        let hits = run(r#"
+pub struct C;
+impl C {
+    pub fn helper() {
+        if let Ok(val) = some_op() {
+            let _ = val;
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_multiple_occurrences() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn foo(env: Env) {
+        if let Ok(a) = op1() { let _ = a; }
+        if let Ok(b) = op2() { let _ = b; }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 2);
+    }
+}

--- a/test-contracts/result_err_ignored-safe/Cargo.toml
+++ b/test-contracts/result_err_ignored-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-result-err-ignored-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/result_err_ignored-safe/src/lib.rs
+++ b/test-contracts/result_err_ignored-safe/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct SafeContract;
+
+const KEY: Symbol = symbol_short!("bal");
+
+#[contractimpl]
+impl SafeContract {
+    // ✅ Errors are handled explicitly via match — the Err arm is not ignored.
+    pub fn process(env: Env) {
+        match env.storage().instance().get::<Symbol, u32>(&KEY) {
+            Some(val) => {
+                env.storage().instance().set(&KEY, &(val + 1));
+            }
+            None => {
+                env.storage().instance().set(&KEY, &1u32);
+            }
+        }
+    }
+
+    // ✅ if let Ok with an explicit else branch is also acceptable.
+    pub fn process_with_else(env: Env) {
+        if let Some(val) = env.storage().instance().get::<Symbol, u32>(&KEY) {
+            env.storage().instance().set(&KEY, &(val + 1));
+        } else {
+            env.storage().instance().set(&KEY, &1u32);
+        }
+    }
+}

--- a/test-contracts/result_err_ignored-vulnerable/Cargo.toml
+++ b/test-contracts/result_err_ignored-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-result-err-ignored-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/result_err_ignored-vulnerable/src/lib.rs
+++ b/test-contracts/result_err_ignored-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+const KEY: Symbol = symbol_short!("bal");
+
+#[contractimpl]
+impl VulnerableContract {
+    // ❌ Error from get() is silently ignored — if the key is missing the
+    //    branch is simply skipped with no indication of failure.
+    pub fn process(env: Env) {
+        if let Ok(val) = env.storage().instance().get::<Symbol, u32>(&KEY) {
+            env.storage().instance().set(&KEY, &(val + 1));
+        }
+    }
+}


### PR DESCRIPTION
  Flag if let Ok(...) = expr { ... } without an else branch inside
  #[contractimpl] functions. Silently swallowed errors can hide
  cross-contract failures or arithmetic overflows.

  - Severity: Low
  - New check: crates/checks/src/result_err_ignored.rs
  - Registered in default_checks()
  - Test contracts: result_err_ignored-{vulnerable,safe}/
  - 
  gh pr create \
    --title "feat(checks): add result-err-ignored check (#245)" \
    --body "## Summary
  Implements #245.
  
  Flags \`if let Ok(...) = expr { ... }\` patterns inside \`#[contractimpl]\` functions that have no \`else\` block. Silently swallowed
  errors can hide cross-contract call failures or arithmetic overflows.
  
  ## Changes
  - \`crates/checks/src/result_err_ignored.rs\` — new \`ResultErrIgnoredCheck\` (Severity: Low)
  - \`crates/checks/src/lib.rs\` — registered in \`default_checks()\`
  - \`test-contracts/result_err_ignored-vulnerable/\` — triggers the check
  - \`test-contracts/result_err_ignored-safe/\` — passes the check
  
  ## Tests
  5 unit tests covering: flag no-else, pass with-else, pass match, ignore non-contractimpl, flag multiple occurrences." \
    --base main
closes #245 