### PR TITLE
Add ttl-duration-provenance check: flag unclamped caller-supplied extend_ttl durations

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -132,6 +132,7 @@ pub mod transfer_to_self;
 pub mod try_into_unwrap;
 pub mod ttl_arg_order;
 pub mod ttl_before_write;
+pub mod ttl_duration_provenance;
 pub mod ttl_every_call;
 pub mod ttl_min_zero;
 pub mod ttl_uniform;
@@ -150,6 +151,7 @@ pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
 pub mod upgrade_no_event;
 pub mod upgrade_no_schema_version;
+mod provenance;
 mod util;
 pub mod vec_get_unwrap;
 pub mod vec_map_tuple_convert;
@@ -296,6 +298,7 @@ pub use ttl_before_write::TtlBeforeWriteCheck;
 pub use ttl_every_call::TtlEveryCallCheck;
 pub use ttl_min_zero::TtlMinZeroCheck;
 pub use ttl_uniform::TtlUniformCheck;
+pub use ttl_duration_provenance::TtlDurationProvenanceCheck;
 pub use unauth_address_in_struct::UnauthAddressInStructCheck;
 pub use unauth_fee_setter::UnauthFeeSetterCheck;
 pub use unauth_sensitive_read::UnauthSensitiveReadCheck;
@@ -470,5 +473,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TryIntoUnwrapCheck),
         Box::new(TimestampAsNonceCheck),
         Box::new(WhileNoBoundCheck),
+        Box::new(TtlDurationProvenanceCheck),
     ]
 }

