### PR TITLE
feat(checks): add storage key collision check

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -30,7 +30,6 @@ pub mod current_contract_unwrap;
 pub mod debug_entrypoint;
 pub mod decimals_mismatch;
 pub mod deploy_arg_auth;
-pub mod deploy_arg_auth;
 pub mod dynamic_symbol_key;
 pub mod env_in_struct;
 pub mod event_duplicate;
@@ -39,6 +38,7 @@ pub mod event_topic_runtime_string;
 pub mod extend_ttl_in_loop;
 pub mod float_arithmetic;
 pub mod hash_as_storage_key;
+pub mod auth_temp_storage;
 pub mod host_result_ignored;
 pub mod i128_to_u64;
 pub mod instance_domain_mixing;
@@ -49,6 +49,8 @@ pub mod instance_vec_growth;
 pub mod invoke_store_no_event;
 pub mod invoke_unchecked_cast;
 pub mod key_length_exceeded;
+pub mod loop_bound_no_cap;
+pub mod nested_loop_storage;
 pub mod key_prefix_collision;
 pub mod linear_whitelist_scan;
 pub mod lock_period_truncation;
@@ -105,6 +107,7 @@ pub mod unbounded_input_storage;
 pub mod unbounded_storage;
 pub mod uncapped_fee;
 pub mod uncapped_slippage;
+pub mod storage_key_collision;
 pub mod unlimited_allowance;
 pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
@@ -150,7 +153,6 @@ pub use current_contract_unwrap::CurrentContractUnwrapCheck;
 pub use debug_entrypoint::DebugEntrypointCheck;
 pub use decimals_mismatch::DecimalsMismatchCheck;
 pub use deploy_arg_auth::DeployArgAuthCheck;
-pub use deploy_arg_auth::DeployArgAuthCheck;
 pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use env_in_struct::EnvInStructCheck;
 pub use event_duplicate::EventDuplicateCheck;
@@ -159,6 +161,7 @@ pub use event_topic_runtime_string::EventTopicRuntimeStringCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
 pub use hash_as_storage_key::HashAsStorageKeyCheck;
+pub use auth_temp_storage::AuthTempStorageCheck;
 pub use host_result_ignored::HostResultIgnoredCheck;
 pub use i128_to_u64::I128ToU64Check;
 pub use instance_domain_mixing::InstanceDomainMixingCheck;
@@ -225,6 +228,7 @@ pub use unbounded_input_storage::UnboundedInputStorageCheck;
 pub use unbounded_storage::UnboundedStorageCheck;
 pub use uncapped_fee::UncappedFeeCheck;
 pub use uncapped_slippage::UncappedSlippageCheck;
+pub use storage_key_collision::StorageKeyCollisionCheck;
 pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
 pub use vec_mutate_in_loop::VecMutateInLoopCheck;
@@ -316,6 +320,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(DebugEntrypointCheck),
         Box::new(ExtendTtlInLoopCheck),
         Box::new(HashAsStorageKeyCheck),
+        Box::new(StorageKeyCollisionCheck),
         Box::new(UnauthAddressInStructCheck),
         Box::new(InvokeUncheckedCastCheck),
         Box::new(InvokeFuncFromInputCheck),

