### PR TITLE
feat(checks): add nonce-in-temp check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ name = "soroban-guard-checks"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "quote",
  "serde",
  "syn",
 ]

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -63,6 +63,7 @@ pub mod negative_deposit;
 pub mod no_param_no_auth;
 pub mod no_std;
 pub mod nonce_increment_order;
+pub mod nonce_in_temp;
 pub mod overflow;
 pub mod ownership_immediate;
 pub mod ownership_no_event;
@@ -184,6 +185,7 @@ pub use nested_loop_storage::NestedLoopStorageCheck;
 pub use no_param_no_auth::NoParamNoAuthCheck;
 pub use no_std::NoStdCheck;
 pub use nonce_increment_order::NonceIncrementOrderCheck;
+pub use nonce_in_temp::NonceInTempCheck;
 pub use overflow::UncheckedArithmeticCheck;
 pub use ownership_immediate::OwnershipImmediateCheck;
 pub use ownership_no_event::OwnershipNoEventCheck;
@@ -342,6 +344,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(LinearWhitelistScanCheck),
         Box::new(UncappedSlippageCheck),
         Box::new(NonceIncrementOrderCheck),
+        Box::new(NonceInTempCheck),
         Box::new(BalanceNegativeCheck),
         Box::new(MulBeforeDivCheck),
         Box::new(TokenSharedStorageCheck),

--- a/crates/checks/src/nonce_in_temp.rs
+++ b/crates/checks/src/nonce_in_temp.rs
@@ -1,0 +1,218 @@
+//! Nonce/sequence stored in temporary storage — expires with TTL, enabling replay attacks.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "nonce-in-temp";
+
+pub struct NonceInTempCheck;
+
+impl Check for NonceInTempCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let mut v = NonceInTempVisitor {
+                fn_name: method.sig.ident.to_string(),
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_temporary(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            m.method == "temporary" || receiver_chain_contains_temporary(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_temporary(&f.base),
+        _ => false,
+    }
+}
+
+fn first_arg_str(m: &ExprMethodCall) -> Option<String> {
+    let arg = m.args.first()?;
+    Some(match arg {
+        Expr::Reference(r) => expr_to_string(&r.expr),
+        other => expr_to_string(other),
+    })
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    match expr {
+        Expr::Path(p) => p
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        Expr::Lit(l) => match &l.lit {
+            syn::Lit::Str(s) => s.value(),
+            _ => String::new(),
+        },
+        Expr::Macro(m) => m
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+fn key_looks_like_nonce(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    lower.contains("nonce")
+        || lower.contains("seqno")
+        || lower.contains("counter")
+        || lower.contains("sequence")
+}
+
+struct NonceInTempVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for NonceInTempVisitor<'_> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_temporary(&i.receiver) {
+            if let Some(key) = first_arg_str(i) {
+                if key_looks_like_nonce(&key) {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` stores a replay-protection key (`{}`) in \
+                             `env.storage().temporary()`. Temporary storage expires with TTL, \
+                             allowing replay of old transactions once the nonce is gone. Use \
+                             `persistent()` storage instead.",
+                            self.fn_name, key
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_nonce_key_in_temporary() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const NONCE: soroban_sdk::Symbol = symbol_short!("nonce");
+#[contractimpl]
+impl C {
+    pub fn execute(env: Env, n: u64) {
+        env.storage().temporary().set(&NONCE, &n);
+    }
+}
+"#,
+        )?;
+        let hits = NonceInTempCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert!(hits[0].description.contains("NONCE"));
+        Ok(())
+    }
+
+    #[test]
+    fn flags_sequence_key_in_temporary() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const SEQ: soroban_sdk::Symbol = symbol_short!("sequence");
+#[contractimpl]
+impl C {
+    pub fn submit(env: Env, s: u64) {
+        env.storage().temporary().set(&SEQ, &s);
+    }
+}
+"#,
+        )?;
+        let hits = NonceInTempCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_counter_key_in_temporary() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const COUNTER: soroban_sdk::Symbol = symbol_short!("counter");
+#[contractimpl]
+impl C {
+    pub fn inc(env: Env) {
+        env.storage().temporary().set(&COUNTER, &1u64);
+    }
+}
+"#,
+        )?;
+        let hits = NonceInTempCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_persistent_nonce() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const NONCE: soroban_sdk::Symbol = symbol_short!("nonce");
+#[contractimpl]
+impl C {
+    pub fn execute(env: Env, n: u64) {
+        env.storage().persistent().set(&NONCE, &n);
+    }
+}
+"#,
+        )?;
+        let hits = NonceInTempCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn no_finding_for_unrelated_temp_key() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+pub struct C;
+const CACHE: soroban_sdk::Symbol = symbol_short!("cache");
+#[contractimpl]
+impl C {
+    pub fn store(env: Env, v: u32) {
+        env.storage().temporary().set(&CACHE, &v);
+    }
+}
+"#,
+        )?;
+        let hits = NonceInTempCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/test-contracts/nonce_in_temp-safe/Cargo.toml
+++ b/test-contracts/nonce_in_temp-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-nonce-in-temp-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/nonce_in_temp-safe/src/lib.rs
+++ b/test-contracts/nonce_in_temp-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct NonceInTempSafe;
+
+const NONCE: Symbol = symbol_short!("nonce");
+
+#[contractimpl]
+impl NonceInTempSafe {
+    /// ✅ Nonce stored in persistent storage — survives TTL expiry, preventing replay attacks.
+    pub fn execute(env: Env, n: u64) {
+        let current: u64 = env.storage().persistent().get(&NONCE).unwrap_or(0);
+        assert!(n > current, "replay");
+        env.storage().persistent().set(&NONCE, &n);
+    }
+}

--- a/test-contracts/nonce_in_temp-vulnerable/Cargo.toml
+++ b/test-contracts/nonce_in_temp-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-nonce-in-temp-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/nonce_in_temp-vulnerable/src/lib.rs
+++ b/test-contracts/nonce_in_temp-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct NonceInTempVulnerable;
+
+const NONCE: Symbol = symbol_short!("nonce");
+
+#[contractimpl]
+impl NonceInTempVulnerable {
+    /// ❌ Nonce stored in temporary storage — expires with TTL, enabling replay attacks.
+    pub fn execute(env: Env, n: u64) {
+        let current: u64 = env.storage().temporary().get(&NONCE).unwrap_or(0);
+        assert!(n > current, "replay");
+        env.storage().temporary().set(&NONCE, &n);
+    }
+}


### PR DESCRIPTION
closes #297 

Files created/modified:

1. crates/checks/src/nonce_in_temp.rs — New check implementing the Check trait. Walks contractimpl functions via AST visitor, flags any temporary().set(key, ...) call where the key string contains nonce, seqno, counter, or
sequence. Severity: High. Includes 5 unit tests (3 positive, 2 negative).

2. crates/checks/src/lib.rs — Added pub mod nonce_in_temp;, pub use nonce_in_temp::NonceInTempCheck;, and Box::new(NonceInTempCheck) in default_checks().

3. test-contracts/nonce_in_temp-vulnerable/ — Contract that stores a nonce in temporary() storage (triggers the check).

4. test-contracts/nonce_in_temp-safe/ — Contract that stores a nonce in persistent() storage (no finding).

The pre-existing compilation errors in the crate are unrelated to this change — zero errors from nonce_in_temp.