### PR TITLE
feat(checks): add double-init detector

### DIFF
--- a/crates/checks/src/double_init.rs
+++ b/crates/checks/src/double_init.rs
@@ -1,0 +1,212 @@
+//! Detects init-like methods that write storage without first checking initialization state.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "double-init";
+
+pub struct DoubleInitCheck;
+
+impl Check for DoubleInitCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !is_init_like(&fn_name) {
+                continue;
+            }
+
+            let mut scan = FuncBodyScan::default();
+            scan.visit_block(&method.block);
+            if !scan.storage_set || scan.storage_guard {
+                continue;
+            }
+
+            let line = first_storage_set_line(&method.block)
+                .unwrap_or_else(|| method.sig.ident.span().start().line);
+            out.push(Finding {
+                check_name: CHECK_NAME.to_string(),
+                severity: Severity::High,
+                file_path: String::new(),
+                line,
+                function_name: fn_name.clone(),
+                description: format!(
+                    "Init-like method `{fn_name}` writes to storage without first checking \
+                     whether initialization state already exists. Add a storage `has` or `get` \
+                     guard before setting initialization data to prevent re-initialization."
+                ),
+            });
+        }
+        out
+    }
+}
+
+fn is_init_like(name: &str) -> bool {
+    name.to_ascii_lowercase().contains("init")
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn is_storage_set_call(m: &ExprMethodCall) -> bool {
+    m.method == "set" && receiver_chain_contains_storage(&m.receiver)
+}
+
+fn is_storage_guard_call(m: &ExprMethodCall) -> bool {
+    matches!(m.method.to_string().as_str(), "has" | "get")
+        && receiver_chain_contains_storage(&m.receiver)
+}
+
+#[derive(Default)]
+struct FuncBodyScan {
+    storage_set: bool,
+    storage_guard: bool,
+}
+
+impl<'ast> Visit<'ast> for FuncBodyScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if is_storage_set_call(i) {
+            self.storage_set = true;
+        }
+        if is_storage_guard_call(i) {
+            self.storage_guard = true;
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+struct FirstStorageSet {
+    line: Option<usize>,
+}
+
+impl<'ast> Visit<'ast> for FirstStorageSet {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if self.line.is_none() && is_storage_set_call(i) {
+            self.line = Some(i.span().start().line);
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+fn first_storage_set_line(block: &Block) -> Option<usize> {
+    let mut visitor = FirstStorageSet { line: None };
+    visitor.visit_block(block);
+    visitor.line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Check, Severity};
+    use syn::parse_file;
+
+    fn run(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(DoubleInitCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_init_storage_set_without_guard() -> Result<(), syn::Error> {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn initialize(env: Env, owner: Address) {
+        env.storage().instance().set(&Symbol::new(&env, "owner"), &owner);
+    }
+}
+"#)?;
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "initialize");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_init_checks_storage_first() -> Result<(), syn::Error> {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn init(env: Env, owner: Address) {
+        let key = Symbol::new(&env, "owner");
+        if env.storage().instance().has(&key) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&key, &owner);
+    }
+}
+"#)?;
+
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_init_reads_storage_first() -> Result<(), syn::Error> {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn initialize(env: Env, owner: Address) {
+        let key = Symbol::new(&env, "owner");
+        let existing: Option<Address> = env.storage().instance().get(&key);
+        if existing.is_some() {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&key, &owner);
+    }
+}
+"#)?;
+
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_init_storage_set() -> Result<(), syn::Error> {
+        let hits = run(r#"
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn set_owner(env: Env, owner: Address) {
+        env.storage().instance().set(&Symbol::new(&env, "owner"), &owner);
+    }
+}
+"#)?;
+
+        assert!(hits.is_empty());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -43,6 +43,7 @@ pub mod deploy_arg_auth;
 pub mod deploy_salt_predictable;
 pub mod deploy_unverified;
 pub mod deployer_reuse;
+pub mod double_init;
 pub mod dynamic_symbol_key;
 pub mod ed25519_key_in_temp;
 pub mod env_in_struct;
@@ -206,6 +207,7 @@ pub use deploy_arg_auth::DeployArgAuthCheck;
 pub use deploy_salt_predictable::DeploySaltPredictableCheck;
 pub use deploy_unverified::DeployUnverifiedCheck;
 pub use deployer_reuse::DeployerReuseCheck;
+pub use double_init::DoubleInitCheck;
 pub use dynamic_symbol_key::DynamicSymbolKeyCheck;
 pub use ed25519_key_in_temp::Ed25519KeyInTempCheck;
 pub use env_in_struct::EnvInStructCheck;
@@ -405,6 +407,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(AddressCmpInsteadOfAuthCheck),
         Box::new(DeployArgAuthCheck),
         Box::new(DeployerReuseCheck),
+        Box::new(DoubleInitCheck),
         Box::new(AuthTempStorageCheck),
         Box::new(MapKeyExplosionCheck),
         Box::new(DynamicSymbolKeyCheck),

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -96,6 +96,28 @@ Names like `set_owner` strongly suggest privilege; without any auth call the sca
 
 ---
 
+## `double-init` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+Inside `#[contractimpl]` methods whose name contains `"init"` (case-insensitive), this rule flags a storage `set` call through `env.storage()` when the same method does not first perform a storage `has` or `get` guard.
+
+**Why it matters**
+
+Initialization entrypoints usually establish privileged state such as owner/admin or one-time configuration. If they can be called again without checking existing initialization state, an attacker may re-initialize the contract and overwrite critical storage.
+
+**Limitations**
+
+- Structural, not dataflow-aware: the guard must appear as a direct storage `has` or `get` call in the same init-like method.
+- Helper-based initialization guards are not recognized.
+- Non-init method names are intentionally ignored to avoid flagging normal setters.
+
+**Fixture:** `test-contracts/double-init-vulnerable/`, `test-contracts/double-init-safe/`
+
+---
+
 ## `instance-ttl-missing` (Medium)
 
 **Status:** Phase 1

--- a/test-contracts/double-init-safe/Cargo.toml
+++ b/test-contracts/double-init-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-double-init-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/double-init-safe/src/lib.rs
+++ b/test-contracts/double-init-safe/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct DoubleInitSafe;
+
+#[contractimpl]
+impl DoubleInitSafe {
+    /// Checks owner storage before writing one-time initialization state.
+    pub fn initialize(env: Env, owner: Address) {
+        let owner_key = Symbol::new(&env, "owner");
+        if env.storage().instance().has(&owner_key) {
+            panic!("already initialized");
+        }
+
+        env.storage().instance().set(&owner_key, &owner);
+    }
+}

--- a/test-contracts/double-init-vulnerable/Cargo.toml
+++ b/test-contracts/double-init-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-double-init-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/double-init-vulnerable/src/lib.rs
+++ b/test-contracts/double-init-vulnerable/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct DoubleInitVulnerable;
+
+#[contractimpl]
+impl DoubleInitVulnerable {
+    /// Re-initializes owner storage every time it is called.
+    pub fn initialize(env: Env, owner: Address) {
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "owner"), &owner);
+    }
+}


### PR DESCRIPTION
Summary
- add a `double-init` check for init-like contract methods that write storage without a storage `has`/`get` guard
- register the check in the default analyzer list
- document the rule and add vulnerable/safe fixture contracts

Tests
- cargo test -p soroban-guard-checks double_init
- cargo test -p soroban-guard-checks
- rustfmt --check crates/checks/src/double_init.rs test-contracts/double-init-safe/src/lib.rs test-contracts/double-init-vulnerable/src/lib.rs
- git diff --check
- cargo run -p soroban-guard-cli -- scan test-contracts/double-init-vulnerable --json
- cargo run -p soroban-guard-cli -- scan test-contracts/double-init-safe --json
- cargo check in test-contracts/double-init-vulnerable
- cargo check in test-contracts/double-init-safe

Closes #378