--- a/crates/checks/src/storage_key_collision.rs
+++ b/crates/checks/src/storage_key_collision.rs
@@ -1,0 +1,183 @@
+//! Flags potential storage key collisions where different keys have similar names that could lead to accidental overwrites.
+//!
+//! Storage keys should be unique and descriptive. Similar key names (e.g., "owner", "owner_addr", "owner_address")
+//! can lead to accidental overwrites if developers use the wrong key in different contexts.
+
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Lit, LitStr, Pat, Stmt};
+
+const CHECK_NAME: &str = "storage-key-collision";
+
+/// Flags storage keys that have similar names and may cause accidental overwrites.
+/// Detects patterns like "owner", "owner_addr", "owner_address" in the same contract.
+pub struct StorageKeyCollisionCheck;
+
+impl Check for StorageKeyCollisionCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        
+        // Collect all storage keys used in the contract
+        let mut keys = Vec::new();
+        
+        // Look for storage set calls with string literal keys
+        for item in &file.items {
+            match item {
+                syn::Item::Fn(func) => {
+                    let mut v = KeyVisitor {
+                        keys: &mut keys,
+                    };
+                    v.visit_item_fn(func);
+                }
+                _ => {}
+            }
+        }
+        
+        // Check for similar keys
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                let key1 = &keys[i].0;
+                let key2 = &keys[j].0;
+                
+                // Check for similarity: same prefix or suffix, or one is substring of another
+                if key1.len() >= 3 && key2.len() >= 3 {
+                    if key1.starts_with(key2) || key2.starts_with(key1) ||
+                       key1.contains(key2) || key2.contains(key1) ||
+                       (key1.len() > key2.len() && key1[..key2.len()].eq_ignore_ascii_case(key2)) ||
+                       (key2.len() > key1.len() && key2[..key1.len()].eq_ignore_ascii_case(key1)) {
+                        
+                        // Skip obvious cases like "owner" and "owner_addr"
+                        if !is_obvious_prefix_suffix(key1, key2) {
+                            out.push(Finding {
+                                check_name: CHECK_NAME.to_string(),
+                                severity: Severity::Medium,
+                                file_path: String::new(),
+                                line: keys[i].1,
+                                function_name: String::new(),
+                                description: format!("Potential storage key collision between '{}' and '{}'. Consider using more distinct key names to avoid accidental overwrites.", key1, key2),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        
+        out
+    }
+}
+
+fn is_obvious_prefix_suffix(key1: &str, key2: &str) -> bool {
+    // Check for common patterns like "owner" and "owner_addr"
+    let key1_lower = key1.to_lowercase();
+    let key2_lower = key2.to_lowercase();
+    
+    if key1_lower == key2_lower {
+        return true;
+    }
+    
+    // Check if one is a prefix of the other with common suffixes
+    if key1_lower.starts_with(&key2_lower) || key2_lower.starts_with(&key1_lower) {
+        let shorter = if key1_lower.len() < key2_lower.len() { &key1_lower } else { &key2_lower };
+        let longer = if key1_lower.len() >= key2_lower.len() { &key1_lower } else { &key2_lower };
+        
+        // Check for common suffixes
+        let suffixes = ["_addr", "_address", "_id", "_identifier", "_key", "_hash"];
+        for suffix in &suffixes {
+            if longer.ends_with(suffix) && longer[..longer.len() - suffix.len()] == *shorter {
+                return true;
+            }
+        }
+    }
+    
+    false
+}
+
+struct KeyVisitor<'a> {
+    keys: &'a mut Vec<(String, usize)>,
+}
+
+impl<'a> Visit<'a> for KeyVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &'a ExprMethodCall) {
+        // Look for storage set calls: env.storage().persistent().set(&"key", &val)
+        if i.method == "set" {
+            // Check if the first argument is a string literal
+            if let Some(arg) = i.args.first() {
+                if let syn::Expr::Reference(ref_ref) = arg {
+                    if let syn::Expr::Lit(lit) = &*ref_ref.expr {
+                        if let syn::Lit::Str(s) = &lit.lit {
+                            self.keys.push((s.value(), lit.span().start().line));
+                        }
+                    }
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(StorageKeyCollisionCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_similar_keys() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct C;
+
+const OWNER: soroban_sdk::Symbol = symbol_short!("owner");
+const OWNER_ADDR: soroban_sdk::Symbol = symbol_short!("owner_addr");
+
+#[contractimpl]
+impl C {
+    pub fn store_owner(env: Env, owner: soroban_sdk::Address) {
+        env.storage().persistent().set(&OWNER, &owner);
+        env.storage().persistent().set(&OWNER_ADDR, &owner);
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_keys_are_distinct() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct C;
+
+const OWNER: soroban_sdk::Symbol = symbol_short!("owner");
+const BALANCE: soroban_sdk::Symbol = symbol_short!("balance");
+
+#[contractimpl]
+impl C {
+    pub fn store_data(env: Env, owner: soroban_sdk::Address, balance: i128) {
+        env.storage().persistent().set(&OWNER, &owner);
+        env.storage().persistent().set(&BALANCE, &balance);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -114,3 +114,24 @@ Instance storage in Soroban has a TTL (time-to-live) and will expire if not peri
 - Checks the entire file, not per function.
 
 **Fixture:** `test-contracts/instance-ttl-vulnerable/`, `test-contracts/instance-ttl-safe/`
+
+---
+
+## `storage-key-collision` (Medium)
+
+**Status:** Phase 1
+
+**What it detects**
+
+Storage keys with similar names that could lead to accidental overwrites, such as "owner", "owner_addr", and "owner_address" in the same contract.
+
+**Why it matters**
+
+Similar key names can cause developers to accidentally use the wrong key when reading or writing storage, leading to data corruption or security vulnerabilities. Distinct key names help prevent these mistakes.
+
+**Limitations**
+
+- Only detects string literal keys, not symbol-based keys
+- May flag some legitimate cases where similar keys are intentionally used
+
+**Fixture:** `test-contracts/storage-key-collision-vulnerable/`, `test-contracts/storage-key-collision-safe/`

--- a/test-contracts/storage-key-collision-safe/Cargo.toml
+++ b/test-contracts/storage-key-collision-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "storage-key-collision-safe"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/storage-key-collision-safe/src/lib.rs
+++ b/test-contracts/storage-key-collision-safe/src/lib.rs
@@ -1,0 +1,20 @@
+//! Safe contract that does not trigger the storage-key-collision check.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct StorageKeyCollisionSafe;
+
+const OWNER: Symbol = symbol_short!("owner");
+const BALANCE: Symbol = symbol_short!("balance");
+const ALLOWANCE: Symbol = symbol_short!("allowance");
+
+#[contractimpl]
+impl StorageKeyCollisionSafe {
+    pub fn store_data(env: Env, owner: soroban_sdk::Address, balance: i128, allowance: i128) {
+        env.storage().persistent().set(&OWNER, &owner);
+        env.storage().persistent().set(&BALANCE, &balance);
+        env.storage().persistent().set(&ALLOWANCE, &allowance);
+    }
+}

--- a/test-contracts/storage-key-collision-vulnerable/Cargo.toml
+++ b/test-contracts/storage-key-collision-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "storage-key-collision-vulnerable"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/storage-key-collision-vulnerable/src/lib.rs
+++ b/test-contracts/storage-key-collision-vulnerable/src/lib.rs
@@ -1,0 +1,20 @@
+//! Vulnerable contract that triggers the storage-key-collision check.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct StorageKeyCollisionVulnerable;
+
+const OWNER: Symbol = symbol_short!("owner");
+const OWNER_ADDR: Symbol = symbol_short!("owner_addr");
+const OWNER_ADDRESS: Symbol = symbol_short!("owner_address");
+
+#[contractimpl]
+impl StorageKeyCollisionVulnerable {
+    pub fn store_owner(env: Env, owner: soroban_sdk::Address) {
+        env.storage().persistent().set(&OWNER, &owner);
+        env.storage().persistent().set(&OWNER_ADDR, &owner);
+        env.storage().persistent().set(&OWNER_ADDRESS, &owner);
+    }
+}


### PR DESCRIPTION
This PR adds the storage key collision check to prevent collisions when using similar keys in the contract storage. Closes #301