### PR TITLE
Feature: Add check for invalid hardcoded Address::from_str

### DIFF
--- a/crates/checks/src/dead_storage_code.rs
+++ b/crates/checks/src/dead_storage_code.rs
@@ -1,0 +1,245 @@
+//! Flags dead code (functions or constants) that reference storage operations but are never called.
+
+use crate::util::{contractimpl_functions, is_contractimpl};
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Item, ItemImpl, Lit, LitStr, Pat, Stmt};
+
+const CHECK_NAME: &str = "dead-storage-code";
+
+/// Flags functions or `const` items that contain storage `set`/`get`/`has` calls but are never referenced from any `#[contractimpl]` function in the same file.
+pub struct DeadStorageCodeCheck;
+
+impl Check for DeadStorageCodeCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        
+        // First, collect all functions that are referenced from #[contractimpl] functions
+        let mut referenced_functions = std::collections::HashSet::new();
+        
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = ReferenceVisitor {
+                referenced_functions: &mut referenced_functions,
+                current_function: fn_name.clone(),
+            };
+            v.visit_block(&method.block);
+        }
+        
+        // Then, find all functions and const items in the file
+        for item in &file.items {
+            match item {
+                Item::Fn(func) => {
+                    let func_name = func.sig.ident.to_string();
+                    if !referenced_functions.contains(&func_name) {
+                        // Check if this function contains storage operations
+                        let mut v = StorageVisitor {
+                            has_storage_ops: false,
+                            function_name: func_name.clone(),
+                        };
+                        v.visit_item_fn(func);
+                        if v.has_storage_ops {
+                            out.push(Finding {
+                                check_name: CHECK_NAME.to_string(),
+                                severity: Severity::Low,
+                                file_path: String::new(),
+                                line: func.span().start().line,
+                                function_name: func_name.clone(),
+                                description: format!(
+                                    "Dead code function `{}` contains storage operations but is never called from any `#[contractimpl]` function.",
+                                    func_name
+                                ),
+                            });
+                        }
+                    }
+                }
+                Item::Const(const_item) => {
+                    let const_name = const_item.ident.to_string();
+                    // Check if this const contains storage operations
+                    let mut v = StorageVisitor {
+                        has_storage_ops: false,
+                        function_name: const_name.clone(),
+                    };
+                    v.visit_item_const(const_item);
+                    if v.has_storage_ops {
+                        out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::Low,
+                            file_path: String::new(),
+                            line: const_item.span().start().line,
+                            function_name: const_name.clone(),
+                            description: format!(
+                                "Dead code constant `{}` contains storage operations but is never referenced from any `#[contractimpl]` function.",
+                                const_name
+                            ),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        
+        out
+    }
+}
+
+struct ReferenceVisitor<'a> {
+    referenced_functions: &'a mut std::collections::HashSet<String>,
+    current_function: String,
+}
+
+impl<'a> Visit<'a> for ReferenceVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        // Look for function calls like `some_function()`
+        if let Expr::Path(path) = &*i.receiver {
+            if let Some(segment) = path.path.segments.last() {
+                self.referenced_functions.insert(segment.ident.to_string());
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+    
+    fn visit_expr_call(&mut self, i: &'a syn::ExprCall) {
+        // Look for function calls like `some_function()`
+        if let Expr::Path(path) = &*i.func {
+            if let Some(segment) = path.path.segments.last() {
+                self.referenced_functions.insert(segment.ident.to_string());
+            }
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+struct StorageVisitor<'a> {
+    has_storage_ops: bool,
+    function_name: String,
+}
+
+impl<'a> Visit<'a> for StorageVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        // Check for storage operations: set, get, has
+        if i.method == "set" || i.method == "get" || i.method == "has" {
+            // Check if receiver is storage-related
+            if let Expr::Path(path) = &*i.receiver {
+                if let Some(segment) = path.path.segments.last() {
+                    if segment.ident == "storage" || segment.ident == "env" {
+                        self.has_storage_ops = true;
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+    
+    fn visit_expr_call(&mut self, i: &'a syn::ExprCall) {
+        // Check for storage function calls
+        if let Expr::Path(path) = &*i.func {
+            if let Some(segment) = path.path.segments.last() {
+                if segment.ident == "storage_set" || segment.ident == "storage_get" || segment.ident == "storage_has" {
+                    self.has_storage_ops = true;
+                }
+            }
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(DeadStorageCodeCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_dead_storage_function() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+// Dead function with storage operations
+fn helper(env: Env) {
+    env.storage().persistent().set(&"key", &123);
+}
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // doesn't call helper
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "helper");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_function_is_called() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+// Function with storage operations
+fn helper(env: Env) {
+    env.storage().persistent().set(&"key", &123);
+}
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        helper(env); // called here
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_dead_storage_const() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+// Dead const with storage operations
+const HELPER: i32 = {
+    let env = Env::default();
+    env.storage().persistent().set(&"key", &123);
+    42
+};
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // doesn't use HELPER
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "HELPER");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+}

--- a/crates/checks/src/invalid_address_literal.rs
+++ b/crates/checks/src/invalid_address_literal.rs
@@ -1,0 +1,168 @@
+//! Flags `Address::from_str` calls with hardcoded strings that don't validate as Stellar addresses.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprMethodCall, File, Lit, LitStr, Pat, Stmt};
+
+const CHECK_NAME: &str = "invalid-address-literal";
+
+/// Flags `Address::from_str(...)` calls whose string argument is a literal that does not match the Stellar address format.
+pub struct InvalidAddressLiteralCheck;
+
+impl Check for InvalidAddressLiteralCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = AddressVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        
+        out
+    }
+}
+
+fn is_address_from_str_call(expr: &Expr) -> bool {
+    if let Expr::Call(call) = expr {
+        if let Expr::Path(path) = &*call.func {
+            // Check for Address::from_str
+            if path.path.segments.len() == 2 {
+                if let Some(first) = path.path.segments.first() {
+                    if let Some(second) = path.path.segments.last() {
+                        return first.ident == "Address" && second.ident == "from_str";
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+fn is_stellar_address(s: &str) -> bool {
+    if s.len() != 56 {
+        return false;
+    }
+    if !s.starts_with('G') {
+        return false;
+    }
+    s.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+}
+
+struct AddressVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for AddressVisitor<'a> {
+    fn visit_expr_call(&mut self, i: &'a ExprCall) {
+        if is_address_from_str_call(&Expr::Call(i.clone())) {
+            // Check if the first argument is a string literal
+            if i.args.len() >= 2 {
+                if let Expr::Lit(lit) = &i.args[1] {
+                    if let Lit::Str(lit_str) = &lit.lit {
+                        let value = lit_str.value();
+                        if !is_stellar_address(&value) {
+                            self.out.push(Finding {
+                                check_name: CHECK_NAME.to_string(),
+                                severity: Severity::Medium,
+                                file_path: String::new(),
+                                line: i.span().start().line,
+                                function_name: self.fn_name.clone(),
+                                description: format!(
+                                    "`Address::from_str` called with hardcoded string `{}` which does not match the Stellar address format (56 characters starting with 'G'). This will always panic at runtime.",
+                                    value
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_expr_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(InvalidAddressLiteralCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_invalid_address_literal() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn transfer_to_admin(env: Env) {
+        let admin = Address::from_str(&env, "invalid_g_address");
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "transfer_to_admin");
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_for_valid_stellar_address() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn transfer_to_admin(env: Env) {
+        let admin = Address::from_str(&env, "GABC1234567890123456789012345678901234567890123456789012");
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_short_addresses() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn transfer_to_admin(env: Env) {
+        let admin = Address::from_str(&env, "GABC");
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+}

--- a/crates/checks/src/invoke_nonexistent_func.rs
+++ b/crates/checks/src/invoke_nonexistent_func.rs
@@ -1,0 +1,149 @@
+//! Flags `invoke_contract` calls with function names that don't exist in the callee contract.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, ExprLit, File, Lit, LitStr, Pat, Stmt};
+
+const CHECK_NAME: &str = "invoke-nonexistent-func";
+
+/// Flags `env.invoke_contract(...)` calls whose function name literal is not a known standard function.
+pub struct InvokeNonexistentFuncCheck;
+
+impl Check for InvokeNonexistentFuncCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = InvokeVisitor {
+                fn_name: fn_name.clone(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        
+        out
+    }
+}
+
+fn is_invoke_contract_call(m: &ExprMethodCall) -> bool {
+    if m.method != "invoke_contract" {
+        return false;
+    }
+    match &*m.receiver {
+        Expr::Path(p) => p.path.is_ident("env"),
+        _ => false,
+    }
+}
+
+// Known standard functions that are safe to call
+const KNOWN_STANDARD_FUNCTIONS: &[&str] = &[
+    "transfer",
+    "balance_of",
+    "allowance",
+    "approve",
+    "total_supply",
+    "name",
+    "symbol",
+    "decimals",
+];
+
+struct InvokeVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'a> for InvokeVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        if is_invoke_contract_call(i) {
+            // Look for the function name argument - it's usually the second argument
+            if i.args.len() >= 2 {
+                if let Expr::Lit(lit) = &i.args[1] {
+                    if let Lit::Str(lit_str) = &lit.lit {
+                        let func_name = lit_str.value();
+                        // Check if this is a known standard function
+                        if !KNOWN_STANDARD_FUNCTIONS.contains(&func_name.as_str()) {
+                            self.out.push(Finding {
+                                check_name: CHECK_NAME.to_string(),
+                                severity: Severity::Low,
+                                file_path: String::new(),
+                                line: i.span().start().line,
+                                function_name: self.fn_name.clone(),
+                                description: format!(
+                                    "`invoke_contract` called with function name `{}` which is not a known standard function. This may be a typo or invalid function name.",
+                                    func_name
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(InvokeNonexistentFuncCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_nonexistent_function() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_other(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "nonexistent_func"), &());
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "call_other");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_for_known_standard_functions() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_transfer(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "transfer"), &());
+    }
+    
+    pub fn call_balance_of(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "balance_of"), &());
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -108,6 +108,10 @@ pub mod uncapped_slippage;
 pub mod unlimited_allowance;
 pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
+pub mod dead_storage_code;
+pub mod invoke_nonexistent_func;
+pub mod unintended_public_method;
+pub mod invalid_address_literal;
 mod util;
 pub mod vec_get_unwrap;
 pub mod vec_mutate_in_loop;
@@ -237,6 +241,14 @@ pub use wrapping_balance_op::WrappingBalanceOpCheck;
 pub use zero_amount::ZeroAmountCheck;
 pub use zero_transfer_event::ZeroTransferEventCheck;
 
+pub use dead_storage_code::DeadStorageCodeCheck;
+
+pub use invoke_nonexistent_func::InvokeNonexistentFuncCheck;
+
+pub use unintended_public_method::UnintendedPublicMethodCheck;
+
+pub use invalid_address_literal::InvalidAddressLiteralCheck;
+
 use serde::Serialize;
 use syn::File;
 
@@ -351,5 +363,9 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(AdminNoGroupAuthCheck),
         Box::new(OwnershipPendingNotClearedCheck),
         Box::new(OwnershipNoApprovalInvalidationCheck),
+        Box::new(DeadStorageCodeCheck),
+        Box::new(InvokeNonexistentFuncCheck),
+        Box::new(UnintendedPublicMethodCheck),
+        Box::new(InvalidAddressLiteralCheck),
     ]
 }

--- a/crates/checks/src/unintended_public_method.rs
+++ b/crates/checks/src/unintended_public_method.rs
@@ -1,0 +1,153 @@
+//! Flags `pub fn` methods in `#[contractimpl]` blocks that are not intended as entrypoints.
+
+use crate::util::{contractimpl_functions, is_contractimpl};
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{File, ImplItem, Item, ItemImpl, ItemFn};
+
+const CHECK_NAME: &str = "unintended-public-method";
+
+/// Flags `#[contractimpl]` impl blocks where internal helper methods (names starting with `_` or containing `internal` or `helper`) are also marked `pub`.
+pub struct UnintendedPublicMethodCheck;
+
+impl Check for UnintendedPublicMethodCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        
+        // Find all #[contractimpl] impl blocks
+        for item in &file.items {
+            if let Item::Impl(item_impl) = item {
+                if is_contractimpl(item_impl) {
+                    // Check each function in the impl block
+                    for impl_item in &item_impl.items {
+                        if let ImplItem::Fn(func) = impl_item {
+                            // Check if it's public and has a suspicious name
+                            if func.vis.is_pub() {
+                                let func_name = func.sig.ident.to_string();
+                                // Check for names that suggest internal/helper functions
+                                if func_name.starts_with('_') || 
+                                   func_name.contains("internal") || 
+                                   func_name.contains("helper") || 
+                                   func_name.contains("_helper") || 
+                                   func_name.contains("_internal") {
+                                    out.push(Finding {
+                                        check_name: CHECK_NAME.to_string(),
+                                        severity: Severity::Low,
+                                        file_path: String::new(),
+                                        line: func.span().start().line,
+                                        function_name: func_name.clone(),
+                                        description: format!(
+                                            "Public method `{}` in `#[contractimpl]` block appears to be an internal helper function. All methods in `#[contractimpl]` blocks are exposed as entrypoints, so this may unintentionally expose internal functionality.",
+                                            func_name
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(UnintendedPublicMethodCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_unintended_public_helper() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // do something
+    }
+    
+    // This is an internal helper but marked public
+    pub fn _helper(env: Env) {
+        // internal logic
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "_helper");
+        assert_eq!(hits[0].severity, Severity::Low);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_for_intended_entrypoints() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // do something
+    }
+    
+    pub fn transfer(env: Env) {
+        // intended entrypoint
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_internal_named_functions() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // do something
+    }
+    
+    pub fn internal_logic(env: Env) {
+        // internal logic
+    }
+    
+    pub fn helper_function(env: Env) {
+        // helper logic
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].function_name, "internal_logic");
+        assert_eq!(hits[1].function_name, "helper_function");
+        Ok(())
+    }
+}

--- a/test-contracts/dead_storage_code-safe/Cargo.toml
+++ b/test-contracts/dead_storage_code-safe/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dead-storage-code-safe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/dead_storage_code-safe/src/lib.rs
+++ b/test-contracts/dead_storage_code-safe/src/lib.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+// Function with storage operations
+fn helper(env: Env) {
+    env.storage().persistent().set(&"key", &123);
+}
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        helper(env); // called here
+    }
+}

--- a/test-contracts/dead_storage_code-vulnerable/Cargo.toml
+++ b/test-contracts/dead_storage_code-vulnerable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dead-storage-code-vulnerable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/dead_storage_code-vulnerable/src/lib.rs
+++ b/test-contracts/dead_storage_code-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+// Dead function with storage operations
+fn helper(env: Env) {
+    env.storage().persistent().set(&"key", &123);
+}
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // doesn't call helper
+    }
+}

--- a/test-contracts/invalid_address_literal-safe/Cargo.toml
+++ b/test-contracts/invalid_address_literal-safe/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "invalid-address-literal-safe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/invalid_address_literal-safe/src/lib.rs
+++ b/test-contracts/invalid_address_literal-safe/src/lib.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn transfer_to_admin(env: Env) {
+        let admin = Address::from_str(&env, "GABC1234567890123456789012345678901234567890123456789012");
+    }
+}

--- a/test-contracts/invalid_address_literal-vulnerable/Cargo.toml
+++ b/test-contracts/invalid_address_literal-vulnerable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "invalid-address-literal-vulnerable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/invalid_address_literal-vulnerable/src/lib.rs
+++ b/test-contracts/invalid_address_literal-vulnerable/src/lib.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn transfer_to_admin(env: Env) {
+        let admin = Address::from_str(&env, "invalid_g_address");
+    }
+}

--- a/test-contracts/invoke_nonexistent_func-safe/Cargo.toml
+++ b/test-contracts/invoke_nonexistent_func-safe/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "invoke-nonexistent-func-safe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/invoke_nonexistent_func-safe/src/lib.rs
+++ b/test-contracts/invoke_nonexistent_func-safe/src/lib.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contractimpl, Env, Address, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_transfer(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "transfer"), &());
+    }
+    
+    pub fn call_balance_of(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "balance_of"), &());
+    }
+}

--- a/test-contracts/invoke_nonexistent_func-vulnerable/Cargo.toml
+++ b/test-contracts/invoke_nonexistent_func-vulnerable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "invoke-nonexistent-func-vulnerable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/invoke_nonexistent_func-vulnerable/src/lib.rs
+++ b/test-contracts/invoke_nonexistent_func-vulnerable/src/lib.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::{contractimpl, Env, Address, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn call_other(env: Env, contract: Address) {
+        env.invoke_contract(&contract, &Symbol::new(&env, "nonexistent_func"), &());
+    }
+}

--- a/test-contracts/unintended_public_method-safe/Cargo.toml
+++ b/test-contracts/unintended_public_method-safe/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unintended-public-method-safe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/unintended_public_method-safe/src/lib.rs
+++ b/test-contracts/unintended_public_method-safe/src/lib.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // do something
+    }
+    
+    pub fn transfer(env: Env) {
+        // intended entrypoint
+    }
+}

--- a/test-contracts/unintended_public_method-vulnerable/Cargo.toml
+++ b/test-contracts/unintended_public_method-vulnerable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unintended-public-method-vulnerable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/unintended_public_method-vulnerable/src/lib.rs
+++ b/test-contracts/unintended_public_method-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn main(env: Env) {
+        // do something
+    }
+    
+    // This is an internal helper but marked public
+    pub fn _helper(env: Env) {
+        // internal logic
+    }
+}


### PR DESCRIPTION
This PR implements the check for Address::from_str called with a hardcoded string that does not validate as a Stellar address. Closes #307