### PR TITLE
feat(checks): add reusable CallGraph infrastructure for interprocedural analysis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,32 @@ impl<'ast> Visit<'ast> for StorageCallCount {
 
 Drive the visitor with `visit::visit_file(&mut v, &file)` or `v.visit_block(&func.block)` for a single function body.
 
+### Interprocedural analysis with the call graph
+
+For checks that need to see across function boundaries (e.g., detecting auth hidden in a helper), use [`CallGraph`](crates/checks/src/callgraph.rs):
+
+```rust
+use crate::CallGraph;
+
+impl Check for MyCheck {
+    fn run(&self, file: &File, _source: &str) -> Vec<Finding> {
+        let graph = CallGraph::build(file);
+        for method in contractimpl_functions(file) {
+            let reachable = graph.reachable_from(&method.sig.ident.to_string());
+            // Now check all functions reachable from this method
+            for func_name in &reachable {
+                // Analyze func_name, which may be a helper called directly or indirectly
+            }
+        }
+        // ...
+    }
+}
+```
+
+`CallGraph::build()` collects all functions in the file (free `fn` items and methods in any `impl` block). `CallGraph::reachable_from(start)` returns all functions transitively reachable from `start` via calls it makes, guarding against infinite loops in recursive functions.
+
+**Limitations:** The call graph only resolves direct function calls (`foo()`, `Self::foo()`) and self-method calls (`self.method()`). It does not handle trait objects, generics, or calls through field variables. For details, see [`docs/checks.md`](docs/checks.md#call-graph-interprocedural-analysis).
+
 ### Further reading
 
 - [`syn` on docs.rs](https://docs.rs/syn/)

--- a/crates/checks/src/callgraph.rs
+++ b/crates/checks/src/callgraph.rs
@@ -1,0 +1,428 @@
+//! Call graph for analyzing interprocedural control flow.
+//!
+//! This module provides a file-local call graph that enables checks to see function calls
+//! across procedure boundaries. It resolves direct function calls and method calls from raw
+//! `syn` AST without type information.
+//!
+//! # Limitations
+//!
+//! - **No trait resolution**: Calls through trait objects (`dyn Trait`), generics, or `Box<dyn Fn>` are not resolved.
+//! - **No external crate calls**: Only resolves calls to functions defined in this file.
+//! - **Method calls limited**: Only self-method calls (`self.helper()`) are resolved, not calls on other values.
+//! - **No recursive loop detection in individual checks**: Recursive functions are handled (BFS/DFS track visited), but checks must guard against infinite loops if they traverse the graph multiple times per function.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use syn::visit::{self, Visit};
+use syn::{Block, Expr, ExprCall, ExprMethodCall, File, ImplItem, Item};
+
+/// A file-local call graph mapping function names to the functions they directly call.
+pub struct CallGraph {
+    edges: HashMap<String, Vec<String>>,
+}
+
+impl CallGraph {
+    /// Build a call graph from a parsed file.
+    ///
+    /// Collects every function defined in the file (free `fn` items and `ImplItem::Fn` in all `impl` blocks)
+    /// and records edges for direct function calls and self-method calls.
+    pub fn build(file: &File) -> Self {
+        let registry = collect_fn_registry(file);
+        let mut edges: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (name, block) in &registry {
+            let mut scanner = CallScanner::new(&registry);
+            scanner.visit_block(block);
+            let callees: Vec<String> = scanner.calls.into_iter().collect();
+            edges.insert(name.clone(), callees);
+        }
+
+        CallGraph { edges }
+    }
+
+    /// Return all functions transitively reachable from `start`, including `start` itself.
+    ///
+    /// Uses BFS to traverse the call graph, stopping at functions not in the registry (external calls).
+    /// Guards against infinite loops in recursive/mutually-recursive functions by tracking visited nodes.
+    pub fn reachable_from(&self, start: &str) -> HashSet<String> {
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+
+        visited.insert(start.to_string());
+        queue.push_back(start.to_string());
+
+        while let Some(name) = queue.pop_front() {
+            if let Some(callees) = self.edges.get(&name) {
+                for callee in callees {
+                    if self.edges.contains_key(callee) && visited.insert(callee.clone()) {
+                        queue.push_back(callee.clone());
+                    }
+                }
+            }
+        }
+
+        visited
+    }
+
+    /// Return the direct callees of a function, or None if the function is not in the graph.
+    pub fn direct_callees(&self, name: &str) -> Option<&Vec<String>> {
+        self.edges.get(name)
+    }
+
+    /// Check if there is an edge from `from` to `to`.
+    pub fn has_edge(&self, from: &str, to: &str) -> bool {
+        self.edges
+            .get(from)
+            .map(|callees| callees.contains(&to.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+/// Collect every function defined in this file: free `fn` items and all `ImplItem::Fn` in any `impl` block.
+fn collect_fn_registry(file: &File) -> HashMap<String, &Block> {
+    let mut registry = HashMap::new();
+    for item in &file.items {
+        match item {
+            Item::Impl(item_impl) => {
+                for impl_item in &item_impl.items {
+                    if let ImplItem::Fn(f) = impl_item {
+                        registry.insert(f.sig.ident.to_string(), &f.block);
+                    }
+                }
+            }
+            Item::Fn(f) => {
+                registry.insert(f.sig.ident.to_string(), &f.block);
+            }
+            _ => {}
+        }
+    }
+    registry
+}
+
+/// Walk a function body and record edges to directly called functions.
+struct CallScanner {
+    /// Functions known to exist in the file.
+    fn_registry: HashSet<String>,
+    /// Functions called from this function body (deduplicated).
+    calls: HashSet<String>,
+}
+
+impl CallScanner {
+    fn new(registry: &HashMap<String, &Block>) -> Self {
+        CallScanner {
+            fn_registry: registry.keys().cloned().collect(),
+            calls: HashSet::new(),
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for CallScanner {
+    fn visit_expr_call(&mut self, i: &'ast ExprCall) {
+        if let Expr::Path(p) = &*i.func {
+            if let Some(seg) = p.path.segments.last() {
+                let name = seg.ident.to_string();
+                if self.fn_registry.contains(&name) {
+                    self.calls.insert(name);
+                }
+            }
+        }
+        visit::visit_expr_call(self, i);
+    }
+
+    fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
+        if let Expr::Path(p) = &*i.receiver {
+            if p.path.is_ident("self") {
+                let method_name = i.method.to_string();
+                if self.fn_registry.contains(&method_name) {
+                    self.calls.insert(method_name);
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, i);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_file;
+
+    #[test]
+    fn builds_simple_call_graph() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn caller() {
+    callee();
+}
+
+fn callee() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        assert!(graph.has_edge("caller", "callee"));
+        assert!(!graph.has_edge("callee", "caller"));
+        Ok(())
+    }
+
+    #[test]
+    fn reachable_from_single_hop() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn a() {
+    b();
+}
+
+fn b() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("a");
+        assert!(reachable.contains("a"));
+        assert!(reachable.contains("b"));
+        assert_eq!(reachable.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn reachable_from_multi_hop_chain() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn a() {
+    b();
+}
+
+fn b() {
+    c();
+}
+
+fn c() {
+    d();
+}
+
+fn d() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("a");
+        assert!(reachable.contains("a"));
+        assert!(reachable.contains("b"));
+        assert!(reachable.contains("c"));
+        assert!(reachable.contains("d"));
+        assert_eq!(reachable.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn handles_mutual_recursion() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn a() {
+    b();
+}
+
+fn b() {
+    a();
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("a");
+        assert!(reachable.contains("a"));
+        assert!(reachable.contains("b"));
+        assert_eq!(reachable.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn handles_self_recursion() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn fib(n: i32) {
+    if n > 1 {
+        fib(n - 1);
+        fib(n - 2);
+    }
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("fib");
+        assert!(reachable.contains("fib"));
+        assert_eq!(reachable.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_self_method_calls_in_impl() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct Contract;
+
+impl Contract {
+    pub fn public_method(&self) {
+        self.helper();
+    }
+
+    fn helper(&self) {
+    }
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        assert!(graph.has_edge("public_method", "helper"));
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_calls_to_external_functions() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn my_fn() {
+    external_fn();
+    my_other_fn();
+}
+
+fn my_other_fn() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let direct_calls = graph.direct_callees("my_fn").unwrap();
+        assert!(direct_calls.contains(&"my_other_fn".to_string()));
+        assert!(!direct_calls.contains(&"external_fn".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_impl_blocks() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct Contract;
+
+impl Contract {
+    pub fn public_method(&self) {
+        self.helper_a();
+    }
+
+    fn helper_a(&self) {
+        self.helper_b();
+    }
+}
+
+impl Contract {
+    fn helper_b(&self) {
+    }
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("public_method");
+        assert!(reachable.contains("public_method"));
+        assert!(reachable.contains("helper_a"));
+        assert!(reachable.contains("helper_b"));
+        Ok(())
+    }
+
+    #[test]
+    fn diamond_dependency() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn a() {
+    b();
+    c();
+}
+
+fn b() {
+    d();
+}
+
+fn c() {
+    d();
+}
+
+fn d() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("a");
+        assert!(reachable.contains("a"));
+        assert!(reachable.contains("b"));
+        assert!(reachable.contains("c"));
+        assert!(reachable.contains("d"));
+        assert_eq!(reachable.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_non_self_method_calls() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+pub struct Contract;
+
+impl Contract {
+    pub fn public_method(&self) {
+        let other = Contract;
+        other.helper();
+    }
+
+    fn helper(&self) {
+    }
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let direct_calls = graph.direct_callees("public_method").unwrap();
+        assert!(!direct_calls.contains(&"helper".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn reachable_from_nonexistent_function() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn a() {
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("nonexistent");
+        assert!(reachable.contains("nonexistent"));
+        assert_eq!(reachable.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn collects_all_functions() -> Result<(), syn::Error> {
+        let file = parse_file(
+            r#"
+fn free_fn() {
+}
+
+pub struct Contract;
+
+impl Contract {
+    pub fn public_method(&self) {
+    }
+
+    fn private_method(&self) {
+    }
+}
+
+impl Display for Contract {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Ok(())
+    }
+}
+"#,
+        )?;
+        let graph = CallGraph::build(&file);
+        let reachable = graph.reachable_from("free_fn");
+        assert!(graph.direct_callees("free_fn").is_some());
+        assert!(graph.direct_callees("public_method").is_some());
+        assert!(graph.direct_callees("private_method").is_some());
+        Ok(())
+    }
+}

--- a/crates/checks/src/lib.rs
+++ b/crates/checks/src/lib.rs
@@ -162,6 +162,7 @@ pub mod upgrade_no_schema_version;
 mod cfg;
 mod provenance;
 mod util;
+pub mod callgraph;
 pub mod vec_get_unwrap;
 pub mod vec_map_tuple_convert;
 pub mod vec_mutate_in_loop;
@@ -352,6 +353,7 @@ pub use invoke_nonexistent_func::InvokeNonexistentFuncCheck;
 pub use unintended_public_method::UnintendedPublicMethodCheck;
 
 pub use invalid_address_literal::InvalidAddressLiteralCheck;
+pub use callgraph::CallGraph;
 
 use serde::Serialize;
 use syn::File;

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -2,6 +2,41 @@
 
 This document describes what each Soroban Guard Core check looks for and why it matters.
 
+## Analysis infrastructure
+
+### Call graph (interprocedural analysis)
+
+The analyzer builds a file-local **call graph** — a map of which functions call which other functions — to enable checks to see control flow across procedure boundaries. This is essential for detecting issues hidden in private helper functions.
+
+**What it resolves**
+
+The call graph recognizes two categories of calls in the AST:
+
+1. **Direct function calls:** `helper_name()` and `Self::helper_name()` — resolved by matching the path's final segment to known function names in the file.
+2. **Self-method calls:** `self.method_name()` — resolved when the receiver is explicitly `self`.
+
+**What it does NOT resolve**
+
+- **Trait object calls** (`self.trait_method()` through `dyn Trait`) — no type information in the AST.
+- **Generic calls** (`T::generic_fn()`) — would require type substitution.
+- **Calls through field variables** (`self.field.method()` where `field` is some type) — requires type resolution.
+- **External crate calls** — only functions defined in this file are included in the registry.
+
+Checks that traverse the call graph must be aware of these limitations and document any patterns they intentionally do not resolve.
+
+**BFS/DFS and loop safety**
+
+The `CallGraph::reachable_from(start)` method uses breadth-first search to compute all functions transitively reachable from a starting function, including the start itself. It guards against infinite loops in recursive or mutually-recursive functions by tracking visited nodes — so even a function that calls itself or participates in a call cycle will not cause the traversal to hang.
+
+**Future interprocedural checks**
+
+The call graph enables future checks to detect:
+
+- Auth hidden in helpers (e.g., `pub fn withdraw() { do_withdraw(env) }` where `do_withdraw(env: Env)` calls `env.require_auth()`).
+- Double-initialization across multiple functions (e.g., `initialize()` and `reinitialize()`).
+- Time-of-check-time-of-use (TOCTOU) races that span helper boundaries.
+- Initialization order issues (e.g., `upgrade()` calls `initialize()` in the wrong order).
+
 ---
 
 ## `missing-require-auth` (High)
@@ -22,7 +57,7 @@ Contract state updates should be gated. This rule only recognizes `env.require_a
 **Limitations**
 
 - Only the `Env` binding named `env` counts.
-- Static analysis cannot see auth hidden in helpers.
+- Static analysis cannot see auth hidden in helpers — the analyzer only looks at the function body itself, not helper functions it calls. The call graph infrastructure exists to enable a future enhanced version of this check that traverses helper call chains; see the [call graph](#call-graph-interprocedural-analysis) section.
 
 **Fixture:** `test-contracts/vulnerable/`, `test-contracts/safe/`
 


### PR DESCRIPTION
## Summary

Add a file-local call graph module that enables checks to see function calls across procedure boundaries. This solves the critical blind spot where auth checks hidden in private helper functions are invisible to static analysis.

### What's included

- **CallGraph struct** (`crates/checks/src/callgraph.rs`):
  - Collects all functions in a file (free `fn` and all `impl` methods)
  - Records direct function calls (`foo()`, `Self::foo()`) and self-method calls (`self.method()`)
  - Computes transitive reachability via BFS, guarding against infinite loops in recursive functions
  - Explicitly documents what it does NOT resolve (trait objects, generics, external calls)

- **12 comprehensive unit tests** covering:
  - Single-hop and multi-hop call chains
  - Mutual and self-recursion
  - Self-method calls in impl blocks
  - Multiple impl blocks
  - External function filtering
  - Diamond-shaped dependencies
  - Edge cases

- **Documentation**:
  - New "Analysis infrastructure" section in `docs/checks.md`
  - Updated `missing-require-auth` docs referencing the call graph
  - Practical code examples in `CONTRIBUTING.md`

### Why this matters

Future checks can now detect:
- Auth hidden in helpers (`pub fn withdraw() { do_withdraw(env) }` → `do_withdraw(env)` calls `env.require_auth()`)
- Double-initialization across function boundaries
- TOCTOU races spanning multiple functions
- Initialization order issues during upgrades

Closes #397