### PR TITLE
feat(checks): add revoked-admin-reuse check

### DIFF
--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -103,6 +103,7 @@ pub mod persistent_overwrite;
 pub mod redundant_auth_args;
 pub mod reentrancy;
 pub mod renounce_no_backup;
+pub mod revoked_admin_reuse;
 pub mod result_err_ignored;
 pub mod result_non_exhaustive;
 pub mod runtime_symbol;
@@ -265,6 +266,7 @@ pub use persistent_overwrite::PersistentOverwriteCheck;
 pub use redundant_auth_args::RedundantAuthArgsCheck;
 pub use reentrancy::ReentrancyCheck;
 pub use renounce_no_backup::RenounceNoBackupCheck;
+pub use revoked_admin_reuse::RevokedAdminReuseCheck;
 pub use result_err_ignored::ResultErrIgnoredCheck;
 pub use result_non_exhaustive::ResultNonExhaustiveCheck;
 pub use runtime_symbol::RuntimeSymbolCheck;
@@ -397,6 +399,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(WeakCommitmentKnownCheck),
         Box::new(ReentrancyCheck),
         Box::new(ResultErrIgnoredCheck),
+        Box::new(RevokedAdminReuseCheck),
         Box::new(TokenTransferUncheckedCheck),
         Box::new(ContracterrorAttrCheck),
         Box::new(TokenBurnAuthCheck),

