### PR TITLE
feat: add ledger-timestamp-as-nonce check

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -119,6 +119,7 @@ pub mod temp_get_no_has;
 pub mod temp_read_in_view;
 pub mod temp_set_no_ttl;
 pub mod tier_key_collision;
+pub mod timestamp_as_nonce;
 pub mod timestamp_expiry_no_min;
 pub mod timestamp_truncation;
 pub mod token_burn_auth;
@@ -274,6 +275,7 @@ pub use storage_type_version::StorageTypeVersionCheck;
 pub use temp_get_no_has::TempGetNoHasCheck;
 pub use temp_set_no_ttl::TempSetNoTtlCheck;
 pub use tier_key_collision::TierKeyCollisionCheck;
+pub use timestamp_as_nonce::TimestampAsNonceCheck;
 pub use timestamp_expiry_no_min::TimestampExpiryNoMinCheck;
 pub use timestamp_truncation::TimestampTruncationCheck;
 pub use token_burn_auth::TokenBurnAuthCheck;
@@ -453,5 +455,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(OwnershipPendingNotClearedCheck),
         Box::new(OwnershipNoApprovalInvalidationCheck),
         Box::new(TryIntoUnwrapCheck),
+        Box::new(TimestampAsNonceCheck),
     ]
 }

--- a/crates/checks/src/timestamp_as_nonce.rs
+++ b/crates/checks/src/timestamp_as_nonce.rs
@@ -1,0 +1,331 @@
+//! Using `env.ledger().timestamp()` as a nonce or unique identifier.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Local, Pat};
+
+const CHECK_NAME: &str = "timestamp-as-nonce";
+
+/// Flags `#[contractimpl]` methods that treat `env.ledger().timestamp()` as a
+/// unique nonce or identifier: it is the close time of the *current ledger*
+/// and is identical for every transaction within that ledger.
+pub struct TimestampAsNonceCheck;
+
+impl Check for TimestampAsNonceCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let mut scan = FuncBodyScan::default();
+            scan.visit_block(&method.block);
+            let Some(line) = scan.first_line else {
+                continue;
+            };
+            let fn_name = method.sig.ident.to_string();
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: fn_name.clone(),
+                description: format!(
+                    "Method `{fn_name}` derives a nonce/identifier from `env.ledger().timestamp()`. \
+                     The ledger timestamp is the close time of the current ledger and is identical \
+                     for every transaction in that ledger, so two transactions can collide on the \
+                     same value, enabling replay. Use a monotonically incrementing counter in \
+                     storage or `env.prng()` instead."
+                ),
+            });
+        }
+        out
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+/// Matches the `env.ledger().timestamp()` chain: a method call named
+/// `"timestamp"` whose receiver is itself a method call named `"ledger"`,
+/// mirroring `is_env_require_auth` in `auth.rs`, which matches `Expr::Path`
+/// on the base receiver.
+fn is_ledger_timestamp_call(m: &ExprMethodCall) -> bool {
+    if m.method != "timestamp" {
+        return false;
+    }
+    let Expr::MethodCall(receiver) = &*m.receiver else {
+        return false;
+    };
+    if receiver.method != "ledger" {
+        return false;
+    }
+    matches!(&*receiver.receiver, Expr::Path(p) if p.path.is_ident("env"))
+}
+
+/// Whether `expr` is, or contains anywhere in its subtree, an
+/// `env.ledger().timestamp()` chain. Structural/textual — not dataflow.
+fn expr_contains_timestamp_chain(expr: &Expr) -> bool {
+    #[derive(Default)]
+    struct Finder(bool);
+
+    impl<'ast> Visit<'ast> for Finder {
+        fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+            if is_ledger_timestamp_call(i) {
+                self.0 = true;
+            }
+            visit::visit_expr_method_call(self, i);
+        }
+    }
+
+    let mut finder = Finder::default();
+    finder.visit_expr(expr);
+    finder.0
+}
+
+fn ident_looks_like_nonce(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("nonce") || lower.contains("id") || lower.contains("unique_id")
+}
+
+#[derive(Default)]
+struct FuncBodyScan {
+    first_line: Option<usize>,
+}
+
+impl FuncBodyScan {
+    fn flag(&mut self, line: usize) {
+        if self.first_line.is_none() {
+            self.first_line = Some(line);
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for FuncBodyScan {
+    fn visit_local(&mut self, i: &'ast Local) {
+        if let Some(init) = &i.init {
+            if expr_contains_timestamp_chain(&init.expr) {
+                let pat = match &i.pat {
+                    Pat::Type(pt) => &*pt.pat,
+                    p => p,
+                };
+                if let Pat::Ident(pi) = pat {
+                    if ident_looks_like_nonce(&pi.ident.to_string()) {
+                        self.flag(i.span().start().line);
+                    }
+                }
+            }
+        }
+        visit::visit_local(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if i.method == "set" && receiver_chain_contains_storage(&i.receiver) {
+            let direct_timestamp_arg = i.args.iter().any(expr_contains_timestamp_chain);
+            if direct_timestamp_arg {
+                self.flag(i.span().start().line);
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(TimestampAsNonceCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_timestamp_stored_directly_as_storage_key() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        env.storage().persistent().set(&env.ledger().timestamp(), &true);
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "record");
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_timestamp_assigned_to_nonce_binding() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        let nonce = env.ledger().timestamp();
+        env.storage().persistent().set(&nonce, &true);
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "record");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_timestamp_assigned_to_id_binding() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        let request_id = env.ledger().timestamp();
+        let _ = request_id;
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "record");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_timestamp_assigned_to_unique_id_binding() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        let unique_id = env.ledger().timestamp();
+        let _ = unique_id;
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_timestamp_assigned_to_unrelated_binding() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        let close_time = env.ledger().timestamp();
+        let _ = close_time;
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_timestamp_used_for_expiry_not_nonce() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+const MIN_DURATION: u64 = 3600;
+
+#[contractimpl]
+impl Contract {
+    pub fn set_expiry(env: Env) {
+        let expiry = env.ledger().timestamp() + MIN_DURATION;
+        env.storage().instance().set(&"expiry", &expiry);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_counter_based_nonce() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn record(env: Env) {
+        let counter: u64 = env.storage().instance().get(&symbol_short!("CNT")).unwrap_or(0);
+        let nonce = counter + 1;
+        env.storage().persistent().set(&nonce, &true);
+        env.storage().instance().set(&symbol_short!("CNT"), &nonce);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::Env;
+
+pub struct Contract;
+
+impl Contract {
+    pub fn record(env: Env) {
+        let nonce = env.ledger().timestamp();
+        env.storage().persistent().set(&nonce, &true);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -162,3 +162,30 @@ Integer division or remainder by zero causes a panic in Rust, which terminates t
 - `assert_eq!(param, 0)` (two-argument form) is not recognized — only the single-argument `assert!` form counts.
 
 **Fixture:** `test-contracts/zero-divisor-vulnerable/`, `test-contracts/zero-divisor-safe/`
+
+---
+
+## `timestamp-as-nonce` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+Inside `#[contractimpl]` methods, any use of `env.ledger().timestamp()` as a unique nonce or identifier:
+
+1. A `let` binding whose init expression contains an `env.ledger().timestamp()` chain, where the binding's name (lowercased) contains `"nonce"`, `"id"`, or `"unique_id"`.
+2. An `env.ledger().timestamp()` chain passed directly as an argument to a storage mutation named `set` (receiver chain containing `.storage()`) — e.g. `env.storage().persistent().set(&env.ledger().timestamp(), &v)`.
+
+Either condition flags the method once.
+
+**Why it matters**
+
+`env.ledger().timestamp()` is the close time of the *current ledger* and is identical for every transaction within that ledger. Using it as a unique nonce, identifier, or storage key means two transactions in the same ledger collide on the same value, enabling replay.
+
+**Limitations**
+
+- Structural/textual, not dataflow: the timestamp chain must appear directly in the flagged binding's init expression or storage-`set` argument, not several variables removed.
+- The name heuristic (`"id"` as a substring) can over-match identifiers that merely contain those letters (e.g. `valid`).
+- Only the `Env` binding named `env` counts, mirroring `missing-require-auth`.
+
+**Fixture:** `test-contracts/timestamp-as-nonce-vulnerable/`, `test-contracts/timestamp-as-nonce-safe/`

--- a/test-contracts/timestamp-as-nonce-safe/Cargo.toml
+++ b/test-contracts/timestamp-as-nonce-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-timestamp-as-nonce-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/timestamp-as-nonce-safe/src/lib.rs
+++ b/test-contracts/timestamp-as-nonce-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("CNT");
+
+#[contract]
+pub struct TimestampAsNonceSafe;
+
+#[contractimpl]
+impl TimestampAsNonceSafe {
+    /// Nonce derived from a monotonically incrementing storage counter —
+    /// unique per call, unlike the ledger close time.
+    pub fn record(env: Env) {
+        let counter: u64 = env.storage().instance().get(&COUNTER).unwrap_or(0);
+        let nonce = counter + 1;
+        env.storage().persistent().set(&nonce, &true);
+        env.storage().instance().set(&COUNTER, &nonce);
+    }
+}

--- a/test-contracts/timestamp-as-nonce-vulnerable/Cargo.toml
+++ b/test-contracts/timestamp-as-nonce-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-timestamp-as-nonce-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/timestamp-as-nonce-vulnerable/src/lib.rs
+++ b/test-contracts/timestamp-as-nonce-vulnerable/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct TimestampAsNonceVulnerable;
+
+#[contractimpl]
+impl TimestampAsNonceVulnerable {
+    /// ❌ Ledger timestamp used as a unique nonce / storage key — every
+    /// transaction in the same ledger gets the same value, enabling replay.
+    pub fn record(env: Env) {
+        let nonce = env.ledger().timestamp();
+        env.storage().persistent().set(&nonce, &true);
+    }
+}


### PR DESCRIPTION
## Summary

`env.ledger().timestamp()` is the close time of the current ledger and is identical for every transaction in that ledger. Using it as a unique nonce or identifier (a storage key, or part of a signed message) means two transactions in the same ledger collide, enabling replay.

- Adds `TimestampAsNonceCheck` (`timestamp-as-nonce`, High) in `crates/checks/src/timestamp_as_nonce.rs`, built on `auth.rs`'s layout per the issue.
- Detection logic, exactly as specified in the issue:
  1. `is_ledger_timestamp_call` matches the `env.ledger().timestamp()` chain — an `ExprMethodCall` named `"timestamp"` whose receiver is an `ExprMethodCall` named `"ledger"`, mirroring the nested-receiver style of `is_env_require_auth` in `auth.rs` (`Expr::Path` match on the base receiver).
  2. `visit_local`: flags a `let` binding whose init expression contains that chain (reusing the matcher) when the binding's `Pat::Ident` name (lowercased) contains `"nonce"`, `"id"`, or `"unique_id"`.
  3. `visit_expr_method_call`: flags the chain when it's passed directly as an argument to a `set` call whose receiver chain contains `.storage()` (reusing `receiver_chain_contains_storage`, same as `auth.rs`/`storage.rs`).
  4. Either condition flags the method once (OR'd, no double-counting).
- Registered in `crates/checks/src/lib.rs` (module, `pub use`, and `default_checks()`).
- New `docs/checks.md` section, matching the existing format.
- New fixtures: `test-contracts/timestamp-as-nonce-vulnerable/` (package `sg-test-timestamp-as-nonce-vulnerable`) and `test-contracts/timestamp-as-nonce-safe/` (counter-based nonce, per the issue's suggested safe pattern).

## Test plan

- [x] 8 new unit tests in `timestamp_as_nonce.rs` covering: direct timestamp-as-storage-key, `nonce`/`id`/`unique_id`-named bindings, an unrelated binding name (no flag), timestamp used for expiry math (no flag — not a nonce/id name), a counter-based nonce (no flag), and a non-`#[contractimpl]` impl (no flag).
- [x] `cargo test --workspace` — 620/620 passing (612 pre-existing + 8 new), zero failures
- [x] `cargo fmt --check` and `cargo clippy --all-targets` on `soroban-guard-checks` — clean

Fixes #380