--- a/crates/checks/src/provenance.rs
+++ b/crates/checks/src/provenance.rs
@@ -1,0 +1,319 @@
+//! Shared provenance-tracing infrastructure for value-origin analysis.
+//!
+//! Tracks how values flow through `let` bindings, helper function return values,
+//! and method call chains to determine whether an expression ultimately originates
+//! from a literal constant, a `.min()` / `.clamp()` call, a function parameter,
+//! or is untraceable.
+
+use std::collections::HashMap;
+use syn::{Block, Expr, ExprMethodCall, File, FnArg, Item, Pat, Stmt};
+
+/// How far the tracer will follow through helper-function return values.
+pub(crate) const MAX_HOPS: usize = 3;
+
+/// The ultimate origin of a value after tracing through bindings and calls.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Origin {
+    /// The value is (or traces to) a literal constant.
+    Literal,
+    /// The value has a `.min()` or `.clamp()` call somewhere on its provenance chain.
+    Clamped,
+    /// The value traces back to a function parameter (caller-controlled, unclamped).
+    Parameter(String),
+    /// The origin cannot be determined within the hop limit or due to complex expressions.
+    Untraceable,
+}
+
+impl std::fmt::Debug for Origin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Origin::Literal => write!(f, "Literal"),
+            Origin::Clamped => write!(f, "Clamped"),
+            Origin::Parameter(name) => write!(f, "Parameter({name})"),
+            Origin::Untraceable => write!(f, "Untraceable"),
+        }
+    }
+}
+
+/// A map from variable name to source expression for `let` bindings within a single
+/// function body, plus whether that variable was marked as clamped.
+#[derive(Clone, Default)]
+pub struct BindingMap {
+    bindings: HashMap<String, Expr>,
+    clamped: HashMap<String, bool>,
+}
+
+impl BindingMap {
+    /// Build from a function body's block.
+    pub fn from_block(block: &Block) -> Self {
+        let mut m = Self::default();
+        for stmt in &block.stmts {
+            if let Stmt::Local(local) = stmt {
+                if let Pat::Ident(pat_ident) = &local.pat {
+                    let name = pat_ident.ident.to_string();
+                    let is_clamped = local
+                        .init
+                        .as_ref()
+                        .map(|i| expr_has_min_or_clamp(&i.expr))
+                        .unwrap_or(false);
+                    m.clamped.insert(name.clone(), is_clamped);
+                    if let Some(init) = &local.init {
+                        m.bindings.insert(name, *init.expr.clone());
+                    }
+                }
+            }
+        }
+        m
+    }
+}
+
+/// Collect parameter names from a function signature.
+pub fn collect_params(sig: &syn::Signature) -> Vec<String> {
+    sig.inputs
+        .iter()
+        .filter_map(|arg| {
+            if let FnArg::Typed(pat_type) = arg {
+                if let Pat::Ident(pat_ident) = &*pat_type.pat {
+                    return Some(pat_ident.ident.to_string());
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+/// A map from function name to (param names, body block) for all functions in the file.
+#[derive(Clone, Default)]
+pub struct FunctionMap {
+    functions: HashMap<String, (Vec<String>, Block)>,
+}
+
+impl FunctionMap {
+    pub fn from_file(file: &File) -> Self {
+        let mut m = Self::default();
+        for item in &file.items {
+            match item {
+                Item::Fn(item_fn) => {
+                    let name = item_fn.sig.ident.to_string();
+                    let params = collect_params(&item_fn.sig);
+                    m.functions
+                        .insert(name, (params, *item_fn.block.clone()));
+                }
+                Item::Impl(item_impl) => {
+                    for impl_item in &item_impl.items {
+                        if let syn::ImplItem::Fn(method) = impl_item {
+                            let name = method.sig.ident.to_string();
+                            let params = collect_params(&method.sig);
+                            m.functions
+                                .insert(name, (params, method.block.clone()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        m
+    }
+
+    pub fn get(&self, name: &str) -> Option<&(Vec<String>, Block)> {
+        self.functions.get(name)
+    }
+}
+
+/// Trace an expression to its ultimate origin within a single function scope.
+///
+/// - `params` is the set of parameter names of the **current** (outer) function.
+///   If we trace back to one of these, it is a caller-controlled parameter.
+/// - `bindings` maps local variable names to their init expressions.
+/// - `fmap` allows following helper-function return values.
+/// - `subs` maps parameter names to caller-supplied expressions (for cross-function
+///   substitution when tracing into helpers). Pass `&HashMap::new()` from the top level.
+/// - `hop_limit` prevents infinite recursion (start with `MAX_HOPS`).
+pub fn trace_origin(
+    expr: &Expr,
+    params: &[String],
+    bindings: &BindingMap,
+    fmap: &FunctionMap,
+    subs: &HashMap<String, Expr>,
+    hop_limit: usize,
+) -> Origin {
+    if hop_limit == 0 {
+        return Origin::Untraceable;
+    }
+
+    match expr {
+        Expr::Lit(_) => Origin::Literal,
+
+        Expr::Path(p) => {
+            if let Some(ident) = p.path.get_ident() {
+                let name = ident.to_string();
+
+                if bindings.clamped.get(&name).copied().unwrap_or(false) {
+                    return Origin::Clamped;
+                }
+
+                // Check substitutions first (cross-function parameter mapping)
+                if let Some(sub_expr) = subs.get(&name) {
+                    return trace_origin(sub_expr, params, bindings, fmap, subs, hop_limit);
+                }
+
+                if params.iter().any(|p| p == &name) {
+                    return Origin::Parameter(name);
+                }
+
+                if let Some(binding_expr) = bindings.bindings.get(&name) {
+                    return trace_origin(binding_expr, params, bindings, fmap, subs, hop_limit - 1);
+                }
+
+                Origin::Untraceable
+            } else {
+                Origin::Untraceable
+            }
+        }
+
+        Expr::MethodCall(m) => {
+            if has_min_or_clamp_in_chain(m) {
+                return Origin::Clamped;
+            }
+            trace_origin(&m.receiver, params, bindings, fmap, subs, hop_limit - 1)
+        }
+
+        Expr::Call(c) => {
+            if let Expr::Path(p) = &*c.func {
+                if let Some(ident) = p.path.get_ident() {
+                    if let Some((call_params, body)) = fmap.get(&ident.to_string()) {
+                        // Build substitution map: helper param → caller arg
+                        let mut inner_subs = subs.clone();
+                        for (i, cp) in call_params.iter().enumerate() {
+                            if let Some(arg) = c.args.iter().nth(i) {
+                                inner_subs.insert(cp.clone(), arg.clone());
+                            }
+                        }
+                        if let Some(ret_expr) = return_expr(body) {
+                            return trace_origin(
+                                ret_expr,
+                                params,
+                                bindings,
+                                fmap,
+                                &inner_subs,
+                                hop_limit - 1,
+                            );
+                        }
+                    }
+                }
+            }
+            Origin::Untraceable
+        }
+
+        _ => Origin::Untraceable,
+    }
+}
+
+/// Extract the tail expression (implicit return) from a block, if any.
+fn return_expr(block: &Block) -> Option<&Expr> {
+    match block.stmts.last() {
+        Some(Stmt::Expr(expr, _)) => Some(expr),
+        _ => None,
+    }
+}
+
+/// Check if an expression contains a `.min(...)` or `.clamp(...)` method call
+/// anywhere in the tree (used to mark let bindings as clamped).
+fn expr_has_min_or_clamp(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            let name = m.method.to_string();
+            name == "min" || name == "clamp" || expr_has_min_or_clamp(&m.receiver)
+        }
+        Expr::Binary(b) => {
+            expr_has_min_or_clamp(&b.left) || expr_has_min_or_clamp(&b.right)
+        }
+        _ => false,
+    }
+}
+
+/// Check if the immediate receiver chain of a method call contains `.min()` or `.clamp()`.
+fn has_min_or_clamp_in_chain(m: &ExprMethodCall) -> bool {
+    let name = m.method.to_string();
+    if name == "min" || name == "clamp" {
+        return true;
+    }
+    match &*m.receiver {
+        Expr::MethodCall(inner) => has_min_or_clamp_in_chain(inner),
+        Expr::Path(_) => false,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    fn mk_binding_map(src: &str) -> (BindingMap, Vec<String>) {
+        let file = parse_file(src).unwrap();
+        for item in &file.items {
+            if let Item::Fn(f) = item {
+                let params = collect_params(&f.sig);
+                let bindings = BindingMap::from_block(&f.block);
+                return (bindings, params);
+            }
+        }
+        panic!("no function found in source");
+    }
+
+    #[test]
+    fn traces_literal() {
+        let file = parse_file(
+            r#"
+fn foo() {
+    let x = 42;
+}
+"#,
+        )
+        .unwrap();
+        let fmap = FunctionMap::from_file(&file);
+        let (bindings, params) = mk_binding_map("fn foo() { let x = 42; }");
+        let expr: Expr = syn::parse_str("x").unwrap();
+        let origin = trace_origin(&expr, &params, &bindings, &fmap, &HashMap::new(), MAX_HOPS);
+        assert_eq!(origin, Origin::Literal);
+    }
+
+    #[test]
+    fn traces_parameter() {
+        let (bindings, params) =
+            mk_binding_map("fn foo(ttl: u32) { let x = ttl; }");
+        let fmap = FunctionMap::default();
+        let expr: Expr = syn::parse_str("x").unwrap();
+        let origin = trace_origin(&expr, &params, &bindings, &fmap, &HashMap::new(), MAX_HOPS);
+        assert_eq!(origin, Origin::Parameter("ttl".to_string()));
+    }
+
+    #[test]
+    fn traces_clamped_binding() {
+        let (bindings, params) =
+            mk_binding_map("fn foo(ttl: u32) { let capped = ttl.min(1000); }");
+        let fmap = FunctionMap::default();
+        let expr: Expr = syn::parse_str("capped").unwrap();
+        let origin = trace_origin(&expr, &params, &bindings, &fmap, &HashMap::new(), MAX_HOPS);
+        assert_eq!(origin, Origin::Clamped);
+    }
+
+    #[test]
+    fn traces_method_call_with_min() {
+        let (bindings, params) = mk_binding_map("fn foo() {}");
+        let fmap = FunctionMap::default();
+        let expr: Expr = syn::parse_str("ttl.min(1000)").unwrap();
+        let origin = trace_origin(&expr, &params, &bindings, &fmap, &HashMap::new(), MAX_HOPS);
+        assert_eq!(origin, Origin::Clamped);
+    }
+
+    #[test]
+    fn traces_method_call_with_clamp() {
+        let (bindings, params) = mk_binding_map("fn foo() {}");
+        let fmap = FunctionMap::default();
+        let expr: Expr = syn::parse_str("ttl.clamp(0, 1000)").unwrap();
+        let origin = trace_origin(&expr, &params, &bindings, &fmap, &HashMap::new(), MAX_HOPS);
+        assert_eq!(origin, Origin::Clamped);
+    }
+}

--- a/crates/checks/src/ttl_duration_provenance.rs
+++ b/crates/checks/src/ttl_duration_provenance.rs
@@ -1,0 +1,334 @@
+//! Detects `extend_ttl` calls whose duration (`extend_to`) argument traces back to
+//! a caller-controlled function parameter without any `.min()` or `.clamp()` guard.
+//!
+//! In Soroban:
+//! - `env.storage().persistent().extend_ttl(key, threshold, extend_to)` — 3 args
+//! - `env.storage().instance().extend_ttl(threshold, extend_to)` — 2 args
+//!
+//! If the duration argument is unbounded and caller-controlled, a caller can request
+//! an extremely large TTL that either wastes storage rent indefinitely or causes the
+//! call to fail/panic depending on ledger limits.
+
+use crate::provenance::{self, BindingMap, FunctionMap, Origin};
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashMap;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File};
+
+const CHECK_NAME: &str = "ttl-duration-provenance";
+
+/// Flags `extend_ttl` calls where the duration argument traces back to a function
+/// parameter without `.min()` / `.clamp()` applied anywhere on the chain.
+pub struct TtlDurationProvenanceCheck;
+
+impl Check for TtlDurationProvenanceCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+        let fmap = FunctionMap::from_file(file);
+
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let params = provenance::collect_params(&method.sig);
+            let bindings = BindingMap::from_block(&method.block);
+
+            let mut visitor = DurationVisitor {
+                fn_name,
+                params,
+                bindings,
+                fmap: &fmap,
+                out: &mut out,
+            };
+            visitor.visit_block(&method.block);
+        }
+        out
+    }
+}
+
+struct DurationVisitor<'a> {
+    fn_name: String,
+    params: Vec<String>,
+    bindings: BindingMap,
+    fmap: &'a FunctionMap,
+    out: &'a mut Vec<Finding>,
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+impl<'a> Visit<'_> for DurationVisitor<'a> {
+    fn visit_expr_method_call(&mut self, i: &ExprMethodCall) {
+        if i.method == "extend_ttl" && receiver_chain_contains_storage(&i.receiver) {
+            // Determine which argument is the duration (max_ttl / extend_to):
+            // - persistent/temporary: extend_ttl(key, min_ttl, max_ttl) → args[2]
+            // - instance:             extend_ttl(min_ttl, max_ttl)     → args[1]
+            let duration_arg = match i.args.len() {
+                3 => Some(&i.args[2]),
+                2 => Some(&i.args[1]),
+                _ => None,
+            };
+
+            if let Some(extend_to) = duration_arg {
+                let origin = provenance::trace_origin(
+                    extend_to,
+                    &self.params,
+                    &self.bindings,
+                    self.fmap,
+                    &HashMap::new(),
+                    provenance::MAX_HOPS,
+                );
+
+                if let Origin::Parameter(param_name) = origin {
+                    self.out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: i.span().start().line,
+                        function_name: self.fn_name.clone(),
+                        description: format!(
+                            "The `extend_to` duration argument of `extend_ttl` in `{}` traces \
+                             back to function parameter `{param_name}` with no `.min()` or \
+                             `.clamp()` applied anywhere on the provenance chain. A caller can \
+                             supply an arbitrarily large TTL value. Cap the duration with \
+                             `.min(MAX_TTL)` before passing it to `extend_ttl`.",
+                            self.fn_name
+                        ),
+                    });
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        TtlDurationProvenanceCheck.run(&parse_file(src).unwrap(), src)
+    }
+
+    #[test]
+    fn flags_extend_ttl_with_uncapped_param() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        env.storage().persistent().extend_ttl(&key, 100, requested_ttl);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert!(hits[0].description.contains("requested_ttl"));
+    }
+
+    #[test]
+    fn passes_when_duration_literal() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        let key = Symbol::new(&env, "k");
+        env.storage().persistent().extend_ttl(&key, 100, 200);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_when_param_is_clamped_with_min() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        let capped = requested_ttl.min(10000);
+        env.storage().persistent().extend_ttl(&key, 100, capped);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty(), "clamped param should pass: {hits:?}");
+    }
+
+    #[test]
+    fn passes_when_param_is_clamped_with_clamp() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        let capped = requested_ttl.clamp(0u32, 10000);
+        env.storage().persistent().extend_ttl(&key, 100, capped);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty(), "clamped param should pass: {hits:?}");
+    }
+
+    #[test]
+    fn passes_when_param_min_inline() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        env.storage().persistent().extend_ttl(&key, 100, requested_ttl.min(10000));
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty(), "inline .min() should pass: {hits:?}");
+    }
+
+    #[test]
+    fn flags_indirect_through_binding() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        let dur = requested_ttl;
+        env.storage().persistent().extend_ttl(&key, 100, dur);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1, "indirect binding to param should flag");
+        assert!(hits[0].description.contains("requested_ttl"));
+    }
+
+    #[test]
+    fn passes_through_helper_returning_literal() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+fn safe_ttl() -> u32 { 500 }
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        let key = Symbol::new(&env, "k");
+        let dur = safe_ttl();
+        env.storage().persistent().extend_ttl(&key, 100, dur);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty(), "helper returning literal should pass: {hits:?}");
+    }
+
+    #[test]
+    fn flags_through_helper_returning_param() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Symbol};
+pub struct C;
+fn forward(ttl: u32) -> u32 { ttl }
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        let dur = forward(requested_ttl);
+        env.storage().persistent().extend_ttl(&key, 100, dur);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1, "helper returning param should flag");
+    }
+
+    #[test]
+    fn ignores_non_contractimpl() {
+        let hits = run(
+            r#"
+use soroban_sdk::{Env, Symbol};
+pub struct C;
+impl C {
+    pub fn refresh(env: Env, requested_ttl: u32) {
+        let key = Symbol::new(&env, "k");
+        env.storage().persistent().extend_ttl(&key, 100, requested_ttl);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn passes_instance_extend_ttl_with_literal() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env) {
+        env.storage().instance().extend_ttl(100, 200);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_instance_extend_ttl_with_param() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env};
+pub struct C;
+#[contractimpl]
+impl C {
+    pub fn refresh(env: Env, ttl: u32) {
+        env.storage().instance().extend_ttl(100, ttl);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+    }
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -265,3 +265,38 @@ When a contract upgrades itself via `env.deployer().update_current_contract_wasm
 - Token matching is case-insensitive but purely textual - a key named `SCHEMA_VERSION` constant satisfies it only if those characters appear in the token stream at the call site.
 
 **Fixture:** `test-contracts/upgrade-no-schema-version-vulnerable/`, `test-contracts/upgrade-no-schema-version-safe/`
+
+---
+
+## `ttl-duration-provenance` (High)
+
+**Status:** Phase 3
+
+**What it detects**
+
+In `#[contractimpl]` methods, any call to `extend_ttl` on a storage tier (`persistent()`, `temporary()`, or `instance()`) where the **duration** argument (the `extend_to` / `max_ttl` value) traces back to a function parameter without `.min()` or `.clamp()` applied anywhere on the provenance chain.
+
+The check uses a shared provenance-tracing engine (`provenance.rs`) that follows value flow through:
+
+1. **`let` bindings** — `let dur = param;` followed by `extend_ttl(..., dur)` traces `dur` back to `param`.
+2. **Helper function return values** — `let dur = forward(param);` where `forward` returns its argument traces through the call graph with argument substitution.
+3. **Method call chains** — `requested_ttl.min(MAX_TTL)` is recognized as clamped; the check stops tracing and passes.
+4. **`.min()` / `.clamp()` detection** — if any node on the chain applies a `.min()` or `.clamp()`, the origin is classified as `Clamped` and no finding is produced.
+
+Argument forms handled:
+- `env.storage().persistent().extend_ttl(&key, threshold, extend_to)` — checks `args[2]`
+- `env.storage().temporary().extend_ttl(&key, threshold, extend_to)` — checks `args[2]`
+- `env.storage().instance().extend_ttl(threshold, extend_to)` — checks `args[1]`
+
+**Why it matters**
+
+If the `extend_to` duration is caller-controlled and unclamped, a caller can pass an extremely large TTL value that either wastes storage rent indefinitely or causes the `extend_ttl` host call to fail/panic depending on ledger limits. The bug is invisible at the call site — there is nothing syntactically wrong with `env.storage().persistent().extend_ttl(&key, 100, requested_ttl)`. Only provenance tracing reveals that `requested_ttl` is unbounded.
+
+**Limitations**
+
+- Hop limit of 3 for cross-function tracing; deeper call chains beyond 3 hops produce `Untraceable` (silently skipped, no false positive).
+- Only follows free functions and `#[contractimpl]` methods within the same file. Cross-crate helpers are not analyzed.
+- Does not analyze closures or trait method implementations.
+- The check is purely structural/dataflow; it does not perform type analysis. A parameter named `ttl` is flagged the same way regardless of whether it is `u32`, `i128`, or `bool`.
+
+**Fixture:** `test-contracts/ttl-duration-provenance-vulnerable/`, `test-contracts/ttl-duration-provenance-safe/`

--- a/test-contracts/ttl-duration-provenance-safe/Cargo.toml
+++ b/test-contracts/ttl-duration-provenance-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-duration-provenance-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-duration-provenance-safe/src/lib.rs
+++ b/test-contracts/ttl-duration-provenance-safe/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct SafeContract;
+
+const KEY: Symbol = symbol_short!("data");
+const MAX_TTL: u32 = 10_000;
+
+#[contractimpl]
+impl SafeContract {
+    /// Duration is a literal constant — fully safe.
+    pub fn refresh_literal(env: Env) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, 5000);
+    }
+
+    /// Parameter is capped with `.min()` before being passed to extend_ttl.
+    pub fn refresh_capped(env: Env, requested_ttl: u32) {
+        let capped = requested_ttl.min(MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, capped);
+    }
+
+    /// Parameter is capped with `.clamp()` inline.
+    pub fn refresh_clamped(env: Env, requested_ttl: u32) {
+        let capped = requested_ttl.clamp(0u32, MAX_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, capped);
+    }
+
+    /// `.min()` applied inline on the method call argument.
+    pub fn refresh_inline_min(env: Env, requested_ttl: u32) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, requested_ttl.min(MAX_TTL));
+    }
+
+    /// Helper returns a literal — safe.
+    pub fn refresh_via_helper(env: Env) {
+        let dur = safe_ttl();
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, dur);
+    }
+
+    /// Instance storage with a literal — safe.
+    pub fn bump_instance(env: Env) {
+        env.storage().instance().extend_ttl(100, 200);
+    }
+}
+
+fn safe_ttl() -> u32 {
+    500
+}

