### PR TITLE
feat: add keccak-misuse check (#299)

### DIFF
--- a/crates/checks/src/keccak_misuse.rs
+++ b/crates/checks/src/keccak_misuse.rs
@@ -1,0 +1,145 @@
+//! Detects `keccak256` used in contracts without Ethereum-compatibility requirements.
+//!
+//! `keccak256` should only be used for Ethereum-compatible operations (e.g., verifying
+//! Ethereum signatures). For general integrity checks, `sha256` is sufficient and
+//! more idiomatic in Soroban contracts.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "keccak-misuse";
+
+/// Flags `env.crypto().keccak256(...)` calls in contracts that have no
+/// Ethereum-compatibility requirement (no `ecrecover` or `eth_`-prefixed calls).
+pub struct KeccakMisuseCheck;
+
+impl Check for KeccakMisuseCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, source: &str) -> Vec<Finding> {
+        // If the source contains Ethereum-compat indicators, skip
+        if has_eth_compat(source) {
+            return vec![];
+        }
+
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut scan = KeccakScan {
+                fn_name,
+                out: &mut out,
+            };
+            scan.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn has_eth_compat(source: &str) -> bool {
+    source.contains("ecrecover") || source.contains("eth_")
+}
+
+struct KeccakScan<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'ast> Visit<'ast> for KeccakScan<'_> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "keccak256" {
+            if let Expr::MethodCall(inner) = &*i.receiver {
+                if inner.method == "crypto" {
+                    let line = i.span().start().line;
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::Low,
+                        file_path: String::new(),
+                        line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "Method `{}` uses `env.crypto().keccak256()` without an \
+                             Ethereum-compatibility requirement. Use `sha256` for general \
+                             integrity checks in Soroban contracts.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_keccak256_without_eth_compat() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn hash_data(env: Env, data: Bytes) -> BytesN<32> {
+        env.crypto().keccak256(&data)
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = KeccakMisuseCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+        assert_eq!(findings[0].severity, Severity::Low);
+    }
+
+    #[test]
+    fn allows_keccak256_with_ecrecover() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn verify_eth_sig(env: Env, data: Bytes) -> BytesN<32> {
+        // ecrecover usage
+        env.crypto().keccak256(&data)
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = KeccakMisuseCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn allows_sha256_usage() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn hash_data(env: Env, data: Bytes) -> BytesN<32> {
+        env.crypto().sha256(&data)
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = KeccakMisuseCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn allows_keccak256_with_eth_prefix() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn eth_verify(env: Env, data: Bytes) -> BytesN<32> {
+        env.crypto().keccak256(&data)
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = KeccakMisuseCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -50,6 +50,7 @@ pub mod invoke_store_no_event;
 pub mod invoke_unchecked_cast;
 pub mod key_length_exceeded;
 pub mod key_prefix_collision;
+pub mod keccak_misuse;
 pub mod linear_whitelist_scan;
 pub mod lock_period_truncation;
 pub mod map_get_unwrap;
@@ -169,6 +170,7 @@ pub use instance_vec_growth::InstanceVecGrowthCheck;
 pub use invoke_store_no_event::InvokeStoreNoEventCheck;
 pub use invoke_unchecked_cast::InvokeUncheckedCastCheck;
 pub use key_prefix_collision::KeyPrefixCollisionCheck;
+pub use keccak_misuse::KeccakMisuseCheck;
 pub use linear_whitelist_scan::LinearWhitelistScanCheck;
 pub use lock_period_truncation::LockPeriodTruncationCheck;
 pub use loop_bound_no_cap::LoopBoundNoCapCheck;
@@ -294,6 +296,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(AmountMulOverflowCheck),
         Box::new(FloatArithmeticCheck),
         Box::new(WeakRandomnessCheck),
+        Box::new(KeccakMisuseCheck),
         Box::new(ReentrancyCheck),
         Box::new(TokenTransferUncheckedCheck),
         Box::new(ContracterrorAttrCheck),

--- a/test-contracts/keccak_misuse-safe/Cargo.toml
+++ b/test-contracts/keccak_misuse-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-keccak-misuse-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/keccak_misuse-safe/src/lib.rs
+++ b/test-contracts/keccak_misuse-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, BytesN, Env, Symbol};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    /// Safe: uses sha256 for integrity check — appropriate for Soroban contracts.
+    pub fn store_hash(env: Env, data: Bytes) {
+        // ✅ sha256 is the correct choice for non-Ethereum integrity checks
+        let hash: BytesN<32> = env.crypto().sha256(&data);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "hash"), &hash);
+    }
+}

--- a/test-contracts/keccak_misuse-vulnerable/Cargo.toml
+++ b/test-contracts/keccak_misuse-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-keccak-misuse-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/keccak_misuse-vulnerable/src/lib.rs
+++ b/test-contracts/keccak_misuse-vulnerable/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, BytesN, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    /// Vulnerable: uses keccak256 for a simple integrity check with no Ethereum requirement.
+    pub fn store_hash(env: Env, data: Bytes) {
+        // ❌ keccak256 used without any Ethereum-compatibility need; sha256 is sufficient
+        let hash: BytesN<32> = env.crypto().keccak256(&data);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "hash"), &hash);
+    }
+}


### PR DESCRIPTION
Detect keccak256 used in contracts without Ethereum-compatibility requirements. sha256 is sufficient for general integrity checks.

- Add crates/checks/src/keccak_misuse.rs (Low severity)
- Add test-contracts/keccak_misuse-vulnerable/
- Add test-contracts/keccak_misuse-safe/
- Register check in default_checks()

closes #299 