### PR TITLE
feat: add sig-verify-inverted and hash-in-loop checks (#293, #294)

### DIFF
--- a/crates/checks/src/hash_in_loop.rs
+++ b/crates/checks/src/hash_in_loop.rs
@@ -1,0 +1,160 @@
+//! Detects `crypto().sha256(...)` or `crypto().keccak256(...)` called inside loops.
+//!
+//! Hash functions are expensive host calls. Calling them inside a loop body
+//! can exhaust the compute budget. Hash once outside the loop instead.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "hash-in-loop";
+
+pub struct HashInLoopCheck;
+
+impl Check for HashInLoopCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = LoopVisitor { fn_name, loop_depth: 0, out: &mut out };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct LoopVisitor<'a> {
+    fn_name: String,
+    loop_depth: usize,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'_> for LoopVisitor<'a> {
+    fn visit_expr_for_loop(&mut self, i: &syn::ExprForLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_for_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_while(&mut self, i: &syn::ExprWhile) {
+        self.loop_depth += 1;
+        visit::visit_expr_while(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_loop(&mut self, i: &syn::ExprLoop) {
+        self.loop_depth += 1;
+        visit::visit_expr_loop(self, i);
+        self.loop_depth -= 1;
+    }
+
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if self.loop_depth > 0 && is_hash_call(i) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::Medium,
+                file_path: String::new(),
+                line: i.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "`crypto().{}(...)` called inside a loop in `{}`. \
+                     Hash functions are expensive host calls; compute the hash \
+                     once outside the loop to avoid exhausting the compute budget.",
+                    i.method, self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn is_hash_call(m: &ExprMethodCall) -> bool {
+    if m.method != "sha256" && m.method != "keccak256" {
+        return false;
+    }
+    is_crypto_receiver(&m.receiver)
+}
+
+fn is_crypto_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "crypto" {
+                return true;
+            }
+            is_crypto_receiver(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        HashInLoopCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_sha256_in_for_loop() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        for i in 0..10u32 {
+            let _ = env.crypto().sha256(&env.crypto().sha256(&()));
+        }
+    }
+}
+"#);
+        assert!(!hits.is_empty());
+        assert_eq!(hits[0].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn flags_keccak256_in_while_loop() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        let mut i = 0;
+        while i < 5 {
+            let _ = env.crypto().keccak256(&());
+            i += 1;
+        }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn passes_hash_outside_loop() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn process(env: Env) {
+        let h = env.crypto().sha256(&());
+        for i in 0..10u32 {
+            let _ = (i, &h);
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -77,6 +77,7 @@ pub mod renounce_no_backup;
 pub mod runtime_symbol;
 pub mod secp256k1_unchecked;
 pub mod self_transfer;
+pub mod sig_verify_inverted;
 pub mod sequence_as_key;
 pub mod sequence_nonce;
 pub mod storage;
@@ -198,6 +199,7 @@ pub use renounce_no_backup::RenounceNoBackupCheck;
 pub use runtime_symbol::RuntimeSymbolCheck;
 pub use secp256k1_unchecked::Secp256k1UncheckedCheck;
 pub use self_transfer::SelfTransferCheck;
+pub use sig_verify_inverted::SigVerifyInvertedCheck;
 pub use sequence_as_key::SequenceAsKeyCheck;
 pub use sequence_nonce::SequenceNonceCheck;
 pub use storage::UnsafeStoragePatternsCheck;
@@ -351,5 +353,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(AdminNoGroupAuthCheck),
         Box::new(OwnershipPendingNotClearedCheck),
         Box::new(OwnershipNoApprovalInvalidationCheck),
+        Box::new(SigVerifyInvertedCheck),
     ]
 }

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -39,6 +39,7 @@ pub mod event_topic_runtime_string;
 pub mod extend_ttl_in_loop;
 pub mod float_arithmetic;
 pub mod hash_as_storage_key;
+pub mod hash_in_loop;
 pub mod host_result_ignored;
 pub mod i128_to_u64;
 pub mod instance_domain_mixing;
@@ -160,6 +161,7 @@ pub use event_topic_runtime_string::EventTopicRuntimeStringCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
 pub use hash_as_storage_key::HashAsStorageKeyCheck;
+pub use hash_in_loop::HashInLoopCheck;
 pub use host_result_ignored::HostResultIgnoredCheck;
 pub use i128_to_u64::I128ToU64Check;
 pub use instance_domain_mixing::InstanceDomainMixingCheck;
@@ -354,5 +356,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(OwnershipPendingNotClearedCheck),
         Box::new(OwnershipNoApprovalInvalidationCheck),
         Box::new(SigVerifyInvertedCheck),
+        Box::new(HashInLoopCheck),
     ]
 }

--- a/crates/checks/src/sig_verify_inverted.rs
+++ b/crates/checks/src/sig_verify_inverted.rs
@@ -1,0 +1,154 @@
+//! Detects inverted `ed25519_verify` results used as access conditions.
+//!
+//! Flags `!env.crypto().ed25519_verify(...)` and
+//! `env.crypto().ed25519_verify(...) == false` when used as `if` conditions.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprBinary, ExprIf, ExprUnary, File, UnOp};
+
+const CHECK_NAME: &str = "sig-verify-inverted";
+
+pub struct SigVerifyInvertedCheck;
+
+impl Check for SigVerifyInvertedCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let mut visitor = Visitor { fn_name, out: &mut out };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct Visitor<'a> {
+    fn_name: String,
+    out: &'a mut Vec<Finding>,
+}
+
+impl<'a> Visit<'_> for Visitor<'a> {
+    fn visit_expr_if(&mut self, i: &ExprIf) {
+        if is_inverted_verify(&i.cond) {
+            self.out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line: i.cond.span().start().line,
+                function_name: self.fn_name.clone(),
+                description: format!(
+                    "Inverted `ed25519_verify` result used as condition in `{}`. \
+                     This allows unauthorized callers and rejects legitimate ones.",
+                    self.fn_name
+                ),
+            });
+        }
+        visit::visit_expr_if(self, i);
+    }
+}
+
+/// Returns true for `!crypto().ed25519_verify(...)` or
+/// `crypto().ed25519_verify(...) == false`.
+fn is_inverted_verify(expr: &Expr) -> bool {
+    match expr {
+        Expr::Unary(ExprUnary { op: UnOp::Not(_), expr, .. }) => is_ed25519_verify_call(expr),
+        Expr::Binary(ExprBinary { left, op: syn::BinOp::Eq(_), right, .. }) => {
+            (is_ed25519_verify_call(left) && is_bool_false(right))
+                || (is_ed25519_verify_call(right) && is_bool_false(left))
+        }
+        _ => false,
+    }
+}
+
+fn is_ed25519_verify_call(expr: &Expr) -> bool {
+    let Expr::MethodCall(m) = expr else { return false };
+    if m.method != "ed25519_verify" {
+        return false;
+    }
+    is_crypto_receiver(&m.receiver)
+}
+
+fn is_crypto_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "crypto" {
+                return true;
+            }
+            is_crypto_receiver(&m.receiver)
+        }
+        _ => false,
+    }
+}
+
+fn is_bool_false(expr: &Expr) -> bool {
+    matches!(expr, Expr::Lit(l) if matches!(&l.lit, syn::Lit::Bool(b) if !b.value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        SigVerifyInvertedCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_not_verify() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn auth(env: Env) {
+        if !env.crypto().ed25519_verify(&env, &(), &()) {
+            return;
+        }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn flags_eq_false() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn auth(env: Env) {
+        if env.crypto().ed25519_verify(&env, &(), &()) == false {
+            return;
+        }
+    }
+}
+"#);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn passes_normal_verify() {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn auth(env: Env) {
+        if env.crypto().ed25519_verify(&env, &(), &()) {
+            return;
+        }
+    }
+}
+"#);
+        assert!(hits.is_empty());
+    }
+}