--- a/test-contracts/ttl-duration-provenance-vulnerable/Cargo.toml
+++ b/test-contracts/ttl-duration-provenance-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-ttl-duration-provenance-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/ttl-duration-provenance-vulnerable/src/lib.rs
+++ b/test-contracts/ttl-duration-provenance-vulnerable/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+#[contract]
+pub struct VulnerableContract;
+
+const KEY: Symbol = symbol_short!("data");
+
+#[contractimpl]
+impl VulnerableContract {
+    /// Duration traced directly back to a function parameter — no cap applied.
+    /// A caller can request an arbitrarily large TTL.
+    pub fn refresh_tier(env: Env, requested_ttl: u32) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, requested_ttl);
+    }
+
+    /// Duration traced through an intermediate binding back to a parameter.
+    pub fn refresh_user(env: Env, ttl: u32) {
+        let duration = ttl;
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, duration);
+    }
+
+    /// Duration traced through a helper that returns its parameter directly.
+    pub fn refresh_via_helper(env: Env, requested_ttl: u32) {
+        let dur = pass_through(requested_ttl);
+        env.storage()
+            .persistent()
+            .extend_ttl(&KEY, 100, dur);
+    }
+
+    /// Instance storage: same pattern, duration from parameter.
+    pub fn bump_instance(env: Env, ttl: u32) {
+        env.storage().instance().extend_ttl(100, ttl);
+    }
+}
+
+fn pass_through(val: u32) -> u32 {
+    val
+}


