### PR TITLE
fix: add upgrade-atomicity-order check — the schema-version write and…

### DIFF
--- a/crates/checks/src/cfg.rs
+++ b/crates/checks/src/cfg.rs
@@ -1,0 +1,703 @@
+//! Minimal control-flow graph + dominance analysis, shared by checks that need
+//! to answer an ordering question ("does A always happen before B on every
+//! path?") rather than "does A appear somewhere in the function?".
+//!
+//! This is intentionally not a general-purpose compiler CFG. It models just
+//! enough of Rust's structured control flow to build a sound graph from a
+//! `syn::Block`:
+//!
+//! - straight-line statement sequences,
+//! - `if`/`else` (including `if` with no `else`, treated as an implicit empty
+//!   `else` that jumps straight to the join point),
+//! - `match` (every arm is a branch into the join point),
+//! - `while` / `for` (the loop header has an edge into the body *and* an edge
+//!   that skips straight to the code after the loop, since the condition may
+//!   be false on entry),
+//! - `loop` (no skip edge — the body always executes at least once; the only
+//!   way out is an explicit `break`),
+//! - `return`, `break`, `continue` as hard terminators that cut off
+//!   fall-through within the current sequence,
+//! - calls to other functions in the same file: a whole-statement call to a
+//!   function present in the supplied registry is *inlined* — the callee's
+//!   own CFG is spliced in at the call site — so markers found inside a
+//!   helper participate in the caller's dominance graph. Direct/mutual
+//!   recursion is broken by a call-stack guard (a function already being
+//!   expanded on the current path is treated as opaque).
+//!
+//! What it does *not* model: closures, `?`-early-return (deliberately: the
+//! two paths through a `?` are "continue normally" or "leave the function
+//! entirely", neither of which changes whether an earlier write dominates a
+//! later call site, so it can be treated as a plain expression), or branch
+//! conditions nested inside arbitrary sub-expressions (only `if`/`match`/loop
+//! used as a whole statement or as a `let` initializer are split into CFG
+//! nodes — the same shapes idiomatic Soroban contracts use).
+//!
+//! Consumers classify expressions into "markers" via a caller-supplied
+//! closure returning a small tag (`u8`); the CFG records where each marker
+//! occurs (block + a monotonically increasing order key) and can then answer
+//! "does the block containing marker A dominate the block containing marker
+//! B, with A occurring first when they share a block?".
+
+use std::collections::{HashMap, HashSet};
+use syn::{Block, Expr, ExprCall, ExprMethodCall, Local, Stmt};
+
+pub type BlockId = usize;
+
+/// A single classified occurrence of interest inside the function (or an
+/// inlined helper), in the order the CFG builder encountered it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Marker {
+    pub tag: u8,
+    pub order: usize,
+    pub line: usize,
+}
+
+struct BlockData {
+    markers: Vec<Marker>,
+    succs: Vec<BlockId>,
+}
+
+/// A built control-flow graph plus every marker the classifier found while
+/// walking it (with inlining already applied).
+pub struct Cfg {
+    blocks: Vec<BlockData>,
+    entry: BlockId,
+}
+
+#[derive(Clone, Copy)]
+struct LoopCtx {
+    header: BlockId,
+    after: BlockId,
+}
+
+struct Builder<'a> {
+    blocks: Vec<BlockData>,
+    registry: &'a HashMap<String, &'a Block>,
+    classify: &'a dyn Fn(&Expr) -> Option<u8>,
+    expanding: Vec<String>,
+    order: usize,
+    loops: Vec<LoopCtx>,
+}
+
+impl<'a> Builder<'a> {
+    fn new_block(&mut self) -> BlockId {
+        self.blocks.push(BlockData {
+            markers: Vec::new(),
+            succs: Vec::new(),
+        });
+        self.blocks.len() - 1
+    }
+
+    fn add_edge(&mut self, from: BlockId, to: BlockId) {
+        self.blocks[from].succs.push(to);
+    }
+
+    fn next_order(&mut self) -> usize {
+        let o = self.order;
+        self.order += 1;
+        o
+    }
+
+    /// Scan a leaf statement/expression for markers, in AST pre-order.
+    fn scan_leaf_expr(&mut self, block: BlockId, expr: &Expr) {
+        let mut v = MarkerVisitor {
+            builder: self,
+            block,
+        };
+        v.walk_expr(expr);
+    }
+
+    fn add_marker(&mut self, block: BlockId, tag: u8, line: usize) {
+        let order = self.next_order();
+        self.blocks[block].markers.push(Marker { tag, order, line });
+    }
+
+    /// Try to resolve a whole-statement call expression to a local function
+    /// name. Handles bare calls (`foo(..)`), `Self::foo(..)` / `Type::foo(..)`,
+    /// and `recv.foo(..)` method calls.
+    fn resolve_call_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Call(ExprCall { func, .. }) => match &**func {
+                Expr::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+                _ => None,
+            },
+            Expr::MethodCall(ExprMethodCall { method, .. }) => Some(method.to_string()),
+            _ => None,
+        }
+    }
+
+    /// If `expr` is a whole-statement call to a registry function (and we are
+    /// not already expanding it on this path), splice the callee's CFG in
+    /// between `current` and a fresh continuation block, returning that
+    /// continuation. Returns `None` if this expression isn't an inlinable
+    /// call (caller should fall back to leaf scanning).
+    fn try_inline(&mut self, current: BlockId, expr: &Expr) -> Option<BlockId> {
+        let name = Self::resolve_call_name(expr)?;
+        let callee = *self.registry.get(&name)?;
+        if self.expanding.contains(&name) {
+            return None;
+        }
+        // Scan the call's own receiver/args for markers before descending,
+        // since e.g. the receiver chain of a method call can itself contain
+        // a classified expression.
+        self.scan_leaf_expr(current, expr);
+
+        self.expanding.push(name);
+        let callee_entry = self.new_block();
+        self.add_edge(current, callee_entry);
+        let exit = self.build_seq(&callee.stmts, callee_entry);
+        self.expanding.pop();
+
+        match exit {
+            Some(exit_block) => {
+                let cont = self.new_block();
+                self.add_edge(exit_block, cont);
+                Some(cont)
+            }
+            // The callee never falls through (e.g. it always returns/panics
+            // on every path) — nothing after this call site is reachable via
+            // this path.
+            None => None,
+        }
+    }
+
+    /// Build a straight-line/branching sequence starting at `start`. Returns
+    /// `Some(open_block)` if control can fall off the end of the sequence, or
+    /// `None` if every path through it terminates (return/break/continue, or
+    /// an inlined call that never returns).
+    fn build_seq(&mut self, stmts: &[Stmt], start: BlockId) -> Option<BlockId> {
+        let mut current = start;
+        for stmt in stmts {
+            match stmt {
+                Stmt::Expr(expr, _) => {
+                    if let Some(next) = self.build_expr_stmt(current, expr)? {
+                        current = next;
+                    }
+                }
+                Stmt::Local(local) => {
+                    current = self.build_local(current, local)?;
+                }
+                Stmt::Macro(m) => {
+                    self.scan_macro(current, &m.mac);
+                }
+                Stmt::Item(_) => {}
+            }
+        }
+        Some(current)
+    }
+
+    /// Returns `Ok`-shaped `Option<Option<BlockId>>`-ish: outer `None` means
+    /// "terminated, stop processing the sequence"; inner `None` means "this
+    /// statement had no control effect, keep `current` as-is" (only used via
+    /// `?` on the outer level — see call site).
+    fn build_expr_stmt(&mut self, current: BlockId, expr: &Expr) -> Option<Option<BlockId>> {
+        match expr {
+            Expr::If(e) => {
+                let join = self.new_block();
+                self.build_if(e, current, join);
+                Some(Some(join))
+            }
+            Expr::Match(e) => {
+                let join = self.new_block();
+                self.build_match(e, current, join);
+                Some(Some(join))
+            }
+            Expr::While(e) => {
+                let after = self.build_while_like(&e.cond, &e.body, current);
+                Some(Some(after))
+            }
+            Expr::ForLoop(e) => {
+                let after = self.build_while_like_forloop(&e.body, current);
+                Some(Some(after))
+            }
+            Expr::Loop(e) => {
+                let after = self.build_plain_loop(&e.body, current);
+                Some(Some(after))
+            }
+            Expr::Return(_) => None,
+            Expr::Break(b) => {
+                if let Some(ctx) = self.loops.last().copied() {
+                    self.add_edge(current, ctx.after);
+                }
+                let _ = b;
+                None
+            }
+            Expr::Continue(_) => {
+                if let Some(ctx) = self.loops.last().copied() {
+                    self.add_edge(current, ctx.header);
+                }
+                None
+            }
+            Expr::Block(b) => {
+                let inner = self.build_seq(&b.block.stmts, current);
+                Some(inner)
+            }
+            _ => {
+                if let Some(cont) = self.try_inline(current, expr) {
+                    Some(Some(cont))
+                } else {
+                    self.scan_leaf_expr(current, expr);
+                    Some(Some(current))
+                }
+            }
+        }
+    }
+
+    fn build_local(&mut self, current: BlockId, local: &Local) -> Option<BlockId> {
+        let Some(init) = &local.init else {
+            return Some(current);
+        };
+        // `let x = if/match/loop { ... };` — split on the initializer.
+        match self.build_expr_stmt(current, &init.expr) {
+            Some(Some(next)) => Some(next),
+            Some(None) => Some(current),
+            None => None,
+        }
+    }
+
+    fn build_if(&mut self, e: &syn::ExprIf, from: BlockId, join: BlockId) {
+        let then_entry = self.new_block();
+        self.add_edge(from, then_entry);
+        if let Some(exit) = self.build_seq(&e.then_branch.stmts, then_entry) {
+            self.add_edge(exit, join);
+        }
+
+        match &e.else_branch {
+            Some((_, else_expr)) => {
+                let else_entry = self.new_block();
+                self.add_edge(from, else_entry);
+                match self.build_expr_stmt(else_entry, else_expr) {
+                    Some(Some(exit)) => self.add_edge(exit, join),
+                    Some(None) | None => {}
+                }
+            }
+            None => {
+                // No else: falling through the condition-false path goes
+                // straight to the join point.
+                self.add_edge(from, join);
+            }
+        }
+    }
+
+    fn build_match(&mut self, e: &syn::ExprMatch, from: BlockId, join: BlockId) {
+        for arm in &e.arms {
+            let arm_entry = self.new_block();
+            self.add_edge(from, arm_entry);
+            match self.build_expr_stmt(arm_entry, &arm.body) {
+                Some(Some(exit)) => self.add_edge(exit, join),
+                Some(None) | None => {}
+            }
+        }
+    }
+
+    fn build_while_like(&mut self, _cond: &Expr, body: &Block, from: BlockId) -> BlockId {
+        let header = self.new_block();
+        self.add_edge(from, header);
+        let after = self.new_block();
+        // Condition may be false immediately: skip the body entirely.
+        self.add_edge(header, after);
+
+        let body_entry = self.new_block();
+        self.add_edge(header, body_entry);
+        self.loops.push(LoopCtx { header, after });
+        if let Some(exit) = self.build_seq(&body.stmts, body_entry) {
+            self.add_edge(exit, header);
+        }
+        self.loops.pop();
+        after
+    }
+
+    fn build_while_like_forloop(&mut self, body: &Block, from: BlockId) -> BlockId {
+        self.build_while_like(&syn::parse_quote!(true), body, from)
+    }
+
+    fn build_plain_loop(&mut self, body: &Block, from: BlockId) -> BlockId {
+        let header = self.new_block();
+        self.add_edge(from, header);
+        let after = self.new_block();
+
+        let body_entry = self.new_block();
+        self.add_edge(header, body_entry);
+        self.loops.push(LoopCtx { header, after });
+        if let Some(exit) = self.build_seq(&body.stmts, body_entry) {
+            self.add_edge(exit, header);
+        }
+        self.loops.pop();
+        after
+    }
+
+    fn scan_macro(&mut self, block: BlockId, mac: &syn::Macro) {
+        if let Ok(expr) = mac.parse_body::<Expr>() {
+            self.scan_leaf_expr(block, &expr);
+        }
+    }
+}
+
+/// Walks an expression tree in pre-order looking for classified markers and
+/// inlinable calls to registry functions that appear as sub-expressions
+/// rather than whole statements (e.g. inside a `let` initializer that is
+/// itself a call: `let x = self.helper(y);`).
+struct MarkerVisitor<'a, 'b> {
+    builder: &'a mut Builder<'b>,
+    block: BlockId,
+}
+
+impl<'a, 'b> MarkerVisitor<'a, 'b> {
+    fn walk_expr(&mut self, expr: &Expr) {
+        if let Some(tag) = (self.builder.classify)(expr) {
+            let line = line_of(expr);
+            self.builder.add_marker(self.block, tag, line);
+        }
+        match expr {
+            Expr::Call(c) => {
+                self.walk_expr(&c.func);
+                for a in &c.args {
+                    self.walk_expr(a);
+                }
+            }
+            Expr::MethodCall(m) => {
+                self.walk_expr(&m.receiver);
+                for a in &m.args {
+                    self.walk_expr(a);
+                }
+            }
+            Expr::Field(f) => self.walk_expr(&f.base),
+            Expr::Reference(r) => self.walk_expr(&r.expr),
+            Expr::Paren(p) => self.walk_expr(&p.expr),
+            Expr::Unary(u) => self.walk_expr(&u.expr),
+            Expr::Binary(b) => {
+                self.walk_expr(&b.left);
+                self.walk_expr(&b.right);
+            }
+            Expr::Assign(a) => {
+                self.walk_expr(&a.left);
+                self.walk_expr(&a.right);
+            }
+            Expr::Try(t) => self.walk_expr(&t.expr),
+            Expr::Cast(c) => self.walk_expr(&c.expr),
+            Expr::Tuple(t) => {
+                for e in &t.elems {
+                    self.walk_expr(e);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn line_of(expr: &Expr) -> usize {
+    use syn::spanned::Spanned;
+    expr.span().start().line
+}
+
+/// Build the CFG for `body`, inlining whole-statement calls to any function
+/// present in `registry`. `classify` tags expressions of interest; markers
+/// are recorded with the block they land in and a global order key that
+/// approximates execution order (including inside inlined callees).
+pub fn build(
+    body: &Block,
+    registry: &HashMap<String, &Block>,
+    classify: &dyn Fn(&Expr) -> Option<u8>,
+) -> Cfg {
+    let mut builder = Builder {
+        blocks: Vec::new(),
+        registry,
+        classify,
+        expanding: Vec::new(),
+        order: 0,
+        loops: Vec::new(),
+    };
+    let entry = builder.new_block();
+    builder.build_seq(&body.stmts, entry);
+    Cfg {
+        blocks: builder.blocks,
+        entry,
+    }
+}
+
+impl Cfg {
+    /// Every marker with the given tag, paired with the block it occurs in.
+    pub fn markers_with_tag(&self, tag: u8) -> Vec<(BlockId, Marker)> {
+        let mut out = Vec::new();
+        for (id, b) in self.blocks.iter().enumerate() {
+            for m in &b.markers {
+                if m.tag == tag {
+                    out.push((id, *m));
+                }
+            }
+        }
+        out
+    }
+
+    fn reachable_preds(&self) -> (Vec<BlockId>, HashMap<BlockId, Vec<BlockId>>) {
+        // Reverse postorder DFS from entry.
+        let mut visited = HashSet::new();
+        let mut postorder = Vec::new();
+        let mut stack: Vec<(BlockId, usize)> = vec![(self.entry, 0)];
+        visited.insert(self.entry);
+        while let Some((node, idx)) = stack.pop() {
+            if idx < self.blocks[node].succs.len() {
+                let succ = self.blocks[node].succs[idx];
+                stack.push((node, idx + 1));
+                if visited.insert(succ) {
+                    stack.push((succ, 0));
+                }
+            } else {
+                postorder.push(node);
+            }
+        }
+        postorder.reverse();
+
+        let reachable: HashSet<BlockId> = postorder.iter().copied().collect();
+        let mut preds: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
+        for &n in &postorder {
+            for &s in &self.blocks[n].succs {
+                if reachable.contains(&s) {
+                    preds.entry(s).or_default().push(n);
+                }
+            }
+        }
+        (postorder, preds)
+    }
+
+    /// Immediate-dominator map for every block reachable from entry (Cooper,
+    /// Harvey & Kennedy's iterative algorithm). Unreachable blocks are simply
+    /// absent — they cannot dominate anything reachable.
+    fn idom(&self) -> HashMap<BlockId, BlockId> {
+        let (rpo, preds) = self.reachable_preds();
+        let rpo_index: HashMap<BlockId, usize> =
+            rpo.iter().enumerate().map(|(i, &b)| (b, i)).collect();
+
+        let mut idom: HashMap<BlockId, BlockId> = HashMap::new();
+        idom.insert(self.entry, self.entry);
+
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for &b in rpo.iter() {
+                if b == self.entry {
+                    continue;
+                }
+                let mut new_idom: Option<BlockId> = None;
+                for &p in preds.get(&b).into_iter().flatten() {
+                    if !idom.contains_key(&p) {
+                        continue;
+                    }
+                    new_idom = Some(match new_idom {
+                        None => p,
+                        Some(cur) => intersect(cur, p, &idom, &rpo_index),
+                    });
+                }
+                if let Some(ni) = new_idom {
+                    if idom.get(&b) != Some(&ni) {
+                        idom.insert(b, ni);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        idom
+    }
+
+    /// Does block `a` dominate block `b`? (`a == b` counts as dominating.)
+    /// Both must be reachable from entry; an unreachable block dominates and
+    /// is dominated by nothing.
+    pub fn block_dominates(&self, a: BlockId, b: BlockId) -> bool {
+        let idom = self.idom();
+        if !idom.contains_key(&a) || !idom.contains_key(&b) {
+            return false;
+        }
+        let mut cur = b;
+        loop {
+            if cur == a {
+                return true;
+            }
+            let next = idom[&cur];
+            if next == cur {
+                return cur == a;
+            }
+            cur = next;
+        }
+    }
+
+    /// Does marker `a` dominate marker `b` on every path (with `a` occurring
+    /// strictly first when they share a block)?
+    pub fn marker_dominates(&self, a_block: BlockId, a: Marker, b_block: BlockId, b: Marker) -> bool {
+        if a_block == b_block {
+            return a.order < b.order;
+        }
+        self.block_dominates(a_block, b_block)
+    }
+}
+
+fn intersect(
+    mut a: BlockId,
+    mut b: BlockId,
+    idom: &HashMap<BlockId, BlockId>,
+    rpo_index: &HashMap<BlockId, usize>,
+) -> BlockId {
+    while a != b {
+        while rpo_index[&a] > rpo_index[&b] {
+            a = idom[&a];
+        }
+        while rpo_index[&b] > rpo_index[&a] {
+            b = idom[&b];
+        }
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use syn::parse_quote;
+
+    fn classify_calls(names: &'static [&'static str]) -> impl Fn(&Expr) -> Option<u8> {
+        move |expr: &Expr| match expr {
+            Expr::MethodCall(m) => names.iter().position(|n| m.method == n).map(|i| i as u8),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn straight_line_write_dominates_upgrade() {
+        let block: Block = parse_quote! {{
+            store.write_version();
+            deployer.update_current_contract_wasm(h);
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert_eq!(w.len(), 1);
+        assert_eq!(u.len(), 1);
+        assert!(cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn write_after_upgrade_does_not_dominate() {
+        let block: Block = parse_quote! {{
+            deployer.update_current_contract_wasm(h);
+            store.write_version();
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert!(!cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn write_in_one_if_branch_does_not_dominate_upgrade_after() {
+        let block: Block = parse_quote! {{
+            if cond {
+                store.write_version();
+            }
+            deployer.update_current_contract_wasm(h);
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert!(!cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn write_before_if_dominates_upgrade_inside_every_branch() {
+        let block: Block = parse_quote! {{
+            store.write_version();
+            if cond {
+                deployer.update_current_contract_wasm(h);
+            } else {
+                deployer.update_current_contract_wasm(h2);
+            }
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert_eq!(w.len(), 1);
+        assert_eq!(u.len(), 2);
+        for (ub, um) in &u {
+            assert!(cfg.marker_dominates(w[0].0, w[0].1, *ub, *um));
+        }
+    }
+
+    #[test]
+    fn write_in_while_body_does_not_dominate_code_after_loop() {
+        let block: Block = parse_quote! {{
+            while cond {
+                store.write_version();
+            }
+            deployer.update_current_contract_wasm(h);
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert!(!cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn write_guarded_by_early_return_still_dominates() {
+        let block: Block = parse_quote! {{
+            if !authorized {
+                return;
+            }
+            store.write_version();
+            deployer.update_current_contract_wasm(h);
+        }};
+        let empty = HashMap::new();
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&block, &empty, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert!(cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn inlines_helper_containing_the_upgrade_call() {
+        let caller: Block = parse_quote! {{
+            store.write_version();
+            self.do_upgrade();
+        }};
+        let callee: Block = parse_quote! {{
+            deployer.update_current_contract_wasm(h);
+        }};
+        let mut registry = HashMap::new();
+        registry.insert("do_upgrade".to_string(), &callee);
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&caller, &registry, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert_eq!(w.len(), 1);
+        assert_eq!(u.len(), 1);
+        assert!(cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+
+    #[test]
+    fn inlined_helper_write_in_branch_does_not_dominate_later_upgrade() {
+        let caller: Block = parse_quote! {{
+            self.maybe_write();
+            deployer.update_current_contract_wasm(h);
+        }};
+        let callee: Block = parse_quote! {{
+            if cond {
+                store.write_version();
+            }
+        }};
+        let mut registry = HashMap::new();
+        registry.insert("maybe_write".to_string(), &callee);
+        let classify = classify_calls(&["write_version", "update_current_contract_wasm"]);
+        let cfg = build(&caller, &registry, &classify);
+        let w = cfg.markers_with_tag(0);
+        let u = cfg.markers_with_tag(1);
+        assert!(!cfg.marker_dominates(w[0].0, w[0].1, u[0].0, u[0].1));
+    }
+}

--- a/crates/checks/src/interprocedural_storage_toctou.rs
+++ b/crates/checks/src/interprocedural_storage_toctou.rs
@@ -102,7 +102,7 @@ fn collect_ops_visitor(
                             } else {
                                 OpKind::Write
                             };
-                            ops.push(StorageOp {
+                            self.ops.push(StorageOp {
                                 kind,
                                 key_tokens: expr_to_string(arg),
                                 tier,
@@ -124,7 +124,7 @@ fn collect_ops_visitor(
                     for item in self.impl_items {
                         if let ImplItem::Fn(m) = item {
                             if m.sig.ident == callee {
-                                let inner = Inner {
+                                let mut inner = Inner {
                                     current_fn: &callee,
                                     impl_items: self.impl_items,
                                     ops: &mut *self.ops,

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -155,8 +155,10 @@ pub mod unintended_public_method;
 pub mod unlimited_allowance;
 pub mod unvalidated_invoke_target;
 pub mod unvalidated_price;
+pub mod upgrade_atomicity_order;
 pub mod upgrade_no_event;
 pub mod upgrade_no_schema_version;
+mod cfg;
 mod provenance;
 mod util;
 pub mod vec_get_unwrap;
@@ -323,6 +325,7 @@ pub use uncapped_fee::UncappedFeeCheck;
 pub use uncapped_slippage::UncappedSlippageCheck;
 pub use unlimited_allowance::UnlimitedAllowanceCheck;
 pub use unvalidated_price::UnvalidatedPriceCheck;
+pub use upgrade_atomicity_order::UpgradeAtomicityOrderCheck;
 pub use upgrade_no_event::UpgradeNoEventCheck;
 pub use upgrade_no_schema_version::UpgradeNoSchemaVersionCheck;
 pub use vec_map_tuple_convert::VecMapTupleConvertCheck;
@@ -490,5 +493,6 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TimestampAsNonceCheck),
         Box::new(WhileNoBoundCheck),
         Box::new(TtlDurationProvenanceCheck),
+        Box::new(UpgradeAtomicityOrderCheck),
     ]
 }

--- a/crates/checks/src/upgrade_atomicity_order.rs
+++ b/crates/checks/src/upgrade_atomicity_order.rs
@@ -1,0 +1,363 @@
+//! Ordering-correct version of `upgrade_no_schema_version`: the version/schema
+//! write must happen-before `update_current_contract_wasm` on *every* path
+//! that reaches the upgrade call, not merely exist somewhere in the file.
+//!
+//! `upgrade_no_schema_version.rs` is a whole-file substring check: it passes
+//! as soon as *any* function anywhere writes a key whose tokens contain
+//! "version"/"schema", regardless of whether that write can actually run
+//! before the upgrade call on the path that reaches it. That means a write
+//! sitting inside an `if` branch that doesn't cover every path to the upgrade
+//! call is invisible to it — the write "exists in the file", so the old
+//! check is satisfied, even though half the entrypoint's control-flow paths
+//! swap the WASM with no version bump at all.
+//!
+//! This check instead builds the CFG (see `crate::cfg`) for each
+//! `#[contractimpl]` function, inlining calls to other functions in the file
+//! so a write or the upgrade call hidden behind a helper still participates,
+//! and asks a dominance question: does the block containing the version/
+//! schema write dominate the block containing the `update_current_contract_wasm`
+//! call, with the write occurring first when they share a block? If not, the
+//! upgrade call is flagged, even when a schema-version write exists
+//! *somewhere* in the function.
+
+use crate::cfg;
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use std::collections::HashMap;
+use syn::{Block, Expr, File, ImplItem, Item};
+
+const CHECK_NAME: &str = "upgrade-atomicity-order";
+
+const TAG_VERSION_WRITE: u8 = 0;
+const TAG_UPGRADE_CALL: u8 = 1;
+
+/// Flags `update_current_contract_wasm` calls that are reachable on some
+/// control-flow path without a version/schema storage write happening first.
+pub struct UpgradeAtomicityOrderCheck;
+
+impl Check for UpgradeAtomicityOrderCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let registry = collect_fn_registry(file);
+        let classify: &dyn Fn(&Expr) -> Option<u8> = &classify_expr;
+
+        let mut out = Vec::new();
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            let graph = cfg::build(&method.block, &registry, classify);
+
+            let upgrade_markers = graph.markers_with_tag(TAG_UPGRADE_CALL);
+            if upgrade_markers.is_empty() {
+                continue;
+            }
+            let write_markers = graph.markers_with_tag(TAG_VERSION_WRITE);
+
+            for (u_block, u_marker) in &upgrade_markers {
+                let dominated = write_markers
+                    .iter()
+                    .any(|(w_block, w_marker)| {
+                        graph.marker_dominates(*w_block, *w_marker, *u_block, *u_marker)
+                    });
+                if !dominated {
+                    out.push(Finding {
+                        check_name: CHECK_NAME.to_string(),
+                        severity: Severity::High,
+                        file_path: String::new(),
+                        line: u_marker.line,
+                        function_name: fn_name.clone(),
+                        description: format!(
+                            "Function `{fn_name}` calls `update_current_contract_wasm` on a \
+                             control-flow path that does not unconditionally pass through a \
+                             version/schema storage write first. A version/schema key may exist \
+                             elsewhere in the file, but this specific path to the WASM swap can \
+                             execute without writing it, leaving upgraded code unable to detect \
+                             the storage layout it is reading."
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+fn classify_expr(expr: &Expr) -> Option<u8> {
+    let Expr::MethodCall(m) = expr else {
+        return None;
+    };
+    if m.method == "update_current_contract_wasm" {
+        return Some(TAG_UPGRADE_CALL);
+    }
+    if m.method == "set" && receiver_chain_contains_storage(&m.receiver) {
+        if let Some(key_arg) = m.args.first() {
+            if key_tokens_contain_version(key_arg) {
+                return Some(TAG_VERSION_WRITE);
+            }
+        }
+    }
+    None
+}
+
+fn receiver_chain_contains_storage(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(m) => {
+            if m.method == "storage" {
+                return true;
+            }
+            receiver_chain_contains_storage(&m.receiver)
+        }
+        Expr::Field(f) => receiver_chain_contains_storage(&f.base),
+        _ => false,
+    }
+}
+
+fn key_tokens_contain_version(expr: &Expr) -> bool {
+    let mut ts = TokenStream::new();
+    expr.to_tokens(&mut ts);
+    let s = ts.to_string().to_lowercase();
+    s.contains("version") || s.contains("schema")
+}
+
+/// Every named function body in the file — `#[contractimpl]` methods, methods
+/// in any other `impl` block, and free functions — so a call to a private
+/// helper resolves to something the CFG builder can inline.
+fn collect_fn_registry(file: &File) -> HashMap<String, &Block> {
+    let mut registry = HashMap::new();
+    for item in &file.items {
+        match item {
+            Item::Impl(item_impl) => {
+                for impl_item in &item_impl.items {
+                    if let ImplItem::Fn(f) = impl_item {
+                        registry.insert(f.sig.ident.to_string(), &f.block);
+                    }
+                }
+            }
+            Item::Fn(f) => {
+                registry.insert(f.sig.ident.to_string(), &f.block);
+            }
+            _ => {}
+        }
+    }
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Vec<Finding> {
+        let file = parse_file(src).unwrap();
+        UpgradeAtomicityOrderCheck.run(&file, src)
+    }
+
+    #[test]
+    fn passes_when_write_unconditionally_precedes_upgrade() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>) {
+        env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_write_inside_if_branch_that_skips_to_upgrade() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, bump_schema: bool) {
+        if bump_schema {
+            env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        }
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].check_name, CHECK_NAME);
+        assert_eq!(hits[0].severity, Severity::High);
+        assert_eq!(hits[0].function_name, "upgrade");
+    }
+
+    #[test]
+    fn flags_write_after_the_upgrade_call() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>) {
+        env.deployer().update_current_contract_wasm(wasm_hash);
+        env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn passes_when_write_precedes_upgrade_in_every_branch() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, other_hash: BytesN<32>, use_other: bool) {
+        env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        if use_other {
+            env.deployer().update_current_contract_wasm(other_hash);
+        } else {
+            env.deployer().update_current_contract_wasm(wasm_hash);
+        }
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_when_upgrade_reachable_without_write_via_a_helper() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, bump_schema: bool) {
+        Self::maybe_bump(env.clone(), bump_schema);
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+
+    fn maybe_bump(env: Env, bump_schema: bool) {
+        if bump_schema {
+            env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        }
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].function_name, "upgrade");
+    }
+
+    #[test]
+    fn passes_when_helper_unconditionally_writes_before_upgrade() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>) {
+        Self::bump(env.clone());
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+
+    fn bump(env: Env) {
+        env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn no_findings_when_no_upgrade_call() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn init(env: Env) {
+        env.storage().instance().set(&42u32, &0u32);
+    }
+}
+"#,
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn flags_when_write_only_reachable_via_a_different_branch_than_upgrade() {
+        let hits = run(
+            r#"
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct C;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl C {
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, legacy: bool) {
+        if legacy {
+            env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        } else {
+            env.deployer().update_current_contract_wasm(wasm_hash);
+        }
+    }
+}
+"#,
+        );
+        assert_eq!(hits.len(), 1);
+    }
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -300,3 +300,35 @@ If the `extend_to` duration is caller-controlled and unclamped, a caller can pas
 - The check is purely structural/dataflow; it does not perform type analysis. A parameter named `ttl` is flagged the same way regardless of whether it is `u32`, `i128`, or `bool`.
 
 **Fixture:** `test-contracts/ttl-duration-provenance-vulnerable/`, `test-contracts/ttl-duration-provenance-safe/`
+
+---
+
+## `upgrade-atomicity-order` (High)
+
+**Status:** Phase 3
+
+**What it detects**
+
+The ordering-correct sibling of `upgrade-no-schema-version` above. That check is satisfied as soon as a version/schema key is written *anywhere* in the file — it cannot tell whether the write actually happens before the upgrade on the path that reaches it. This check instead builds a control-flow graph (CFG) and asks a dominance question: for every call to `update_current_contract_wasm`, does a version/schema storage write unconditionally happen first on every path that reaches that call?
+
+Algorithm (implemented in `cfg.rs`, a small reusable CFG + dominance engine, and consumed by this check):
+
+1. For each `#[contractimpl]` function, build a CFG of its body. Straight-line statements form basic blocks; `if`/`else` and `match` each become a branch into a shared join block; `while`/`for` headers get both an edge into the body and an edge that skips it entirely (the condition may be false on entry); plain `loop` only gets the into-body edge (it always runs at least once); `return`/`break`/`continue` cut off fall-through in the current block.
+2. Whole-statement calls to another function defined in the same file (a free `fn` or any `impl` method, resolved by name — `foo(..)`, `Self::foo(..)`, `self.foo(..)`) are **inlined**: the callee's own CFG is spliced into the caller's graph at the call site, so a write or the upgrade call hidden behind a helper still participates in the same dominance analysis. Direct/mutual recursion is broken by a call-stack guard.
+3. Every call to `update_current_contract_wasm` and every storage `set` call (on a receiver chain containing `.storage()`) whose key tokens contain `"version"` or `"schema"` is recorded as a marker with the block it lands in and a monotonically increasing order key.
+4. Dominance is computed with the standard iterative algorithm (Cooper, Harvey & Kennedy) over the reachable subgraph. A version/schema write is considered to "happen before" an upgrade call only if its block dominates the upgrade call's block — or, when they share a block, if its order key is smaller (so a write placed *after* the upgrade call in the same straight-line block does not count).
+5. Any `update_current_contract_wasm` call for which no write marker satisfies step 4 is flagged, even if a schema-version write exists elsewhere in the function.
+
+**Why it matters**
+
+A version/schema write inside an `if` branch that doesn't cover every path to the upgrade call gives upgraded code no way to detect the storage layout it just inherited on the paths that skip it — the same silent-corruption risk `upgrade-no-schema-version` describes, except here it happens even though the "does a version key exist in this file" check passes.
+
+**Limitations**
+
+- Branch conditions nested inside arbitrary sub-expressions (e.g. an `if` used as a function-call argument rather than a whole statement or a `let` initializer) are not split into separate CFG nodes; they are scanned as part of the enclosing straight-line block.
+- Only one inlinable call is recognized per statement — the whole statement must itself be the call (or a `let` initializer whose entire right-hand side is the call). A write or upgrade call nested deeper inside a compound expression alongside other logic is still found by the marker scan, but is not itself a splice point for further inlining.
+- `?`-early-return is intentionally not modeled as a branch: since one of its two paths leaves the function entirely (irrelevant to whether an earlier write dominates a later call site) and the other continues normally, treating it as a plain expression does not introduce false negatives for this check.
+- Interprocedural inlining only resolves calls to functions defined in the same file; calls into other crates or trait objects are treated as opaque (not inlined, no markers assumed inside them).
+- Marker detection for both halves of the pattern is the same syntactic/textual matching used by `upgrade-no-schema-version` (method name `update_current_contract_wasm`; storage `set` whose key tokens contain `"version"`/`"schema"`) — this check adds ordering correctness on top, not semantic key-value verification.
+
+**Fixture:** `test-contracts/upgrade-atomicity-order-vulnerable/`, `test-contracts/upgrade-atomicity-order-safe/`

--- a/test-contracts/upgrade-atomicity-order-safe/Cargo.toml
+++ b/test-contracts/upgrade-atomicity-order-safe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sg-test-upgrade-atomicity-order-safe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = "=21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "=21.0.0", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/test-contracts/upgrade-atomicity-order-safe/src/lib.rs
+++ b/test-contracts/upgrade-atomicity-order-safe/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct UpgradeAtomicityOrderSafe;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl UpgradeAtomicityOrderSafe {
+    pub fn init(env: Env) {
+        env.storage().instance().set(&SCHEMA_VERSION, &1u32);
+    }
+
+    /// The schema-version bump runs unconditionally before the WASM swap on
+    /// every path through this function, regardless of `bump_schema` --
+    /// there is no branch that can reach `update_current_contract_wasm`
+    /// without writing the version key first.
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, bump_schema: bool) {
+        env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        if bump_schema {
+            env.events()
+                .publish((symbol_short!("upgrade"),), env.ledger().timestamp());
+        }
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+}

--- a/test-contracts/upgrade-atomicity-order-vulnerable/Cargo.toml
+++ b/test-contracts/upgrade-atomicity-order-vulnerable/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sg-test-upgrade-atomicity-order-vulnerable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = "=21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "=21.0.0", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/test-contracts/upgrade-atomicity-order-vulnerable/src/lib.rs
+++ b/test-contracts/upgrade-atomicity-order-vulnerable/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[contract]
+pub struct UpgradeAtomicityOrderVulnerable;
+
+const SCHEMA_VERSION: soroban_sdk::Symbol = symbol_short!("ver");
+
+#[contractimpl]
+impl UpgradeAtomicityOrderVulnerable {
+    pub fn init(env: Env) {
+        env.storage().instance().set(&SCHEMA_VERSION, &1u32);
+    }
+
+    /// The schema-version bump only runs when `bump_schema` is true, but the
+    /// WASM swap runs unconditionally right after. A caller that passes
+    /// `bump_schema = false` upgrades the contract with no version write at
+    /// all on that path, even though a `set(&SCHEMA_VERSION, ...)` call
+    /// "exists in the file" — which is all the older substring-based
+    /// `upgrade-no-schema-version` check looks for.
+    pub fn upgrade(env: Env, wasm_hash: BytesN<32>, bump_schema: bool) {
+        if bump_schema {
+            env.storage().instance().set(&SCHEMA_VERSION, &2u32);
+        }
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+}


### PR DESCRIPTION
… the update_current_contract_wasm call both exist in the file, but the version write doesn't dominate the wasm swap on every path
closes #421 


Description
upgrade_no_schema_version.rs's own documented limitation says it all: "Does not verify the version key is written atomically with the upgrade call, only that it exists somewhere in the file." This issue asks for the actual ordering-correct version: the version/schema write must happen-before the update_current_contract_wasm call on every control-flow path that reaches the upgrade, not merely exist "somewhere."

Detection logic
Built on the CFG/dominance infra in this batch:

Reuse the existing detection of the update_current_contract_wasm call site and the version/schema-key set() call site from upgrade_no_schema_version.rs.
Build the CFG for the function containing the upgrade call (and, via the call graph, any helper it calls that might contain either half of the pattern).
Flag unless the block containing the version-write dominates the block containing the update_current_contract_wasm call — this correctly handles the case where the version write is inside an if branch that doesn't cover every path to the upgrade call, which today's substring-based check cannot see at all.