--- a/test-contracts/hash-in-loop-safe/Cargo.toml
+++ b/test-contracts/hash-in-loop-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hash-in-loop-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hash-in-loop-safe/src/lib.rs
+++ b/test-contracts/hash-in-loop-safe/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct HashInLoopSafe;
+
+#[contractimpl]
+impl HashInLoopSafe {
+    // ✅ Hash computed once outside the loop
+    pub fn process(env: Env, count: u32) {
+        let h = env.crypto().sha256(&());
+        for i in 0..count {
+            let _ = (i, &h);
+        }
+    }
+}

--- a/test-contracts/hash-in-loop-vulnerable/Cargo.toml
+++ b/test-contracts/hash-in-loop-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-hash-in-loop-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/hash-in-loop-vulnerable/src/lib.rs
+++ b/test-contracts/hash-in-loop-vulnerable/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct HashInLoopVulnerable;
+
+#[contractimpl]
+impl HashInLoopVulnerable {
+    // ❌ sha256 called inside a for loop — wastes compute budget
+    pub fn process_sha256(env: Env, count: u32) {
+        for i in 0..count {
+            let _ = (i, env.crypto().sha256(&()));
+        }
+    }
+
+    // ❌ keccak256 called inside a while loop
+    pub fn process_keccak256(env: Env) {
+        let mut i = 0u32;
+        while i < 10 {
+            let _ = env.crypto().keccak256(&());
+            i += 1;
+        }
+    }
+}

