### PR TITLE
feat(checks): add governance-threshold-drift check

### DIFF
--- a/crates/checks/src/governance_threshold_drift.rs
+++ b/crates/checks/src/governance_threshold_drift.rs
@@ -1,0 +1,443 @@
+//! Detects governance-threshold drift: two `#[contractimpl]` methods that both
+//! gate on a counter-like variable (vote / signer count) but use different
+//! integer thresholds for what is meant to be the same quorum concept.
+//!
+//! This is the governance analogue of `scale-factor-drift`: each call site is
+//! internally consistent, but a mismatch between independent call sites
+//! silently weakens (or strengthens) the governance gate.
+
+use crate::util::contractimpl_functions;
+use crate::{Check, Finding, Severity};
+use std::collections::HashMap;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{BinOp, Expr, ExprBinary, ExprLit, File, Item, Lit};
+
+const CHECK_NAME: &str = "governance-threshold-drift";
+
+/// Flags governance functions that gate on the same counter variable but use
+/// different threshold values.
+pub struct GovernanceThresholdDriftCheck;
+
+impl Check for GovernanceThresholdDriftCheck {
+    fn name(&self) -> &str {
+        CHECK_NAME
+    }
+
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let consts = collect_file_consts(file);
+        let mut sites: Vec<ThresholdSite> = Vec::new();
+
+        for method in contractimpl_functions(file) {
+            let fn_name = method.sig.ident.to_string();
+            if !is_governance_fn(&fn_name) {
+                continue;
+            }
+            let mut scanner = ThresholdScanner {
+                fn_name: fn_name.clone(),
+                _fn_line: method.sig.fn_token.span().start().line,
+                consts: &consts,
+                sites: Vec::new(),
+            };
+            scanner.visit_block(&method.block);
+            sites.extend(scanner.sites);
+        }
+
+        let mut by_counter: HashMap<String, Vec<&ThresholdSite>> = HashMap::new();
+        for site in &sites {
+            by_counter
+                .entry(site.counter.clone())
+                .or_default()
+                .push(site);
+        }
+
+        let mut out = Vec::new();
+        for (counter, counter_sites) in &by_counter {
+            let mut thresholds: Vec<&str> = counter_sites
+                .iter()
+                .map(|s| s.threshold.as_str())
+                .collect();
+            thresholds.sort();
+            thresholds.dedup();
+            if thresholds.len() < 2 {
+                continue;
+            }
+
+            let mut seen_thresholds: Vec<&str> = Vec::new();
+            for site in counter_sites {
+                if seen_thresholds.contains(&site.threshold.as_str()) {
+                    continue;
+                }
+                seen_thresholds.push(&site.threshold);
+
+                let other_sites: Vec<&&ThresholdSite> = counter_sites
+                    .iter()
+                    .filter(|s| s.threshold != site.threshold)
+                    .collect();
+                let other_summary = other_sites
+                    .iter()
+                    .map(|s| {
+                        format!(
+                            "`{}` in `{}` (line {}) uses {}",
+                            s.op, s.fn_name, s.line, s.threshold
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ");
+
+                out.push(Finding {
+                    check_name: CHECK_NAME.to_string(),
+                    severity: Severity::High,
+                    file_path: String::new(),
+                    line: site.line,
+                    function_name: site.fn_name.clone(),
+                    description: format!(
+                        "Governance function `{}` gates on `{}` with threshold {}, \
+                         but {} uses a different threshold for the same counter variable. \
+                         Every governance function that gates on the same quorum concept \
+                         must agree on the threshold value, or the governance check can \
+                         be bypassed.",
+                        site.fn_name, counter, site.threshold, other_summary
+                    ),
+                });
+            }
+        }
+        out
+    }
+}
+
+struct ThresholdSite {
+    counter: String,
+    threshold: String,
+    op: String,
+    line: usize,
+    fn_name: String,
+}
+
+struct ThresholdScanner<'a> {
+    fn_name: String,
+    _fn_line: usize,
+    consts: &'a HashMap<String, String>,
+    sites: Vec<ThresholdSite>,
+}
+
+impl<'ast> Visit<'ast> for ThresholdScanner<'_> {
+    fn visit_expr_binary(&mut self, i: &'ast ExprBinary) {
+        if let Some(site) = try_extract_threshold_site(i, &self.fn_name, self.consts) {
+            self.sites.push(site);
+        }
+        visit::visit_expr_binary(self, i);
+    }
+}
+
+fn try_extract_threshold_site(
+    bin: &ExprBinary,
+    fn_name: &str,
+    consts: &HashMap<String, String>,
+) -> Option<ThresholdSite> {
+    let op = bin_op_name(&bin.op)?;
+
+    let left_counter = extract_counter_name(&bin.left);
+    let right_threshold = extract_threshold_value(&bin.right, consts);
+    if let (Some(counter), Some(threshold)) = (left_counter, right_threshold) {
+        return Some(ThresholdSite {
+            counter,
+            threshold,
+            op: format!("{}{}", op, "="),
+            line: bin.span().start().line,
+            fn_name: fn_name.to_string(),
+        });
+    }
+
+    let right_counter = extract_counter_name(&bin.right);
+    let left_threshold = extract_threshold_value(&bin.left, consts);
+    if let (Some(counter), Some(threshold)) = (right_counter, left_threshold) {
+        return Some(ThresholdSite {
+            counter,
+            threshold,
+            op: format!("{}{}", op, "="),
+            line: bin.span().start().line,
+            fn_name: fn_name.to_string(),
+        });
+    }
+
+    None
+}
+
+fn bin_op_name(op: &BinOp) -> Option<&'static str> {
+    match op {
+        BinOp::Ge(_) => Some(">"),
+        BinOp::Gt(_) => Some(">"),
+        BinOp::Le(_) => Some("<"),
+        BinOp::Lt(_) => Some("<"),
+        BinOp::Eq(_) => Some("="),
+        _ => None,
+    }
+}
+
+fn extract_counter_name(expr: &Expr) -> Option<String> {
+    let name = expr_path_ident(expr)?;
+    if is_counter_name(&name) {
+        Some(name.to_lowercase())
+    } else {
+        None
+    }
+}
+
+fn extract_threshold_value(expr: &Expr, consts: &HashMap<String, String>) -> Option<String> {
+    if let Some(lit) = int_literal_str(expr) {
+        return Some(lit);
+    }
+    if let Some(name) = expr_path_ident(expr) {
+        if let Some(val) = consts.get(&name) {
+            return Some(val.clone());
+        }
+    }
+    None
+}
+
+fn expr_path_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(p) if p.path.segments.len() == 1 => {
+            Some(p.path.segments[0].ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn int_literal_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(i), ..
+        }) => Some(i.base10_digits().to_string()),
+        _ => None,
+    }
+}
+
+fn is_counter_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("vote")
+        || lower.contains("signer")
+        || lower.contains("count")
+        || lower.contains("yes")
+        || lower.contains("approval")
+        || lower.contains("support")
+        || lower.contains("nay")
+        || lower.contains("voter")
+}
+
+fn is_governance_fn(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("propose")
+        || lower.contains("vote")
+        || lower.contains("execute")
+        || lower.contains("quorum")
+        || lower.contains("threshold")
+        || lower.contains("approve")
+        || lower.contains("ratify")
+        || lower.contains("finalize")
+        || lower.contains("submit")
+}
+
+fn collect_file_consts(file: &File) -> HashMap<String, String> {
+    let mut consts = HashMap::new();
+    for item in &file.items {
+        if let Item::Const(c) = item {
+            let name = c.ident.to_string();
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Int(lit), ..
+            }) = &*c.expr
+            {
+                consts.insert(name, lit.base10_digits().to_string());
+            }
+        }
+    }
+    consts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Check;
+    use syn::parse_file;
+
+    fn run(src: &str) -> Result<Vec<Finding>, syn::Error> {
+        let file = parse_file(src)?;
+        Ok(GovernanceThresholdDriftCheck.run(&file, src))
+    }
+
+    #[test]
+    fn flags_different_thresholds_in_propose_and_execute() -> Result<(), syn::Error> {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn propose(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= 2 {
+            true
+        } else {
+            false
+        }
+    }
+}
+"#,
+        )?;
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|h| h.check_name == CHECK_NAME));
+        assert!(hits.iter().all(|h| h.severity == Severity::High));
+        assert!(hits.iter().any(|h| h.function_name == "propose"));
+        assert!(hits.iter().any(|h| h.function_name == "execute"));
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_same_named_const_used() -> Result<(), syn::Error> {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+const QUORUM: u32 = 3;
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn propose(env: Env, signers: u32) -> bool {
+        if signers >= QUORUM {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= QUORUM {
+            true
+        } else {
+            false
+        }
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_same_literal_used() -> Result<(), syn::Error> {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn propose(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_governance_functions() -> Result<(), syn::Error> {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn deposit(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn withdraw(env: Env, signers: u32) -> bool {
+        if signers >= 2 {
+            true
+        } else {
+            false
+        }
+    }
+}
+"#,
+        )?;
+        assert!(hits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn flags_three_functions_with_mixed_thresholds() -> Result<(), syn::Error> {
+        let hits = run(
+            r#"
+use soroban_sdk::{contractimpl, Env, Address};
+
+pub struct C;
+
+#[contractimpl]
+impl C {
+    pub fn propose(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn vote(env: Env, signers: u32) -> bool {
+        if signers >= 3 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= 2 {
+            true
+        } else {
+            false
+        }
+    }
+}
+"#,
+        )?;
+        assert!(!hits.is_empty());
+        assert!(hits.iter().any(|h| h.function_name == "execute"));
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -56,6 +56,7 @@ pub mod event_topic_runtime_string;
 pub mod expect_leaks;
 pub mod extend_ttl_in_loop;
 pub mod float_arithmetic;
+pub mod governance_threshold_drift;
 pub mod hash_as_storage_key;
 pub mod host_result_ignored;
 pub mod i128_to_u64;
@@ -233,6 +234,7 @@ pub use event_topic_runtime_string::EventTopicRuntimeStringCheck;
 pub use expect_leaks::ExpectLeaksCheck;
 pub use extend_ttl_in_loop::ExtendTtlInLoopCheck;
 pub use float_arithmetic::FloatArithmeticCheck;
+pub use governance_threshold_drift::GovernanceThresholdDriftCheck;
 pub use hash_as_storage_key::HashAsStorageKeyCheck;
 pub use host_result_ignored::HostResultIgnoredCheck;
 pub use i128_to_u64::I128ToU64Check;
@@ -413,6 +415,7 @@ pub fn default_checks() -> Vec<Box<dyn Check + Send + Sync>> {
         Box::new(TempGetNoHasCheck),
         Box::new(AmountMulOverflowCheck),
         Box::new(FloatArithmeticCheck),
+        Box::new(GovernanceThresholdDriftCheck),
         Box::new(Sha256EmptyCheck),
         Box::new(Ed25519KeyInTempCheck),
         Box::new(WeakRandomnessCheck),

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -332,3 +332,38 @@ A version/schema write inside an `if` branch that doesn't cover every path to th
 - Marker detection for both halves of the pattern is the same syntactic/textual matching used by `upgrade-no-schema-version` (method name `update_current_contract_wasm`; storage `set` whose key tokens contain `"version"`/`"schema"`) — this check adds ordering correctness on top, not semantic key-value verification.
 
 **Fixture:** `test-contracts/upgrade-atomicity-order-vulnerable/`, `test-contracts/upgrade-atomicity-order-safe/`
+
+---
+
+## `governance-threshold-drift` (High)
+
+**Status:** Phase 3
+
+**What it detects**
+
+Across all `#[contractimpl]` methods in a file whose names contain governance-related keywords (`propose`, `vote`, `execute`, `quorum`, `threshold`, `approve`, `ratify`, `finalize`, `submit`):
+
+1. Binary comparisons (`>=`, `>`, `<=`, `<`, `==`) where one operand is a "counter-like" variable (name contains `vote`, `signer`, `count`, `yes`, `approval`, `support`, `nay`, or `voter`) and the other is an integer literal or a named `const` resolved to its literal value.
+2. The check groups these threshold comparisons by the normalized counter variable name across all governance functions.
+3. If two or more governance functions use different threshold values for the same counter variable, each mismatched site is flagged.
+
+**Why it matters**
+
+This is the governance analogue of `scale-factor-drift`: a `propose()` function gates on `signers >= 3`, but an `execute()` function — added later or maintained by someone else — gates on `signers >= 2`. Each call site is internally consistent; the bug only exists as a disagreement between independent call sites for what is meant to be the same quorum concept. An attacker can exploit this to execute a proposal that never met the propose gate's threshold.
+
+**Algorithm**
+
+1. Collect all file-level `const` definitions and resolve their literal values.
+2. For each `#[contractimpl]` method whose name contains a governance keyword, scan the function body for binary comparison expressions.
+3. For each comparison, check if one side matches the counter-variable heuristic and the other side is an integer literal or resolvable named const.
+4. Group all recorded threshold sites by the normalized counter variable name.
+5. Within each group, if more than one distinct threshold value exists, flag every site using a threshold that differs from at least one other site.
+
+**Limitations**
+
+- The governance-function heuristic is name-based: functions like `process_proposal` are recognized, but a governance function named `do_thing` is not.
+- The counter-variable heuristic is name-based: `signers >= 3` is recognized, but `s >= 3` (single-letter alias) is not.
+- Only binary comparisons in the function body are scanned; threshold checks hidden behind helper function calls are not resolved cross-functionally.
+- Named consts are resolved only at file scope; local `let` bindings are not followed to their literal origins for threshold grouping.
+
+**Fixture:** `test-contracts/governance-threshold-drift-vulnerable/`, `test-contracts/governance-threshold-drift-safe/`

--- a/test-contracts/governance-threshold-drift-safe/Cargo.toml
+++ b/test-contracts/governance-threshold-drift-safe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-governance-threshold-drift-safe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/governance-threshold-drift-safe/src/lib.rs
+++ b/test-contracts/governance-threshold-drift-safe/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+const QUORUM: u32 = 3;
+
+#[contract]
+pub struct GovernanceSafe;
+
+#[contractimpl]
+impl GovernanceSafe {
+    /// A proposal is considered supported when at least QUORUM signers approve.
+    pub fn propose(env: Env, proposer: Address, signers: u32) -> bool {
+        proposer.require_auth();
+        if signers >= QUORUM {
+            env.storage()
+                .instance()
+                .set(&"proposal_active", &true);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Execute checks the same QUORUM constant as `propose` — no drift.
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= QUORUM {
+            env.storage()
+                .instance()
+                .set(&"executed", &true);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/test-contracts/governance-threshold-drift-vulnerable/Cargo.toml
+++ b/test-contracts/governance-threshold-drift-vulnerable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sg-test-governance-threshold-drift-vulnerable"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/test-contracts/governance-threshold-drift-vulnerable/src/lib.rs
+++ b/test-contracts/governance-threshold-drift-vulnerable/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct GovernanceVulnerable;
+
+#[contractimpl]
+impl GovernanceVulnerable {
+    /// A proposal is considered supported when at least 3 signers approve.
+    pub fn propose(env: Env, proposer: Address, signers: u32) -> bool {
+        proposer.require_auth();
+        if signers >= 3 {
+            env.storage()
+                .instance()
+                .set(&"proposal_active", &true);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Execute checks that the proposal has enough support — but uses a
+    /// different (lower) threshold than `propose`, which is a governance-bypass
+    /// bug: a proposal that failed the propose gate can still be executed.
+    pub fn execute(env: Env, signers: u32) -> bool {
+        if signers >= 2 {
+            env.storage()
+                .instance()
+                .set(&"executed", &true);
+            true
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
Closes #416

Adds a governance-threshold-drift check that detects governance functions (propose, vote, execute, etc.) that gate on the same counter variable (votes, signers, etc.) but use different integer thresholds for what is meant to be the same quorum concept.

This is the governance analogue of scale-factor-drift: each call site is internally consistent, but a mismatch between independent call sites silently weakens the governance gate.

Changes:
- New check: crates/checks/src/governance_threshold_drift.rs
- Test fixtures: governance-threshold-drift-vulnerable/ and -safe/
- Registered in lib.rs, documented in docs/checks.md
- 5 unit tests, all passing
- 728/729 tests pass (1 pre-existing failure unrelated to this change)