--- a/crates/checks/src/revoked_admin_reuse.rs
+++ b/crates/checks/src/revoked_admin_reuse.rs
@@ -1,0 +1,672 @@
+//! Detects admin-setting functions that do not check a revoked/blacklisted-admins
+//! collection that is maintained elsewhere in the same file.
+//!
+//! # Vulnerability class: revoked-admin-reuse
+//!
+//! A contract that maintains a "removed admins" collection for audit/compliance
+//! purposes has a real bug if `set_admin(new_admin)` never checks `new_admin`
+//! against that collection — a previously revoked admin can be silently
+//! re-appointed, defeating the revocation.
+//!
+//! # Algorithm (file-level, two-pass)
+//!
+//! **Pass 1 — detect revoked-admins collection(s):**
+//! Walk every `#[contractimpl]` function body. When we find a method call of
+//! `push_back` or `insert` whose receiver chain (going up to the storage key)
+//! contains an identifier whose name matches a revocation keyword (revoked,
+//! removed, blacklist, denylist, banned), record the storage key string (if a
+//! string literal key is used) or variable name(s) involved. We also look for
+//! standalone patterns: a storage `get/set` whose key identifier contains
+//! revocation keywords.
+//!
+//! **Pass 2 — detect admin-setting functions without membership check:**
+//! For each function whose name matches the ADMIN_SETTER_NAMES heuristic (set_admin,
+//! set_owner, transfer_ownership, update_admin, change_admin, rotate_admin, …) that
+//! also has an `Address`-typed parameter and stores something to storage: check
+//! whether its body contains a `.contains(` or `.has(` call that references a
+//! revocation-flavoured identifier. If no such check is present, flag it.
+//!
+//! # Limitations
+//!
+//! - Pure syntactic analysis: no type inference, no call-graph expansion.
+//! - Only detects revoked-admins collections that exist in the *same* file.
+//! - The membership check is identified heuristically: any `.contains(` or
+//!   `.has(` call whose receiver or arguments contain a revocation-keyword
+//!   identifier clears the finding.
+//! - A helper function that performs the check but isn't inlined will produce a
+//!   false positive.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, File, Ident, LitStr};
+
+const CHECK_NAME: &str = "revoked-admin-reuse";
+
+/// Function names that indicate admin rotation.
+const ADMIN_SETTER_NAMES: &[&str] = &[
+    "set_admin",
+    "set_owner",
+    "transfer_ownership",
+    "update_admin",
+    "change_admin",
+    "rotate_admin",
+    "assign_admin",
+    "replace_admin",
+    "new_admin",
+];
+
+/// Substrings in identifiers/keys that suggest a revocation collection.
+const REVOCATION_KEYWORDS: &[&str] = &[
+    "revoked",
+    "removed",
+    "blacklist",
+    "denylist",
+    "banned",
+    "blocklist",
+    "blocked",
+];
+
+pub struct RevokedAdminReuseCheck;
+
+impl Check for RevokedAdminReuseCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let functions = contractimpl_functions(file);
+        if functions.is_empty() {
+            return vec![];
+        }
+
+        // ── Pass 1: Does this file have a revoked-admins collection? ──────────
+        // Collect every revocation-flavoured identifier/key seen anywhere in the
+        // contractimpl body of any function.
+        let revocation_idents: Vec<String> = {
+            let mut collector = RevocationCollector::default();
+            for func in &functions {
+                collector.visit_block(&func.block);
+            }
+            collector.keys
+        };
+
+        if revocation_idents.is_empty() {
+            // No revoked-admins collection detected in this file — nothing to flag.
+            return vec![];
+        }
+
+        // ── Pass 2: Admin-setter functions missing the membership check ───────
+        let mut findings = Vec::new();
+
+        for func in &functions {
+            let fn_name = func.sig.ident.to_string();
+
+            // Only target admin-setter functions.
+            if !ADMIN_SETTER_NAMES.contains(&fn_name.as_str()) {
+                // Broader heuristic: function name contains "admin" or "owner" and
+                // also contains a setter verb.
+                let lower = fn_name.to_lowercase();
+                let is_setter = lower.contains("set_")
+                    || lower.contains("update_")
+                    || lower.contains("change_")
+                    || lower.contains("rotate_")
+                    || lower.contains("assign_")
+                    || lower.contains("replace_");
+                let is_admin_related = lower.contains("admin") || lower.contains("owner");
+                if !(is_setter && is_admin_related) {
+                    continue;
+                }
+            }
+
+            // Does the function have at least one Address parameter?
+            let has_address_param = func.sig.inputs.iter().any(|arg| {
+                if let syn::FnArg::Typed(pt) = arg {
+                    type_contains_address(&pt.ty)
+                } else {
+                    false
+                }
+            });
+            if !has_address_param {
+                continue;
+            }
+
+            // Does the function write to storage?
+            let mut write_scan = StorageWriteScan::default();
+            write_scan.visit_block(&func.block);
+            if !write_scan.found_write {
+                continue;
+            }
+
+            // Does the function body contain a membership check against any of
+            // the revocation-flavoured identifiers?
+            let mut check_scan = MembershipCheckScan {
+                revocation_idents: &revocation_idents,
+                found_check: false,
+            };
+            check_scan.visit_block(&func.block);
+
+            if !check_scan.found_check {
+                let line = func.sig.fn_token.span().start().line;
+                findings.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line,
+                    function_name: fn_name.clone(),
+                    description: format!(
+                        "Function `{fn_name}` sets a new admin but does not check the new \
+                         address against the revoked-admins collection (detected in this \
+                         file). A previously revoked admin can be silently re-appointed."
+                    ),
+                });
+            }
+        }
+
+        findings
+    }
+}
+
+// ─── Helper: does a type path look like `Address`? ───────────────────────────
+
+fn type_contains_address(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(tp) => tp
+            .path
+            .segments
+            .iter()
+            .any(|seg| seg.ident == "Address"),
+        syn::Type::Reference(r) => type_contains_address(&r.elem),
+        _ => false,
+    }
+}
+
+// ─── Pass-1 visitor: collect revocation-keyword identifiers/keys ─────────────
+
+/// Walks AST nodes and records every revocation-flavoured identifier seen:
+/// - Idents / path segments whose name contains a revocation keyword.
+/// - String literal keys (in storage `.get`/`.set` calls, etc.) whose value
+///   contains a revocation keyword.
+///
+/// We record the *lowercased* canonical form so that the pass-2 check doesn't
+/// need to match case.
+#[derive(Default)]
+struct RevocationCollector {
+    keys: Vec<String>,
+}
+
+impl RevocationCollector {
+    fn consider_str(&mut self, s: &str) {
+        let lower = s.to_lowercase();
+        if REVOCATION_KEYWORDS.iter().any(|kw| lower.contains(kw)) && !self.keys.contains(&lower) {
+            self.keys.push(lower);
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for RevocationCollector {
+    fn visit_ident(&mut self, i: &'ast Ident) {
+        self.consider_str(&i.to_string());
+        visit::visit_ident(self, i);
+    }
+
+    fn visit_lit_str(&mut self, i: &'ast LitStr) {
+        self.consider_str(&i.value());
+        visit::visit_lit_str(self, i);
+    }
+}
+
+// ─── Pass-1 storage-write scan ───────────────────────────────────────────────
+
+#[derive(Default)]
+struct StorageWriteScan {
+    found_write: bool,
+}
+
+fn receiver_chain_has_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_has_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_has_storage(&f.base),
+        _ => false,
+    }
+}
+
+impl<'ast> Visit<'ast> for StorageWriteScan {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if !self.found_write {
+            let name = i.method.to_string();
+            if matches!(name.as_str(), "set" | "remove" | "push_back" | "insert")
+                && receiver_chain_has_storage(&i.receiver)
+            {
+                self.found_write = true;
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+// ─── Pass-2 membership-check scan ────────────────────────────────────────────
+
+/// Looks for a `.contains(` or `.has(` call whose receiver or arguments
+/// contain a revocation-keyword identifier, indicating the function does gate
+/// on the revoked-admins list.
+///
+/// Also scans macro invocations (e.g. `assert!(...)`) using their token stream
+/// source text, since the syn visitor does not descend into macro arguments.
+struct MembershipCheckScan<'a> {
+    revocation_idents: &'a [String],
+    found_check: bool,
+}
+
+impl<'a> MembershipCheckScan<'a> {
+    fn ident_matches_any(&self, name: &str) -> bool {
+        let lower = name.to_lowercase();
+        self.revocation_idents
+            .iter()
+            .any(|k| lower.contains(k.as_str()) || k.contains(&lower))
+            || REVOCATION_KEYWORDS.iter().any(|kw| lower.contains(kw))
+    }
+
+    /// Check whether a raw token stream string (from a macro body) contains a
+    /// membership-check pattern referencing a revocation-flavoured name.
+    ///
+    /// `proc_macro2::TokenStream::to_string()` inserts spaces between tokens,
+    /// so we can't match `.contains(` literally. Instead we check that both a
+    /// revocation-keyword identifier AND a membership-check method name appear
+    /// anywhere in the token text — a conservative but effective heuristic.
+    fn macro_tokens_have_check(&self, tokens: &str) -> bool {
+        let has_membership_method = tokens.contains("contains")
+            || tokens.contains("has");
+
+        if !has_membership_method {
+            return false;
+        }
+
+        // Check if any word in the tokens matches a revocation keyword.
+        for word in tokens.split(|c: char| !c.is_alphanumeric() && c != '_') {
+            if !word.is_empty() && self.ident_matches_any(word) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl<'ast, 'a> Visit<'ast> for MembershipCheckScan<'a> {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if !self.found_check {
+            let method_name = i.method.to_string();
+            if matches!(method_name.as_str(), "contains" | "has" | "contains_key") {
+                // Check if the receiver chain or any argument ident is
+                // revocation-flavoured.
+                let mut ident_scan = IdentCollector::default();
+                ident_scan.visit_expr(&i.receiver);
+                for arg in &i.args {
+                    ident_scan.visit_expr(arg);
+                }
+                if ident_scan
+                    .names
+                    .iter()
+                    .any(|n| self.ident_matches_any(n))
+                {
+                    self.found_check = true;
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_macro(&mut self, i: &'ast syn::Macro) {
+        if !self.found_check {
+            // Macros are opaque to the AST visitor — fall back to scanning the
+            // raw token stream text for membership-check patterns.
+            let tokens_str = i.tokens.to_string();
+            if self.macro_tokens_have_check(&tokens_str) {
+                self.found_check = true;
+            }
+        }
+        visit::visit_macro(self, i);
+    }
+}
+
+/// Collects all identifiers in an expression subtree.
+#[derive(Default)]
+struct IdentCollector {
+    names: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for IdentCollector {
+    fn visit_ident(&mut self, i: &'ast Ident) {
+        self.names.push(i.to_string().to_lowercase());
+        visit::visit_ident(self, i);
+    }
+    fn visit_lit_str(&mut self, i: &'ast LitStr) {
+        self.names.push(i.value().to_lowercase());
+        visit::visit_lit_str(self, i);
+    }
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    // ── Vulnerable cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn flags_set_admin_missing_revoked_check() -> Result<(), syn::Error> {
+        // revoke_admin pushes to revoked_admins Vec; set_admin never checks it.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    /// Revoke an existing admin and record it.
+    pub fn revoke_admin(env: Env, admin: Address) {
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or_default();
+        revoked.push_back(admin.clone());
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    /// Set a new admin — BUG: never checks revoked_admins.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1, "expected one finding");
+        assert_eq!(hits[0].function_name, "set_admin");
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_set_owner_missing_blacklist_check() -> Result<(), syn::Error> {
+        // Uses the word "blacklist" in variable name.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn ban_admin(env: Env, addr: Address) {
+        let mut blacklist: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&"blacklist")
+            .unwrap_or_default();
+        blacklist.push_back(addr);
+        env.storage().instance().set(&"blacklist", &blacklist);
+    }
+
+    pub fn set_owner(env: Env, new_owner: Address) {
+        env.require_auth();
+        // Missing: check blacklist before accepting new_owner
+        env.storage().instance().set(&"owner", &new_owner);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1, "expected one finding for set_owner");
+        assert_eq!(hits[0].function_name, "set_owner");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_rotate_admin_missing_removed_check() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Map};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn remove_admin(env: Env, addr: Address) {
+        let mut removed: Map<Address, bool> = env
+            .storage()
+            .persistent()
+            .get(&"removed_admins")
+            .unwrap_or_default();
+        removed.set(addr.clone(), true);
+        env.storage().persistent().set(&"removed_admins", &removed);
+    }
+
+    pub fn rotate_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        // Bug: no check against removed_admins
+        env.storage().persistent().set(&"current_admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "rotate_admin");
+        Ok(())
+    }
+
+    // ── Safe cases ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn passes_set_admin_with_contains_check() -> Result<(), syn::Error> {
+        // set_admin explicitly checks revoked_admins.contains(new_admin)
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn revoke_admin(env: Env, admin: Address) {
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or_default();
+        revoked.push_back(admin.clone());
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        let revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or_default();
+        assert!(!revoked.contains(&new_admin), "admin was revoked");
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert!(hits.is_empty(), "expected no findings when check is present");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_set_owner_with_has_on_blacklist_storage() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn ban_address(env: Env, addr: Address) {
+        env.storage().persistent().set(&"blacklist", &addr);
+    }
+
+    pub fn set_owner(env: Env, new_owner: Address) {
+        env.require_auth();
+        let is_blacklisted = env.storage().persistent().has(&"blacklist");
+        assert!(!is_blacklisted, "owner is blacklisted");
+        env.storage().instance().set(&"owner", &new_owner);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_no_revocation_collection_exists() -> Result<(), syn::Error> {
+        // Contract has set_admin but no revocation collection at all — not flagged.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert!(
+            hits.is_empty(),
+            "should not flag when no revocation collection exists"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_contractimpl_impl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{Address, Env, Vec};
+
+pub struct C;
+
+impl C {
+    pub fn revoke_admin(env: Env, admin: Address) {
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or_default();
+        revoked.push_back(admin);
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert!(
+            hits.is_empty(),
+            "should only analyze #[contractimpl] blocks"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn passes_rotate_admin_with_denylist_contains() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn add_to_denylist(env: Env, addr: Address) {
+        let mut denylist: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&"denylist")
+            .unwrap_or_default();
+        denylist.push_back(addr);
+        env.storage().instance().set(&"denylist", &denylist);
+    }
+
+    pub fn rotate_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        let denylist: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&"denylist")
+            .unwrap_or_default();
+        assert!(!denylist.contains(&new_admin));
+        env.storage().instance().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert!(hits.is_empty(), "rotate_admin does check the denylist");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_update_admin_heuristic_name() -> Result<(), syn::Error> {
+        // Not in ADMIN_SETTER_NAMES but matches broader heuristic.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Address, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn record_revoked(env: Env, addr: Address) {
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or_default();
+        revoked.push_back(addr);
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    pub fn update_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+}
+"#,
+        )?;
+        let hits = RevokedAdminReuseCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "update_admin");
+        Ok(())
+    }
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -265,3 +265,44 @@ When a contract upgrades itself via `env.deployer().update_current_contract_wasm
 - Token matching is case-insensitive but purely textual - a key named `SCHEMA_VERSION` constant satisfies it only if those characters appear in the token stream at the call site.
 
 **Fixture:** `test-contracts/upgrade-no-schema-version-vulnerable/`, `test-contracts/upgrade-no-schema-version-safe/`
+
+---
+
+## `revoked-admin-reuse` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+Contracts that maintain a "revoked / removed admins" collection for audit or compliance purposes, but whose admin-rotation function never checks the incoming address against that collection before accepting it as the new admin.
+
+The check runs in two passes over all `#[contractimpl]` function bodies in the file:
+
+**Pass 1 — revocation-collection detection**
+
+Walk every identifier and string literal in every `#[contractimpl]` function body. Any identifier or key string whose lowercased text contains one of the following revocation keywords is recorded as a "revocation token":
+
+`revoked`, `removed`, `blacklist`, `denylist`, `banned`, `blocklist`, `blocked`
+
+If no such token is found anywhere in the file, the check produces no findings.
+
+**Pass 2 — admin-setter without membership check**
+
+For each function whose name matches the admin-setter heuristic (exact members of `ADMIN_SETTER_NAMES`: `set_admin`, `set_owner`, `transfer_ownership`, `update_admin`, `change_admin`, `rotate_admin`, `assign_admin`, `replace_admin`, `new_admin`; or the broader rule: name contains a setter verb *and* contains `admin` or `owner`):
+
+1. The function must accept at least one `Address` parameter.
+2. The function must contain at least one storage write (`set`, `remove`, `push_back`, or `insert` on a receiver chain that includes `.storage()`).
+3. If conditions 1 and 2 hold, the body is scanned for a `.contains(`, `.has(`, or `.contains_key(` method call whose receiver or arguments involve a revocation-keyword identifier. If no such call is found, the function is flagged.
+
+**Why it matters**
+
+An admin-rotation mechanism that maintains a "removed admins" list for compliance reasons silently breaks if `set_admin(new_admin)` never cross-checks `new_admin` against that list. A previously revoked admin can be re-appointed without detection, defeating the entire removal mechanism.
+
+**Limitations**
+
+- Pure syntactic analysis: no type inference, no inter-procedural call graph. A helper function that performs the membership check internally will produce a false positive if not inlined.
+- Only detects revoked-admins collections that exist in the *same* file as the admin-setter.
+- The membership-check detection is heuristic: any `.contains(` / `.has(` call whose receiver or arguments contain a revocation-keyword identifier clears the finding, regardless of whether it is actually guarding the storage write.
+- The collection-detection pass fires on any identifier that *contains* a revocation keyword (e.g. a local variable named `not_revoked` would match `revoked`). Narrow your variable names to avoid false negatives in unusual cases.
+
+**Fixture:** `test-contracts/revoked-admin-reuse-vulnerable/`, `test-contracts/revoked-admin-reuse-safe/`

--- a/test-contracts/revoked-admin-reuse-safe/Cargo.toml
+++ b/test-contracts/revoked-admin-reuse-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-revoked-admin-reuse-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/revoked-admin-reuse-safe/src/lib.rs
+++ b/test-contracts/revoked-admin-reuse-safe/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+//! Safe fixture for `revoked-admin-reuse`.
+//!
+//! `set_admin` explicitly loads the `revoked_admins` Vec and asserts the new
+//! address is not present before accepting it, preventing re-appointment of a
+//! previously revoked admin.
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+#[contract]
+pub struct RevokedAdminReuseSafe;
+
+#[contractimpl]
+impl RevokedAdminReuseSafe {
+    /// Record a revoked admin in persistent storage for compliance tracking.
+    pub fn revoke_admin(env: Env, admin: Address) {
+        env.require_auth();
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or(Vec::new(&env));
+        revoked.push_back(admin.clone());
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    /// ✅ SAFE: checks that new_admin is not in the revoked list before
+    /// storing it as the current admin.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        let revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or(Vec::new(&env));
+        // Reject a previously revoked admin.
+        if revoked.contains(&new_admin) {
+            panic!("address was previously revoked and cannot be re-appointed as admin");
+        }
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+
+    /// Read the current admin.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().persistent().get(&"admin").unwrap()
+    }
+}

--- a/test-contracts/revoked-admin-reuse-vulnerable/Cargo.toml
+++ b/test-contracts/revoked-admin-reuse-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-revoked-admin-reuse-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/revoked-admin-reuse-vulnerable/src/lib.rs
+++ b/test-contracts/revoked-admin-reuse-vulnerable/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+//! Vulnerable fixture for `revoked-admin-reuse`.
+//!
+//! This contract maintains a `revoked_admins` Vec for audit purposes, but
+//! `set_admin` never checks whether the incoming address was previously revoked.
+//! A previously-revoked admin can be silently re-appointed.
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+#[contract]
+pub struct RevokedAdminReuseVulnerable;
+
+#[contractimpl]
+impl RevokedAdminReuseVulnerable {
+    /// Record a revoked admin in persistent storage for compliance tracking.
+    pub fn revoke_admin(env: Env, admin: Address) {
+        env.require_auth();
+        let mut revoked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&"revoked_admins")
+            .unwrap_or(Vec::new(&env));
+        revoked.push_back(admin.clone());
+        env.storage().persistent().set(&"revoked_admins", &revoked);
+    }
+
+    /// ❌ BUG: accepts any Address as the new admin without checking the
+    /// revoked_admins list — a previously revoked admin can be re-appointed.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        env.require_auth();
+        // Missing: check that new_admin is not in revoked_admins
+        env.storage().persistent().set(&"admin", &new_admin);
+    }
+
+    /// Read the current admin.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().persistent().get(&"admin").unwrap()
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `revoked-admin-reuse` detector requested in #420.

A contract that maintains a "revoked / removed admins" collection for audit or compliance purposes has a real bug if `set_admin(new_admin)` never checks `new_admin` against that collection — a previously revoked admin can be silently re-appointed, defeating the revocation.

## Detection algorithm (two-pass, file-level)

**Pass 1 — detect revoked-admins collection:**
Walk every `#[contractimpl]` function body and collect every identifier / string-literal key whose name contains a revocation keyword: `revoked`, `removed`, `blacklist`, `denylist`, `banned`, `blocklist`, `blocked`.

**Pass 2 — flag admin-setter functions missing the membership check:**
For each function matching the admin-setter heuristic (name in `ADMIN_SETTER_NAMES` or matches setter + admin/owner pattern) that takes an `Address` param and writes to storage: flag it if its body contains no `.contains()` / `.has()` call referencing a revocation-flavoured identifier. Macro invocations (`assert!`, `require!`) are scanned via raw token-stream text as a fallback, since syn's AST visitor treats macros as opaque.

## What's included

| File | Change |
|------|--------|
| `crates/checks/src/revoked_admin_reuse.rs` | New check module + 9 unit tests |
| `crates/checks/src/lib.rs` | `pub mod`, `pub use`, registered in `default_checks()` |
| `test-contracts/revoked-admin-reuse-vulnerable/` | Fixture: `set_admin` with no revocation check (flagged) |
| `test-contracts/revoked-admin-reuse-safe/` | Fixture: `set_admin` checks `revoked.contains(&new_admin)` (passes) |
| `docs/checks.md` | Rule entry: algorithm, severity, limitations, fixture references |

## Tests

All 652 existing tests continue to pass. 9 new tests cover:
- Vulnerable: `set_admin` missing revoked check, `set_owner` missing blacklist check, `rotate_admin` missing removed check, heuristic name match (`update_admin`)
- Safe: `.contains()` check present, `.has()` on blacklist storage, denylist `.contains()` in `assert!`, no revocation collection in file

## Limitations (documented in `docs/checks.md`)

- Syntactic only — no type inference or call-graph expansion
- Only detects revoked-admins collections in the same file
- A helper function performing the check but not inlined produces a false positive

Closes #420