### PR TITLE
feat: add hardcoded-passphrase check (#300)

### DIFF
--- a/crates/checks/src/hardcoded_passphrase.rs
+++ b/crates/checks/src/hardcoded_passphrase.rs
@@ -1,0 +1,141 @@
+//! Detects hardcoded Stellar network passphrase strings in contract functions.
+//!
+//! Hardcoding network passphrases (e.g. `"Test SDF Network ; September 2015"`,
+//! `"Public Global Stellar Network ; September 2015"`) is fragile and error-prone.
+//! They should be obtained from the environment or passed as parameters.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{ExprLit, File, Lit};
+
+const CHECK_NAME: &str = "hardcoded-passphrase";
+
+/// Flags string literals matching known Stellar network passphrase patterns.
+pub struct HardcodedPassphraseCheck;
+
+impl Check for HardcodedPassphraseCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut v = PassphraseVisitor {
+                fn_name,
+                out: &mut out,
+            };
+            v.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+fn is_network_passphrase(s: &str) -> bool {
+    s.contains("Network ;")
+        || s.contains("Test SDF")
+        || s.contains("Public Global Stellar")
+        || s.contains("Standalone Network")
+}
+
+struct PassphraseVisitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl Visit<'_> for PassphraseVisitor<'_> {
+    fn visit_expr_lit(&mut self, i: &ExprLit) {
+        if let Lit::Str(lit_str) = &i.lit {
+            let value = lit_str.value();
+            if is_network_passphrase(&value) {
+                self.out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::Low,
+                    file_path: String::new(),
+                    line: i.span().start().line,
+                    function_name: self.fn_name.clone(),
+                    description: format!(
+                        "Method `{}` contains a hardcoded Stellar network passphrase `{}`. \
+                         Passphrases should be obtained from the environment or passed as \
+                         parameters to avoid fragility across network deployments.",
+                        self.fn_name, value
+                    ),
+                });
+            }
+        }
+        visit::visit_expr_lit(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn flags_testnet_passphrase() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn verify(env: Env) {
+        let network = "Test SDF Network ; September 2015";
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = HardcodedPassphraseCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_name, CHECK_NAME);
+        assert_eq!(findings[0].severity, Severity::Low);
+    }
+
+    #[test]
+    fn flags_mainnet_passphrase() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn verify(env: Env) {
+        let network = "Public Global Stellar Network ; September 2015";
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = HardcodedPassphraseCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Low);
+    }
+
+    #[test]
+    fn flags_network_semicolon_pattern() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn verify(env: Env) {
+        let network = "Standalone Network ; February 2017";
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = HardcodedPassphraseCheck.run(&file, code);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn allows_unrelated_strings() {
+        let code = r#"
+#[contractimpl]
+impl MyContract {
+    pub fn verify(env: Env) {
+        let msg = "hello world";
+        let key = "admin";
+    }
+}
+        "#;
+        let file = parse_file(code).unwrap();
+        let findings = HardcodedPassphraseCheck.run(&file, code);
+        assert!(findings.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -39,6 +39,7 @@ pub mod event_topic_runtime_string;
 pub mod extend_ttl_in_loop;
 pub mod float_arithmetic;
 pub mod hash_as_storage_key;
+pub mod hardcoded_passphrase;
 pub mod host_result_ignored;
 pub mod i128_to_u64;
 pub mod instance_domain_mixing;
@@ -159,6 +160,7 @@ pub use event_topic_runtime_string::EventTopicRuntimeStringCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
 pub use hash_as_storage_key::HashAsStorageKeyCheck;
+pub use hardcoded_passphrase::HardcodedPassphraseCheck;
 pub use host_result_ignored::HostResultIgnoredCheck;
 pub use i128_to_u64::I128ToU64Check;
 pub use instance_domain_mixing::InstanceDomainMixingCheck;
@@ -316,6 +318,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(DebugEntrypointCheck),
         Box::new(ExtendTtlInLoopCheck),
         Box::new(HashAsStorageKeyCheck),
+        Box::new(HardcodedPassphraseCheck),
         Box::new(UnauthAddressInStructCheck),
         Box::new(InvokeUncheckedCastCheck),
         Box::new(InvokeFuncFromInputCheck),

--- a/test-contracts/hardcoded_passphrase-safe/Cargo.toml
+++ b/test-contracts/hardcoded_passphrase-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hardcoded-passphrase-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hardcoded_passphrase-safe/src/lib.rs
+++ b/test-contracts/hardcoded_passphrase-safe/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, String, Symbol};
+
+#[contract]
+pub struct SafeContract;
+
+#[contractimpl]
+impl SafeContract {
+    /// Safe: network passphrase passed as a parameter, not hardcoded.
+    pub fn get_network(env: Env, passphrase: String) -> String {
+        // ✅ Passphrase supplied by caller — works across testnet/mainnet
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "net"), &passphrase);
+        passphrase
+    }
+}

--- a/test-contracts/hardcoded_passphrase-vulnerable/Cargo.toml
+++ b/test-contracts/hardcoded_passphrase-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hardcoded-passphrase-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hardcoded_passphrase-vulnerable/src/lib.rs
+++ b/test-contracts/hardcoded_passphrase-vulnerable/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+#[contractimpl]
+impl VulnerableContract {
+    /// Vulnerable: hardcoded Stellar network passphrase in contract logic.
+    pub fn get_network(env: Env) -> soroban_sdk::String {
+        // ❌ Hardcoded passphrase — fragile across network deployments
+        let passphrase = "Test SDF Network ; September 2015";
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "net"), &passphrase);
+        soroban_sdk::String::from_str(&env, passphrase)
+    }
+}


### PR DESCRIPTION
Detect hardcoded Stellar network passphrase strings in contract functions. Passphrases should be passed as parameters or obtained from the environment.

- Add crates/checks/src/hardcoded_passphrase.rs (Low severity)
- Add test-contracts/hardcoded_passphrase-vulnerable/
- Add test-contracts/hardcoded_passphrase-safe/
- Register check in default_checks()

closes #300 