### PR TITLE
feat(checks): add interprocedural-storage-toctou check (Closes #401)

### DIFF
--- a/crates/checks/src/interprocedural_storage_toctou.rs
+++ b/crates/checks/src/interprocedural_storage_toctou.rs
@@ -1,0 +1,434 @@
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use quote::ToTokens;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, ImplItem, ItemImpl};
+
+const CHECK_NAME: &str = "interprocedural-storage-toctou";
+
+pub struct InterproceduralStorageTocTouCheck;
+
+fn get_storage_tier(m: &ExprMethodCall) -> Option<String> {
+    let mut current = &m.receiver;
+    loop {
+        match &**current {
+            Expr::MethodCall(mc) => {
+                if matches!(
+                    mc.method.to_string().as_str(),
+                    "persistent" | "instance" | "temporary"
+                ) {
+                    return Some(mc.method.to_string());
+                }
+                current = &mc.receiver;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn expr_to_string(expr: &Expr) -> String {
+    expr.to_token_stream().to_string()
+}
+
+struct StorageOp {
+    kind: OpKind,
+    key_tokens: String,
+    tier: String,
+    line: usize,
+    function_name: String,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum OpKind {
+    Read,
+    Write,
+}
+
+fn method_name_is_storage_read(name: &str) -> bool {
+    matches!(name, "has" | "get")
+}
+
+fn method_name_is_storage_write(name: &str) -> bool {
+    matches!(name, "set" | "remove")
+}
+
+fn collect_ops_in_block<'a>(
+    block: &'a syn::Block,
+    current_fn: &str,
+    impl_items: &'a [ImplItem],
+) -> Vec<StorageOp> {
+    let mut ops = Vec::new();
+    collect_ops_visitor(block, current_fn, impl_items, &mut ops);
+    ops
+}
+
+fn collect_ops_visitor(
+    block: &syn::Block,
+    current_fn: &str,
+    impl_items: &[ImplItem],
+    ops: &mut Vec<StorageOp>,
+) {
+    struct Inner<'a> {
+        current_fn: &'a str,
+        impl_items: &'a [ImplItem],
+        ops: &'a mut Vec<StorageOp>,
+    }
+
+    impl<'ast> Visit<'ast> for Inner<'ast> {
+        fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+            let method_name = i.method.to_string();
+
+            if method_name_is_storage_read(&method_name) || method_name_is_storage_write(&method_name)
+            {
+                if receiver_chain_contains_storage(&i.receiver) {
+                    if let Some(tier) = get_storage_tier(i) {
+                        if let Some(arg) = i.args.first() {
+                            let kind = if method_name_is_storage_read(&method_name) {
+                                OpKind::Read
+                            } else {
+                                OpKind::Write
+                            };
+                            ops.push(StorageOp {
+                                kind,
+                                key_tokens: expr_to_string(arg),
+                                tier,
+                                line: i.span().start().line,
+                                function_name: self.current_fn.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            visit::visit_expr_method_call(self, i);
+        }
+
+        fn visit_expr_call(&mut self, i: &'ast syn::ExprCall) {
+            if let Expr::Path(p) = &*i.func {
+                if let Some(ident) = p.path.get_ident() {
+                    let callee = ident.to_string();
+                    for item in self.impl_items {
+                        if let ImplItem::Fn(m) = item {
+                            if m.sig.ident == callee {
+                                let inner = Inner {
+                                    current_fn: &callee,
+                                    impl_items: self.impl_items,
+                                    ops: &mut *self.ops,
+                                };
+                                inner.visit_block(&m.block);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            visit::visit_expr_call(self, i);
+        }
+    }
+
+    let mut inner = Inner {
+        current_fn,
+        impl_items,
+        ops,
+    };
+    inner.visit_block(block);
+}
+
+fn is_read_same_fn_as_write(read: &StorageOp, write: &StorageOp) -> bool {
+    read.function_name == write.function_name
+}
+
+impl Check for InterproceduralStorageTocTouCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut out = Vec::new();
+
+        let contractimpl_blocks: Vec<&ItemImpl> = file
+            .items
+            .iter()
+            .filter_map(|item| {
+                if let syn::Item::Impl(item_impl) = item {
+                    if crate::util::is_contractimpl(item_impl) {
+                        return Some(item_impl);
+                    }
+                }
+                None
+            })
+            .collect();
+
+        for impl_block in &contractimpl_blocks {
+            for entrypoint in contractimpl_functions(file) {
+                let fn_name = entrypoint.sig.ident.to_string();
+                let mut reachable_ops =
+                    collect_ops_in_block(&entrypoint.block, &fn_name, &impl_block.items);
+
+                let mut own_function_names: Vec<String> = Vec::new();
+
+                struct OwnFnCollector<'a> {
+                    own_fns: &'a mut Vec<String>,
+                }
+                impl<'ast> Visit<'ast> for OwnFnCollector<'ast> {
+                    fn visit_expr_call(&mut self, i: &'ast syn::ExprCall) {
+                        if let Expr::Path(p) = &*i.func {
+                            if let Some(ident) = p.path.get_ident() {
+                                self.own_fns.push(ident.to_string());
+                            }
+                        }
+                        visit::visit_expr_call(self, i);
+                    }
+                }
+                let mut collector = OwnFnCollector {
+                    own_fns: &mut own_function_names,
+                };
+                collector.visit_block(&entrypoint.block);
+
+                if reachable_ops.len() < 2 {
+                    continue;
+                }
+
+                let reads: Vec<&StorageOp> = reachable_ops
+                    .iter()
+                    .filter(|o| o.kind == OpKind::Read)
+                    .collect();
+                let writes: Vec<&StorageOp> = reachable_ops
+                    .iter()
+                    .filter(|o| o.kind == OpKind::Write)
+                    .collect();
+
+                for read in &reads {
+                    for write in &writes {
+                        if read.tier != write.tier {
+                            continue;
+                        }
+                        if read.key_tokens != write.key_tokens {
+                            continue;
+                        }
+                        if is_read_same_fn_as_write(read, write) {
+                            continue;
+                        }
+                        if read.line >= write.line {
+                            continue;
+                        }
+
+                        out.push(Finding {
+                            check_name: CHECK_NAME.to_string(),
+                            severity: Severity::High,
+                            file_path: String::new(),
+                            line: read.line,
+                            function_name: fn_name.clone(),
+                            description: format!(
+                                "Interprocedural TOCTOU: `{}()`/{}/`{}` reads key `{}` in `{}()` at line {} \
+                                 but `{}()` in `{}()` writes the same key at line {} without re-checking. \
+                                 An attacker can race the read and write across function boundaries.",
+                                read.tier,
+                                if read.key_tokens.starts_with('&') { "has" } else { "get" },
+                                read.key_tokens,
+                                read.key_tokens,
+                                read.function_name,
+                                read.line,
+                                write.tier,
+                                write.function_name,
+                                write.line,
+                            ),
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run_on_src(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(InterproceduralStorageTocTouCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_claim_do_claim_split() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+
+pub struct C;
+
+const CLAIMED: Symbol = symbol_short!("claimed");
+
+#[contractimpl]
+impl C {
+    fn already_claimed(env: &Env) -> bool {
+        env.storage().persistent().has(&CLAIMED)
+    }
+
+    fn do_claim(env: &Env) {
+        env.storage().persistent().set(&CLAIMED, &true);
+    }
+
+    pub fn claim(env: Env) {
+        if !Self::already_claimed(&env) {
+            Self::do_claim(&env);
+        }
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 1, "should flag the TOCTOU pattern");
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn safe_when_recheck_in_write_fn() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+
+pub struct C;
+
+const CLAIMED: Symbol = symbol_short!("claimed");
+
+#[contractimpl]
+impl C {
+    fn already_claimed_and_set(env: &Env) -> bool {
+        if env.storage().persistent().has(&CLAIMED) {
+            return true;
+        }
+        env.storage().persistent().set(&CLAIMED, &true);
+        false
+    }
+
+    pub fn claim(env: Env) {
+        Self::already_claimed_and_set(&env);
+    }
+}
+"#,
+        )?;
+        assert!(
+            hits.is_empty(),
+            "safe pattern should not be flagged: {:?}",
+            hits
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn safe_no_cross_function_ops() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+
+pub struct C;
+
+const K: Symbol = symbol_short!("k");
+
+#[contractimpl]
+impl C {
+    pub fn get_directly(env: Env) {
+        let _val = env.storage().persistent().get(&K);
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_different_keys() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+
+pub struct C;
+
+const K1: Symbol = symbol_short!("k1");
+const K2: Symbol = symbol_short!("k2");
+
+#[contractimpl]
+impl C {
+    fn read_k1(env: &Env) -> bool {
+        env.storage().persistent().has(&K1)
+    }
+
+    fn write_k2(env: &Env) {
+        env.storage().persistent().set(&K2, &true);
+    }
+
+    pub fn do_stuff(env: Env) {
+        if Self::read_k1(&env) {
+            Self::write_k2(&env);
+        }
+    }
+}
+"#,
+        )?;
+        assert!(
+            hits.is_empty(),
+            "different keys should not be flagged: {:?}",
+            hits
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_different_tiers() -> Result<(), syn::Error> {
+        let hits = run_on_src(
+            r#"
+use soroban_sdk::{contractimpl, symbol_short, Env, Symbol};
+
+pub struct C;
+
+const K: Symbol = symbol_short!("k");
+
+#[contractimpl]
+impl C {
+    fn read_instance(env: &Env) -> bool {
+        env.storage().instance().has(&K)
+    }
+
+    fn write_persistent(env: &Env) {
+        env.storage().persistent().set(&K, &true);
+    }
+
+    pub fn do_stuff(env: Env) {
+        if Self::read_instance(&env) {
+            Self::write_persistent(&env);
+        }
+    }
+}
+"#,
+        )?;
+        assert!(
+            hits.is_empty(),
+            "different tiers should not be flagged: {:?}",
+            hits
+        );
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -118,6 +118,7 @@ pub mod storage_key_collision;
 pub mod storage_no_cache;
 pub mod storage_type_confusion;
 pub mod storage_type_version;
+pub mod interprocedural_storage_toctou;
 pub mod temp_get_no_has;
 pub mod temp_read_in_view;
 pub mod temp_set_no_ttl;
@@ -280,6 +281,7 @@ pub use storage_key_collision::StorageKeyCollisionCheck;
 pub use storage_no_cache::StorageNoCacheCheck;
 pub use storage_type_confusion::StorageTypeConfusionCheck;
 pub use storage_type_version::StorageTypeVersionCheck;
+pub use interprocedural_storage_toctou::InterproceduralStorageTocTouCheck;
 pub use temp_get_no_has::TempGetNoHasCheck;
 pub use temp_set_no_ttl::TempSetNoTtlCheck;
 pub use tier_key_collision::TierKeyCollisionCheck;
@@ -457,6 +459,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TokenSharedStorageCheck),
         Box::new(AdminNoEventCheck),
         Box::new(UnauthorizedStorageReadCheck),
+        Box::new(InterproceduralStorageTocTouCheck),
         Box::new(TierKeyCollisionCheck),
         Box::new(StorageTypeVersionCheck),
         Box::new(AdminZeroAddressCheck),

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -265,3 +265,31 @@ When a contract upgrades itself via `env.deployer().update_current_contract_wasm
 - Token matching is case-insensitive but purely textual - a key named `SCHEMA_VERSION` constant satisfies it only if those characters appear in the token stream at the call site.
 
 **Fixture:** `test-contracts/upgrade-no-schema-version-vulnerable/`, `test-contracts/upgrade-no-schema-version-safe/`
+
+---
+
+## `interprocedural-storage-toctou` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+Using the call graph, for each public `#[contractimpl]` entrypoint, this check finds every storage `has`/`get` read reachable from it and every storage `set`/`remove` write reachable from it. It flags when:
+
+1. A read and a write operate on the **same storage key** (structural token comparison) and the **same storage tier** (`persistent`/`instance`/`temporary`).
+2. The read happens in a **different function** than the write (i.e. the read and write are not in the same function body).
+3. The read precedes the write (`read.line < write.line`).
+
+This catches the common Soroban pattern where a `claim()` entrypoint calls `already_claimed()` (which does `has()`) and then `do_claim()` (which does `set()`) — two separate functions with no shared local variable, invisible to single-function checks like `storage-has-get-race`.
+
+**Why it matters**
+
+Without a re-check guard (early return / panic / assert) structurally between the read and the write, an attacker can race the two calls by submitting two transactions that execute the `has()` check before either executes the `set()` write, leading to double-claim, double-withdrawal, or similar TOCTOU exploits.
+
+**Limitations**
+
+- Only follows direct `Self::foo(...)` and `foo(...)` calls within the same `#[contractimpl]` impl block. Does not follow calls through trait methods, external contracts, or closures.
+- Key equality is determined by structural token-string comparison, not semantic equivalence. Two different expressions that produce the same runtime key (e.g. `&KEY` vs `&Symbol::new(&env, "key")`) are treated as different keys.
+- The check does not analyze guards (early returns, panics) structurally — it relies on the read/write being in different functions as its primary signal. A safe pattern that folds the re-check into the write function (e.g. `already_claimed_and_set`) is not flagged.
+
+**Fixture:** `test-contracts/interprocedural-storage-toctou-vulnerable/`, `test-contracts/interprocedural-storage-toctou-safe/`

--- a/test-contracts/interprocedural-storage-toctou-safe/Cargo.toml
+++ b/test-contracts/interprocedural-storage-toctou-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "interprocedural-storage-toctou-safe"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/interprocedural-storage-toctou-safe/src/lib.rs
+++ b/test-contracts/interprocedural-storage-toctou-safe/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct InterproceduralTocTouSafe;
+
+const CLAIMED: Symbol = symbol_short!("claimed");
+
+#[contractimpl]
+impl InterproceduralTocTouSafe {
+    fn already_claimed_and_set(env: &Env) -> bool {
+        if env.storage().persistent().has(&CLAIMED) {
+            return true;
+        }
+        env.storage().persistent().set(&CLAIMED, &true);
+        false
+    }
+
+    pub fn claim(env: Env) {
+        Self::already_claimed_and_set(&env);
+    }
+}

--- a/test-contracts/interprocedural-storage-toctou-vulnerable/Cargo.toml
+++ b/test-contracts/interprocedural-storage-toctou-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "interprocedural-storage-toctou-vulnerable"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0", features = ["testutils"] }

--- a/test-contracts/interprocedural-storage-toctou-vulnerable/src/lib.rs
+++ b/test-contracts/interprocedural-storage-toctou-vulnerable/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct InterproceduralTocTouVulnerable;
+
+const CLAIMED: Symbol = symbol_short!("claimed");
+
+#[contractimpl]
+impl InterproceduralTocTouVulnerable {
+    fn already_claimed(env: &Env) -> bool {
+        env.storage().persistent().has(&CLAIMED)
+    }
+
+    fn do_claim(env: &Env) {
+        env.storage().persistent().set(&CLAIMED, &true);
+    }
+
+    pub fn claim(env: Env) {
+        if !Self::already_claimed(&env) {
+            Self::do_claim(&env);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new static analysis check `interprocedural-storage-toctou` that detects TOCTOU (time-of-check-time-of-use) vulnerabilities where `has()`/`get()` storage reads and `set()`/`remove()` storage writes on the same key live in **different functions** — invisible to single-function checks like `storage-has-get-race`.

### Detection logic

1. For each `#[contractimpl]` entrypoint, builds a lightweight call graph following `Self::foo(...)` and bare `foo(...)` calls within the same impl block.
2. Collects all storage `has`/`get` reads and `set`/`remove` writes reachable from each entrypoint, tagged with storage tier and key expression (token-string comparison via `quote::ToTokens`).
3. Flags when a read and a write operate on the same key and tier, the read is in a different function than the write, and the read precedes the write.

### Changes

- **New file:** `crates/checks/src/interprocedural_storage_toctou.rs` — check implementation with unit tests
- **Modified:** `crates/checks/src/lib.rs` — module registration and default_checks entry
- **Modified:** `docs/checks.md` — rule documentation
- **New fixtures:** `test-contracts/interprocedural-storage-toctou-vulnerable/` and `-safe/`

Closes #401