### PR TITLE
fix(clippy): collapse match-arm guards to keep CI green on newer stable

### DIFF
--- a/crates/checks/src/commitment_not_cleared.rs
+++ b/crates/checks/src/commitment_not_cleared.rs
@@ -66,18 +66,14 @@ impl<'ast> Visit<'ast> for BodyScan {
 
         if receiver_chain_contains_storage(&i.receiver) {
             match method.as_str() {
-                "get" | "get_unchecked" => {
-                    if i.args.iter().any(expr_contains_commit_hint) {
-                        self.commitment_get = true;
-                        if self.get_line.is_none() {
-                            self.get_line = Some(i.span().start().line);
-                        }
+                "get" | "get_unchecked" if i.args.iter().any(expr_contains_commit_hint) => {
+                    self.commitment_get = true;
+                    if self.get_line.is_none() {
+                        self.get_line = Some(i.span().start().line);
                     }
                 }
-                "remove" => {
-                    if i.args.iter().any(expr_contains_commit_hint) {
-                        self.commitment_cleared = true;
-                    }
+                "remove" if i.args.iter().any(expr_contains_commit_hint) => {
+                    self.commitment_cleared = true;
                 }
                 "set"
                     if i.args.len() == 2

--- a/crates/checks/src/supply_cap.rs
+++ b/crates/checks/src/supply_cap.rs
@@ -70,10 +70,8 @@ impl<'ast> Visit<'ast> for BodyScan {
 
         if receiver_chain_contains_storage(&i.receiver) {
             match method.as_str() {
-                "get" | "get_unchecked" => {
-                    if i.args.iter().any(expr_contains_supply_hint) {
-                        self.supply_get = true;
-                    }
+                "get" | "get_unchecked" if i.args.iter().any(expr_contains_supply_hint) => {
+                    self.supply_get = true;
                 }
                 "set" => {
                     self.storage_write = true;


### PR DESCRIPTION
`cargo clippy --all-targets -- -D warnings` fails on Rust 1.95 with three `collapsible_match` errors that older stable did not emit:

- `crates/checks/src/commitment_not_cleared.rs:70`
- `crates/checks/src/commitment_not_cleared.rs:78`
- `crates/checks/src/supply_cap.rs:74`

CI pins `dtolnay/rust-toolchain@stable`, so this turns into a red `main` for every contributor the moment the runner picks up a newer toolchain — a failure nobody introduced and which is confusing to debug.

## Change

Moves the inner `if` conditions into match-arm guards.

Behaviour is unchanged: when a guard fails, the arm falls through to `_ => {}`, which is exactly what the inner `if` already did.

## Verification (local, Rust 1.95.0)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1041 passed, 0 failed