--- a/test-contracts/sig-verify-inverted-safe/Cargo.toml
+++ b/test-contracts/sig-verify-inverted-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-sig-verify-inverted-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/sig-verify-inverted-safe/src/lib.rs
+++ b/test-contracts/sig-verify-inverted-safe/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct SigVerifyInvertedSafe;
+
+#[contractimpl]
+impl SigVerifyInvertedSafe {
+    // ✅ Correct: allows access only when signature is VALID
+    pub fn auth(env: Env) {
+        if env.crypto().ed25519_verify(&env, &(), &()) {
+            return;
+        }
+    }
+}

--- a/test-contracts/sig-verify-inverted-vulnerable/Cargo.toml
+++ b/test-contracts/sig-verify-inverted-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-sig-verify-inverted-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/sig-verify-inverted-vulnerable/src/lib.rs
+++ b/test-contracts/sig-verify-inverted-vulnerable/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct SigVerifyInvertedVulnerable;
+
+#[contractimpl]
+impl SigVerifyInvertedVulnerable {
+    // ❌ Inverted: allows access when signature is INVALID
+    pub fn auth(env: Env) {
+        if !env.crypto().ed25519_verify(&env, &(), &()) {
+            return;
+        }
+    }
+
+    // ❌ Equivalent: == false also inverts the check
+    pub fn auth2(env: Env) {
+        if env.crypto().ed25519_verify(&env, &(), &()) == false {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements two new static analysis checks for Soroban smart contracts.

### #293 — `sig-verify-inverted` (High)

Detects inverted `ed25519_verify` results used as `if` conditions:
- `!env.crypto().ed25519_verify(...)`
- `env.crypto().ed25519_verify(...) == false`

Both patterns allow unauthorized callers while rejecting legitimate ones.

**Files:**
- `crates/checks/src/sig_verify_inverted.rs`
- `test-contracts/sig-verify-inverted-vulnerable/`
- `test-contracts/sig-verify-inverted-safe/`

### #294 — `hash-in-loop` (Medium)

Detects `crypto().sha256()` or `crypto().keccak256()` called inside `for`, `while`, or `loop` bodies. Hash functions are expensive host calls; repeated invocation inside a loop can exhaust the compute budget.

**Files:**
- `crates/checks/src/hash_in_loop.rs`
- `test-contracts/hash-in-loop-vulnerable/`
- `test-contracts/hash-in-loop-safe/`

## What was tested

Unit tests included in each check file covering:
- Positive detection (vulnerable patterns)
- True-negative (safe patterns pass without findings)

## Closes
Closes #293 
Closes #294 