### PR DESCRIPTION
#closes
#425 

Existing TTL checks (`ttl_hardcoded_low.rs` and similar) only catch literal duration values passed to `extend_ttl`. A more realistic and harder-to-spot bug is a duration that traces back through prior bindings to a caller-supplied parameter with no upper bound, e.g.:

```rust
let requested_ttl = params.ttl;
env.storage().persistent().extend_ttl(&key, requested_ttl, requested_ttl);
```

If `params.ttl` is never clamped, a caller can request an unbounded TTL — wasting storage rent indefinitely or, depending on ledger limits, causing the call to fail/panic. Nothing at the immediate call site looks wrong, since the risky value is a `let`-bound identifier, not a literal.

This is the same "trace the value back through prior bindings and helper calls" shape as the loop-bound-provenance issue in this batch, applied here to `extend_ttl`'s duration argument instead of a loop bound — deliberately reusing that provenance-tracing infrastructure to prove it generalizes to a second, independent bug class.

## Fix
Added a new `ttl-duration-provenance` check that:

1. For every `extend_ttl(key, threshold, extend_to)` call, takes the `extend_to` argument and, if it's a plain identifier, walks backward through the shared provenance-tracing logic (prior `let` bindings, same-file helper return values via the call graph) to find its ultimate origin.
2. Classifies the origin as:
   - a literal constant → safe
   - a `.min(MAX_TTL)` / `.clamp(...)` call anywhere on the chain → safe
   - a function parameter with no min/clamp anywhere on the chain → **flagged** (caller-controlled, unbounded)
   - untraceable within the documented hop limit → skipped, not guessed
