### PR TITLE
feat(checks): add batch-partial-write check

### DIFF
--- a/crates/checks/src/batch_partial_write.rs
+++ b/crates/checks/src/batch_partial_write.rs
@@ -1,0 +1,579 @@
+//! Detects loops over a Vec/iterable parameter where the loop body contains
+//! both a storage mutation and an early-exit (return / `?` / conditional break)
+//! that is reachable **after** the mutation within the same iteration.
+//!
+//! # Vulnerability class: batch-partial-write
+//!
+//! ```rust,ignore
+//! for item in items.iter() {
+//!     env.storage().persistent().set(&item.key, &item.value); // ← write
+//!     if !validate(&item) {
+//!         return Err(ContractError::Invalid); // ← exit AFTER write
+//!     }
+//! }
+//! ```
+//!
+//! If `items[2]` fails validation, items 0 and 1 have already been committed
+//! to storage.  Soroban's contract-local storage does not roll back on a
+//! Rust-level `return Err(…)` inside the same invocation — the earlier writes
+//! persist.
+//!
+//! # Safe two-pass pattern (suppressed)
+//!
+//! The check recognises the safe idiom where the function contains **two**
+//! separate top-level loops over the **same** iterable: the first loop
+//! contains only validation (exits, no writes) and the second only mutations
+//! (writes, no exits meaningful to atomicity).  When that pattern is found,
+//! no finding is emitted for either loop.
+//!
+//! # Algorithm
+//!
+//! For each `for` / `while` loop inside a `#[contractimpl]` function:
+//!
+//! 1. Collect all storage-mutation nodes in the loop body
+//!    (`env.storage().*.set`, `.remove`, `.push_back`, `.insert`).
+//! 2. Collect all early-exit nodes: `return`, `?` operator, `panic!`.
+//! 3. Flag if the loop body has **at least one mutation AND at least one
+//!    early-exit that appears textually after the first mutation** — a
+//!    conservative linear-order approximation.
+//! 4. Suppress the finding when the enclosing function has **two or more
+//!    top-level loops over the same iterable** and at least one of those loops
+//!    is mutation-free (pure validation) — the safe two-pass idiom.
+//!
+//! # Limitations
+//!
+//! - Statement ordering is used as a CFG approximation; a mutation inside an
+//!   always-taken branch that precedes a conditional exit is not distinguished
+//!   from one that may not execute.
+//! - Two-pass suppression requires both loops to reference the same iterable
+//!   variable name.  A rename or intermediate binding defeats it.
+//! - Mutations inside helper-function calls are not tracked (false negatives).
+//! - Nested loops are not recursed into; only the outermost loop level is
+//!   checked.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::{HashMap, HashSet};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprForLoop, ExprMethodCall, ExprReturn, ExprTry, ExprWhile, File, Stmt};
+
+const CHECK_NAME: &str = "batch-partial-write";
+
+pub struct BatchPartialWriteCheck;
+
+impl Check for BatchPartialWriteCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for func in contractimpl_functions(file) {
+            let fn_name = func.sig.ident.to_string();
+
+            // Collect all top-level loops in the function body.
+            let mut collector = TopLevelLoopCollector::default();
+            collector.visit_block(&func.block);
+            let loops = collector.loops;
+
+            if loops.is_empty() {
+                continue;
+            }
+
+            // Determine which iterables have the safe two-pass pattern.
+            let safe_iterables = detect_two_pass_iterables(&loops);
+
+            for lp in &loops {
+                // Suppress if this loop is part of a confirmed two-pass pattern.
+                if let Some(ref name) = lp.iter_name {
+                    if safe_iterables.contains(name.as_str()) {
+                        continue;
+                    }
+                }
+
+                if loop_has_write_then_exit(lp) {
+                    findings.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: lp.line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Function `{fn_name}` writes to storage inside a loop and then has \
+                             an early-exit (return / ?) reachable in the same iteration. If a \
+                             later element triggers the exit, earlier elements are already \
+                             committed — the batch is partially applied with no rollback."
+                        ),
+                    });
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ─── Data model ──────────────────────────────────────────────────────────────
+
+struct LoopInfo {
+    /// Lowercased base variable name of the iterable (if determinable).
+    iter_name: Option<String>,
+    /// Source line of the loop keyword.
+    line: usize,
+    /// Ordered sequence of events observed in the loop body.
+    events: Vec<LoopEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum LoopEvent {
+    StorageWrite,
+    EarlyExit,
+}
+
+// ─── Two-pass suppression ─────────────────────────────────────────────────────
+
+/// Returns the set of iterable names for which the function uses the safe
+/// two-pass idiom: at least one loop with NO mutations (validation-only) AND
+/// at least one loop WITH mutations, both iterating the same variable.
+fn detect_two_pass_iterables<'a>(loops: &'a [LoopInfo]) -> HashSet<&'a str> {
+    let mut by_iter: HashMap<&str, (bool, bool)> = HashMap::new();
+    // (has_pure_validation_loop, has_mutation_loop)
+    for lp in loops {
+        if let Some(ref name) = lp.iter_name {
+            let has_write = lp.events.iter().any(|e| *e == LoopEvent::StorageWrite);
+            let entry = by_iter.entry(name.as_str()).or_insert((false, false));
+            if !has_write {
+                entry.0 = true; // pure-validation loop
+            } else {
+                entry.1 = true; // mutation loop
+            }
+        }
+    }
+
+    by_iter
+        .into_iter()
+        .filter(|(_, (pure_val, has_mut))| *pure_val && *has_mut)
+        .map(|(name, _)| name)
+        .collect()
+}
+
+// ─── Vulnerable-pattern check ─────────────────────────────────────────────────
+
+/// True when the loop body has a storage write followed (in textual order) by
+/// at least one early-exit.
+fn loop_has_write_then_exit(lp: &LoopInfo) -> bool {
+    let mut seen_write = false;
+    for event in &lp.events {
+        match event {
+            LoopEvent::StorageWrite => seen_write = true,
+            LoopEvent::EarlyExit => {
+                if seen_write {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// ─── Top-level loop collector ─────────────────────────────────────────────────
+
+/// Visits only the **direct** children of a function body and captures each
+/// `for` / `while` loop without recursing into nested loops.
+#[derive(Default)]
+struct TopLevelLoopCollector {
+    loops: Vec<LoopInfo>,
+}
+
+impl<'ast> Visit<'ast> for TopLevelLoopCollector {
+    fn visit_expr_for_loop(&mut self, i: &'ast ExprForLoop) {
+        let iter_name = extract_iter_name(&i.expr);
+        let mut body_scan = LoopBodyScanner::default();
+        body_scan.visit_block(&i.body);
+        self.loops.push(LoopInfo {
+            iter_name,
+            line: i.for_token.span().start().line,
+            events: body_scan.events,
+        });
+        // Do NOT recurse — nested loops belong to a different "iteration scope".
+    }
+
+    fn visit_expr_while(&mut self, i: &'ast ExprWhile) {
+        let mut body_scan = LoopBodyScanner::default();
+        body_scan.visit_block(&i.body);
+        self.loops.push(LoopInfo {
+            iter_name: None,
+            line: i.while_token.span().start().line,
+            events: body_scan.events,
+        });
+        // Do NOT recurse.
+    }
+}
+
+// ─── Loop body scanner ────────────────────────────────────────────────────────
+
+/// Walks a loop body and records `StorageWrite` and `EarlyExit` events in
+/// textual (statement) order.  Does NOT descend into nested loops.
+#[derive(Default)]
+struct LoopBodyScanner {
+    events: Vec<LoopEvent>,
+}
+
+impl<'ast> Visit<'ast> for LoopBodyScanner {
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        let method = i.method.to_string();
+        if matches!(method.as_str(), "set" | "remove" | "push_back" | "insert") {
+            if receiver_chain_has_storage(&i.receiver) {
+                self.events.push(LoopEvent::StorageWrite);
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+
+    fn visit_expr_try(&mut self, i: &'ast ExprTry) {
+        self.events.push(LoopEvent::EarlyExit);
+        visit::visit_expr_try(self, i);
+    }
+
+    fn visit_expr_return(&mut self, i: &'ast ExprReturn) {
+        self.events.push(LoopEvent::EarlyExit);
+        visit::visit_expr_return(self, i);
+    }
+
+    fn visit_macro(&mut self, i: &'ast syn::Macro) {
+        let name = i
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        if matches!(name.as_str(), "panic" | "todo" | "unreachable") {
+            self.events.push(LoopEvent::EarlyExit);
+        }
+        visit::visit_macro(self, i);
+    }
+
+    // Do NOT descend into nested loops — their events belong to a different
+    // iteration scope.
+    fn visit_expr_for_loop(&mut self, _i: &'ast ExprForLoop) {}
+    fn visit_expr_while(&mut self, _i: &'ast ExprWhile) {}
+
+    fn visit_stmt(&mut self, i: &'ast Stmt) {
+        visit::visit_stmt(self, i);
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Extract the base variable name from a loop's iterable expression.
+/// Handles: `items`, `items.iter()`, `&items`, `items.iter().cloned()`, etc.
+fn extract_iter_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(p) => p.path.get_ident().map(|i| i.to_string()),
+        Expr::Reference(r) => extract_iter_name(&r.expr),
+        Expr::MethodCall(m) => extract_iter_name(&m.receiver),
+        _ => None,
+    }
+}
+
+/// True when the receiver chain of a method call passes through `.storage()`.
+fn receiver_chain_has_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_has_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_has_storage(&f.base),
+        _ => false,
+    }
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    // ── Vulnerable cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn flags_write_then_return_err_in_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn batch_store(env: Env, items: Vec<u32>) -> Result<(), u32> {
+        for item in items.iter() {
+            env.storage().persistent().set(&item, &item);
+            if *item == 0 {
+                return Err(*item);
+            }
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1, "expected one finding");
+        assert_eq!(hits[0].function_name, "batch_store");
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn flags_write_then_question_mark_in_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec, Address};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn apply(env: Env, recipients: Vec<Address>) -> Result<(), ()> {
+        for r in recipients.iter() {
+            env.storage().instance().set(&r, &true);
+            r.require_auth()?;
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "apply");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_write_then_panic_in_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn process(env: Env, keys: Vec<u32>) {
+        for k in keys.iter() {
+            env.storage().temporary().set(&k, &k);
+            if *k > 1000 {
+                panic!("value too large");
+            }
+        }
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "process");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_remove_then_return_in_loop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn prune(env: Env, keys: Vec<u32>) -> Result<(), ()> {
+        for k in keys.iter() {
+            env.storage().persistent().remove(&k);
+            if *k > 999 {
+                return Err(());
+            }
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "prune");
+        Ok(())
+    }
+
+    // ── Safe cases ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn passes_two_pass_validate_then_write() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn batch_store(env: Env, items: Vec<u32>) -> Result<(), u32> {
+        // Pass 1: validate all elements first
+        for item in items.iter() {
+            if *item == 0 {
+                return Err(*item);
+            }
+        }
+        // Pass 2: write all — safe because validation passed for every element
+        for item in items.iter() {
+            env.storage().persistent().set(&item, &item);
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert!(hits.is_empty(), "two-pass pattern should not be flagged");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_exit_before_write_in_loop() -> Result<(), syn::Error> {
+        // Validation guard comes BEFORE the write — safe.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn guarded_store(env: Env, items: Vec<u32>) -> Result<(), u32> {
+        for item in items.iter() {
+            if *item == 0 {
+                return Err(*item);   // exit before any write
+            }
+            env.storage().persistent().set(&item, &item);
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert!(hits.is_empty(), "exit-before-write should not be flagged");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_write_only_loop_no_exit() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn store_all(env: Env, items: Vec<u32>) {
+        for item in items.iter() {
+            env.storage().persistent().set(&item, &item);
+        }
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert!(hits.is_empty(), "write-only loop should not be flagged");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_exit_only_loop_no_write() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn validate_all(env: Env, items: Vec<u32>) -> Result<(), u32> {
+        for item in items.iter() {
+            if *item == 0 {
+                return Err(*item);
+            }
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert!(hits.is_empty(), "exit-only loop should not be flagged");
+        Ok(())
+    }
+
+    #[test]
+    fn passes_non_contractimpl_ignored() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+use soroban_sdk::{Env, Vec};
+
+pub struct C;
+
+impl C {
+    pub fn batch_store(env: Env, items: Vec<u32>) -> Result<(), u32> {
+        for item in items.iter() {
+            env.storage().persistent().set(&item, &item);
+            if *item == 0 { return Err(*item); }
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert!(hits.is_empty(), "non-contractimpl block must be ignored");
+        Ok(())
+    }
+
+    #[test]
+    fn flags_second_loop_when_different_iterables() -> Result<(), syn::Error> {
+        // Two-pass suppression is per-iterable; `writes` loop is still vulnerable.
+        let file = parse_file(
+            r#"
+use soroban_sdk::{contractimpl, Env, Vec};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn mixed(env: Env, checks: Vec<u32>, writes: Vec<u32>) -> Result<(), u32> {
+        for c in checks.iter() {
+            if *c == 0 { return Err(*c); }
+        }
+        for w in writes.iter() {
+            env.storage().persistent().set(&w, &w);
+            if *w > 999 { return Err(*w); }
+        }
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let hits = BatchPartialWriteCheck.run(&file, "");
+        assert_eq!(hits.len(), 1, "writes loop should still be flagged");
+        assert_eq!(hits[0].function_name, "mixed");
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -25,6 +25,7 @@ pub mod authorize_empty;
 pub mod balance_negative_check;
 pub mod balance_not_verified_after_transfer;
 pub mod balance_overflow;
+pub mod batch_partial_write;
 pub mod broken_pause;
 pub mod bump_after_read;
 pub mod bump_to_ttl;
@@ -191,6 +192,7 @@ pub use authorize_empty::AuthorizeEmptyCheck;
 pub use balance_negative_check::BalanceNegativeCheck;
 pub use balance_not_verified_after_transfer::BalanceNotVerifiedAfterTransferCheck;
 pub use balance_overflow::BalanceOverflowCheck;
+pub use batch_partial_write::BatchPartialWriteCheck;
 pub use broken_pause::BrokenPauseCheck;
 pub use bump_after_read::BumpAfterReadCheck;
 pub use bump_to_ttl::BumpToTtlCheck;
@@ -418,6 +420,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(MigrationGuardCheck),
         Box::new(WithdrawAuthCheck),
         Box::new(BrokenPauseCheck),
+        Box::new(BatchPartialWriteCheck),
         Box::new(BytesNotBytesNCheck),
         Box::new(DebugEntrypointCheck),
         Box::new(ExtendTtlInLoopCheck),

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -265,3 +265,92 @@ When a contract upgrades itself via `env.deployer().update_current_contract_wasm
 - Token matching is case-insensitive but purely textual - a key named `SCHEMA_VERSION` constant satisfies it only if those characters appear in the token stream at the call site.
 
 **Fixture:** `test-contracts/upgrade-no-schema-version-vulnerable/`, `test-contracts/upgrade-no-schema-version-safe/`
+
+---
+
+## `revoked-admin-reuse` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+Contracts that maintain a "revoked / removed admins" collection for audit or compliance purposes, but whose admin-rotation function never checks the incoming address against that collection before accepting it as the new admin.
+
+The check runs in two passes over all `#[contractimpl]` function bodies in the file:
+
+**Pass 1 — revocation-collection detection**
+
+Walk every identifier and string literal in every `#[contractimpl]` function body. Any identifier or key string whose lowercased text contains one of the following revocation keywords is recorded as a "revocation token":
+
+`revoked`, `removed`, `blacklist`, `denylist`, `banned`, `blocklist`, `blocked`
+
+If no such token is found anywhere in the file, the check produces no findings.
+
+**Pass 2 — admin-setter without membership check**
+
+For each function whose name matches the admin-setter heuristic (exact members of `ADMIN_SETTER_NAMES`: `set_admin`, `set_owner`, `transfer_ownership`, `update_admin`, `change_admin`, `rotate_admin`, `assign_admin`, `replace_admin`, `new_admin`; or the broader rule: name contains a setter verb *and* contains `admin` or `owner`):
+
+1. The function must accept at least one `Address` parameter.
+2. The function must contain at least one storage write (`set`, `remove`, `push_back`, or `insert` on a receiver chain that includes `.storage()`).
+3. If conditions 1 and 2 hold, the body is scanned for a `.contains(`, `.has(`, or `.contains_key(` method call whose receiver or arguments involve a revocation-keyword identifier. If no such call is found, the function is flagged.
+
+**Why it matters**
+
+An admin-rotation mechanism that maintains a "removed admins" list for compliance reasons silently breaks if `set_admin(new_admin)` never cross-checks `new_admin` against that list. A previously revoked admin can be re-appointed without detection, defeating the entire removal mechanism.
+
+**Limitations**
+
+- Pure syntactic analysis: no type inference, no inter-procedural call graph. A helper function that performs the membership check internally will produce a false positive if not inlined.
+- Only detects revoked-admins collections that exist in the *same* file as the admin-setter.
+- The membership-check detection is heuristic: any `.contains(` / `.has(` call whose receiver or arguments contain a revocation-keyword identifier clears the finding, regardless of whether it is actually guarding the storage write.
+- The collection-detection pass fires on any identifier that *contains* a revocation keyword (e.g. a local variable named `not_revoked` would match `revoked`). Narrow your variable names to avoid false negatives in unusual cases.
+
+**Fixture:** `test-contracts/revoked-admin-reuse-vulnerable/`, `test-contracts/revoked-admin-reuse-safe/`
+
+---
+
+## `batch-partial-write` (High)
+
+**Status:** Phase 2
+
+**What it detects**
+
+A loop over a Vec/iterable parameter that writes to storage **and then** can exit early (via `return`, `?`, or `panic!`) within the same iteration. If a later element triggers the early exit, all earlier elements have already been permanently written — the batch is partially applied with no rollback.
+
+```rust
+// ❌ Vulnerable: write before validation per element
+for item in items.iter() {
+    env.storage().persistent().set(&item.key, &item.value); // committed
+    if !validate(&item) {
+        return Err(ContractError::Invalid); // too late — earlier writes persist
+    }
+}
+```
+
+**Detection algorithm**
+
+For each `for` / `while` loop inside a `#[contractimpl]` function:
+
+1. **Collect storage-mutation events** — any `.set()`, `.remove()`, `.push_back()`, or `.insert()` call whose receiver chain includes `.storage()`.
+2. **Collect early-exit events** — `return` expressions, `?` operators, and `panic!` / `todo!` / `unreachable!` macro invocations.
+3. **Flag** if the loop body has at least one mutation event followed (in textual order) by at least one early-exit event within the same iteration.
+4. **Suppress** the finding when the enclosing function contains two or more top-level loops over the **same** iterable variable and at least one of those loops is mutation-free (the safe two-pass idiom):
+
+```rust
+// ✅ Safe two-pass idiom
+for item in items.iter() { validate(&item)?; }   // no writes
+for item in items.iter() { env.storage()...set(...); }  // no exits
+```
+
+**Why it matters**
+
+Soroban's contract-local storage does not roll back on a Rust-level `return Err(…)` — only a full transaction abort (host trap) would undo earlier writes. A caller who submits a batch where element N fails validation ends up with elements 0…N-1 persisted and N…end skipped, silently corrupting contract state.
+
+**Limitations**
+
+- Statement ordering is used as a CFG approximation; a mutation inside an always-taken branch that precedes a conditional exit is not distinguished from one that may not execute (possible false positive).
+- Two-pass suppression requires both loops to reference the same iterable variable name; a rename or intermediate binding defeats it (possible false positive).
+- Mutations inside helper-function calls are not tracked (false negatives).
+- Nested loops are not recursed into; only top-level loops in the function are checked.
+
+**Fixture:** `test-contracts/batch-partial-write-vulnerable/`, `test-contracts/batch-partial-write-safe/`

--- a/test-contracts/batch-partial-write-safe/Cargo.toml
+++ b/test-contracts/batch-partial-write-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-batch-partial-write-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/batch-partial-write-safe/src/lib.rs
+++ b/test-contracts/batch-partial-write-safe/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+//! Safe fixture for `batch-partial-write`.
+//!
+//! Uses the two-pass idiom: validate **all** elements in a first loop
+//! (no writes), then write **all** elements in a second loop (no exits).
+//! If any element is invalid, the function returns before any write occurs.
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+#[contract]
+pub struct BatchPartialWriteSafe;
+
+#[contractimpl]
+impl BatchPartialWriteSafe {
+    /// ✅ SAFE: two-pass — validate all first, then write all.
+    pub fn batch_update(env: Env, values: Vec<u32>) -> Result<(), u32> {
+        // Pass 1: validate every element before touching storage
+        for val in values.iter() {
+            if val == 0 {
+                return Err(val); // no storage written yet
+            }
+        }
+        // Pass 2: all elements are valid, now write atomically
+        for val in values.iter() {
+            env.storage().persistent().set(&val, &val);
+        }
+        Ok(())
+    }
+
+    /// ✅ SAFE: exit guard comes before the write in the same iteration.
+    pub fn guarded_store(env: Env, keys: Vec<u32>) -> Result<(), u32> {
+        for k in keys.iter() {
+            if k > 1000 {
+                return Err(k); // exit before any write
+            }
+            env.storage().persistent().set(&k, &k);
+        }
+        Ok(())
+    }
+}

--- a/test-contracts/batch-partial-write-vulnerable/Cargo.toml
+++ b/test-contracts/batch-partial-write-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-batch-partial-write-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/batch-partial-write-vulnerable/src/lib.rs
+++ b/test-contracts/batch-partial-write-vulnerable/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+//! Vulnerable fixture for `batch-partial-write`.
+//!
+//! `batch_update` writes each item to storage **before** validating it.
+//! If item[2] fails validation, items[0] and items[1] are already persisted —
+//! the batch is partially applied with no rollback.
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+#[contract]
+pub struct BatchPartialWriteVulnerable;
+
+#[contractimpl]
+impl BatchPartialWriteVulnerable {
+    /// ❌ BUG: writes to storage first, then validates.
+    /// A failing item leaves earlier items permanently written.
+    pub fn batch_update(env: Env, values: Vec<u32>) -> Result<(), u32> {
+        for val in values.iter() {
+            // write happens before validation — partial state on early exit
+            env.storage().persistent().set(&val, &val);
+            if val == 0 {
+                return Err(val); // some earlier items already written!
+            }
+        }
+        Ok(())
+    }
+
+    /// ❌ BUG: uses `?` operator after write inside a loop.
+    pub fn batch_apply(env: Env, keys: Vec<u32>) -> Result<(), u32> {
+        for k in keys.iter() {
+            env.storage().instance().set(&k, &k);
+            let _check = validate(k)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate(v: u32) -> Result<u32, u32> {
+    if v > 1000 { Err(v) } else { Ok(v) }
+}


### PR DESCRIPTION
Detects loops over a Vec/iterable that write to storage and then can exit early (return / ? / panic!) within the same iteration. If a later element triggers the early exit, earlier elements are already committed to Soroban's persistent storage with no rollback.

Algorithm (loop-level, order-aware):
- Collect StorageWrite and EarlyExit events in textual order for each top-level for/while loop inside a #[contractimpl] function.
- Flag when at least one StorageWrite is followed by at least one EarlyExit in the same loop body.
- Suppress the finding when the function uses the safe two-pass idiom: two or more loops over the same iterable, where one is mutation-free (pure validation) and another is exit-free (pure writes).

Adds:
- crates/checks/src/batch_partial_write.rs (check + 10 unit tests)
- test-contracts/batch-partial-write-vulnerable/ (write-then-exit loop)
- test-contracts/batch-partial-write-safe/ (two-pass + exit-before-write)
- docs/checks.md entry for batch-partial-write (High severity)
- Registered in crates/checks/src/lib.rs and default_checks()

Closes #422