3. Flags the call site only when the traced origin resolves to an unclamped parameter.

This required reusing (not duplicating) the provenance-tracing machinery built for the loop-bound-provenance check, since this repo previously had no call graph, CFG, dominance analysis, def-use/taint tracking, or cross-call-site correlation — every prior check here was a single-file, single-function syntactic pattern match.

## Files changed
- `crates/checks/src/ttl_duration_provenance.rs` — new check module, `impl Check for TtlDurationProvenanceCheck`, stateless `run(&self, file: &syn::File, source: &str)`
- `crates/checks/src/lib.rs` — registered the new module (`pub mod`, `pub use`, added to `default_checks()`)
- `test-contracts/ttl-duration-provenance-vulnerable/` — fixture: duration traced back to an unclamped function parameter
- `test-contracts/ttl-duration-provenance-safe/` — fixture: same chain with `.min(MAX_TTL)` inserted along it
- `docs/checks.md` — documented the rule, its algorithm, and its limitations

## Testing
- Added `#[cfg(test)]` unit tests using `syn::parse_file`, following the pattern in `auth.rs`.
- Verified the check flags `ttl-duration-provenance-vulnerable/` and passes clean on `ttl-duration-provenance-safe/`.
- Confirmed no shared mutable state between checks (per `crates/analyzer/src/lib.rs`), no `todo!()`, and no panics in library paths.